### PR TITLE
feat: add webhook secret rotation with dual-valid window and audit logs

### DIFF
--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -49,6 +49,8 @@ export interface Config {
     // Webhooks
     webhookUrl?: string | undefined;
     webhookSecret?: string | undefined;
+    /** Previous secret kept valid during rotation window */
+    webhookSecretPrevious?: string | undefined;
 
     // Feature flags
     enableStreamValidation: boolean;
@@ -266,6 +268,7 @@ export function loadConfig(): Config {
 
         webhookUrl: process.env.WEBHOOK_URL,
         webhookSecret: process.env.WEBHOOK_SECRET,
+        webhookSecretPrevious: process.env.WEBHOOK_SECRET_PREVIOUS,
 
         enableStreamValidation: parseBoolEnv(process.env.ENABLE_STREAM_VALIDATION, true),
         enableRateLimit: parseBoolEnv(process.env.ENABLE_RATE_LIMIT, !isProduction),

--- a/src/db/client.ts
+++ b/src/db/client.ts
@@ -1,9 +1,22 @@
 import { Pool } from 'pg'
 
-// Utilize the DATABASE_URL environment variable as specified in the README
-export const pool = new Pool({
-  connectionString: process.env.DATABASE_URL,
-})
+// Lazy-initialized so importing this module never opens a connection at load time.
+let _pool: Pool | null = null;
+
+export function getPool(): Pool {
+  if (!_pool) {
+    _pool = new Pool({ connectionString: process.env.DATABASE_URL });
+  }
+  return _pool;
+}
+
+/** Swap the pool instance (test use only). */
+export function setPool(p: Pool | null): void {
+  _pool = p;
+}
+
+// Keep a named export for callers that used the old `pool` directly.
+export const pool = { query: (...args: any[]) => getPool().query(...args as [any]) };
 
 export async function getStreamById(id: string) {
   const query = `

--- a/src/lib/auditLog.ts
+++ b/src/lib/auditLog.ts
@@ -22,7 +22,7 @@
 
 import { logger } from './logger.js';
 
-export type AuditAction = 'STREAM_CREATED' | 'STREAM_CANCELLED';
+export type AuditAction = 'STREAM_CREATED' | 'STREAM_CANCELLED' | 'WEBHOOK_SECRET_ROTATED';
 
 export interface AuditEntry {
   /** Monotonically increasing sequence number within this process lifetime. */

--- a/src/webhooks/signature.ts
+++ b/src/webhooks/signature.ts
@@ -27,10 +27,14 @@ export type WebhookVerificationResult = {
   status: 200 | 400 | 401 | 409 | 413;
   code: WebhookVerificationCode;
   message: string;
+  /** True when the previous (rotating-out) secret matched instead of the current one. */
+  usedPreviousSecret?: boolean;
 };
 
 export type VerifyWebhookSignatureInput = {
   secret?: string;
+  /** Previous secret kept valid during rotation window. */
+  secretPrevious?: string;
   deliveryId?: string;
   timestamp?: string;
   signature?: string;
@@ -72,6 +76,7 @@ export function verifyWebhookSignature(
 ): WebhookVerificationResult {
   const {
     secret,
+    secretPrevious,
     deliveryId,
     timestamp,
     signature,
@@ -148,16 +153,30 @@ export function verifyWebhookSignature(
     };
   }
 
-  const expectedSignature = computeWebhookSignature(secret, timestamp, body);
   const actualSignature = signature.trim().toLowerCase();
 
-  const matches = actualSignature.length === expectedSignature.length &&
-    timingSafeEqual(
-      Buffer.from(actualSignature, 'utf8'),
-      Buffer.from(expectedSignature, 'utf8'),
-    );
+  // Try current secret first, then fall back to previous secret (rotation window).
+  const secrets: Array<{ value: string; isPrevious: boolean }> = [
+    { value: secret, isPrevious: false },
+    ...(secretPrevious ? [{ value: secretPrevious, isPrevious: true }] : []),
+  ];
 
-  if (!matches) {
+  let matched = false;
+  let usedPreviousSecret = false;
+
+  for (const { value, isPrevious } of secrets) {
+    const expected = computeWebhookSignature(value, timestamp, body);
+    if (
+      actualSignature.length === expected.length &&
+      timingSafeEqual(Buffer.from(actualSignature, 'utf8'), Buffer.from(expected, 'utf8'))
+    ) {
+      matched = true;
+      usedPreviousSecret = isPrevious;
+      break;
+    }
+  }
+
+  if (!matched) {
     return {
       ok: false,
       status: 401,
@@ -180,5 +199,6 @@ export function verifyWebhookSignature(
     status: 200,
     code: 'ok',
     message: 'Webhook signature verified',
+    ...(usedPreviousSecret ? { usedPreviousSecret: true } : {}),
   };
 }

--- a/tests/webhooks.test.ts
+++ b/tests/webhooks.test.ts
@@ -2,6 +2,11 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { WebhookService } from '../src/webhooks/service.js';
 import { webhookDeliveryStore } from '../src/webhooks/store.js';
 import type { WebhookEvent } from '../src/webhooks/types.js';
+import {
+  computeWebhookSignature,
+  verifyWebhookSignature,
+} from '../src/webhooks/signature.js';
+import { recordAuditEvent, getAuditEntries, _resetAuditLog } from '../src/lib/auditLog.js';
 
 // Mock fetch for testing
 const originalFetch = global.fetch;
@@ -237,5 +242,125 @@ describe('WebhookService', () => {
 
     // Now it should be detected as duplicate
     expect(service.isDuplicateDelivery(delivery1.deliveryId)).toBe(true);
+  });
+});
+
+describe('webhook secret rotation (dual-valid window)', () => {
+  const rawBody = '{"event":"stream.created"}';
+  const timestamp = '1710000000';
+  const now = 1710000000;
+
+  it('accepts a signature made with the current secret', () => {
+    const sig = computeWebhookSignature('new-secret', timestamp, rawBody);
+    const result = verifyWebhookSignature({
+      secret: 'new-secret',
+      secretPrevious: 'old-secret',
+      deliveryId: 'deliv_1',
+      timestamp,
+      signature: sig,
+      rawBody,
+      now,
+    });
+    expect(result.ok).toBe(true);
+    expect(result.usedPreviousSecret).toBeUndefined();
+  });
+
+  it('accepts a signature made with the previous secret during rotation window', () => {
+    const sig = computeWebhookSignature('old-secret', timestamp, rawBody);
+    const result = verifyWebhookSignature({
+      secret: 'new-secret',
+      secretPrevious: 'old-secret',
+      deliveryId: 'deliv_2',
+      timestamp,
+      signature: sig,
+      rawBody,
+      now,
+    });
+    expect(result.ok).toBe(true);
+    expect(result.usedPreviousSecret).toBe(true);
+  });
+
+  it('rejects when signature matches neither secret', () => {
+    const sig = computeWebhookSignature('totally-wrong', timestamp, rawBody);
+    const result = verifyWebhookSignature({
+      secret: 'new-secret',
+      secretPrevious: 'old-secret',
+      deliveryId: 'deliv_3',
+      timestamp,
+      signature: sig,
+      rawBody,
+      now,
+    });
+    expect(result.ok).toBe(false);
+    expect(result.code).toBe('signature_mismatch');
+  });
+
+  it('rejects when no previous secret is set and signature uses an old key', () => {
+    const sig = computeWebhookSignature('old-secret', timestamp, rawBody);
+    const result = verifyWebhookSignature({
+      secret: 'new-secret',
+      deliveryId: 'deliv_4',
+      timestamp,
+      signature: sig,
+      rawBody,
+      now,
+    });
+    expect(result.ok).toBe(false);
+    expect(result.code).toBe('signature_mismatch');
+  });
+
+  it('still enforces timestamp tolerance with dual secrets', () => {
+    const sig = computeWebhookSignature('old-secret', timestamp, rawBody);
+    const result = verifyWebhookSignature({
+      secret: 'new-secret',
+      secretPrevious: 'old-secret',
+      deliveryId: 'deliv_5',
+      timestamp,
+      signature: sig,
+      rawBody,
+      now: 1710000000 + 9999, // way outside tolerance
+    });
+    expect(result.ok).toBe(false);
+    expect(result.code).toBe('timestamp_outside_tolerance');
+  });
+
+  it('still detects duplicate deliveries with dual secrets', () => {
+    const sig = computeWebhookSignature('old-secret', timestamp, rawBody);
+    const result = verifyWebhookSignature({
+      secret: 'new-secret',
+      secretPrevious: 'old-secret',
+      deliveryId: 'deliv_dup_rotation',
+      timestamp,
+      signature: sig,
+      rawBody,
+      now,
+      isDuplicateDelivery: () => true,
+    });
+    expect(result.ok).toBe(false);
+    expect(result.code).toBe('duplicate_delivery');
+  });
+});
+
+describe('audit log — WEBHOOK_SECRET_ROTATED', () => {
+  beforeEach(() => _resetAuditLog());
+
+  it('records a rotation event', () => {
+    recordAuditEvent('WEBHOOK_SECRET_ROTATED', 'webhook', 'global', 'corr-abc', {
+      rotatedBy: 'admin',
+    });
+    const entries = getAuditEntries();
+    expect(entries).toHaveLength(1);
+    expect(entries[0].action).toBe('WEBHOOK_SECRET_ROTATED');
+    expect(entries[0].resourceType).toBe('webhook');
+    expect(entries[0].correlationId).toBe('corr-abc');
+    expect(entries[0].meta?.rotatedBy).toBe('admin');
+  });
+
+  it('seq increments across rotation events', () => {
+    recordAuditEvent('WEBHOOK_SECRET_ROTATED', 'webhook', 'global');
+    recordAuditEvent('WEBHOOK_SECRET_ROTATED', 'webhook', 'global');
+    const entries = getAuditEntries();
+    expect(entries[0].seq).toBe(1);
+    expect(entries[1].seq).toBe(2);
   });
 });


### PR DESCRIPTION
- verifyWebhookSignature now accepts an optional secretPrevious field so both the current and previous secret are valid during a rotation window; current secret is always tried first
- usedPreviousSecret flag on the result lets callers log/alert when the old key is still in use
- Config picks up WEBHOOK_SECRET_PREVIOUS env var (webhookSecretPrevious)
- AuditAction union extended with WEBHOOK_SECRET_ROTATED
- db/client.ts pool is now lazy-initialised so importing the module never opens a Postgres connection at load time
- tests/webhooks.test.ts covers: current-secret accept, previous-secret accept, wrong-secret reject, no-previous-secret reject, timestamp tolerance still enforced, duplicate delivery still detected, and audit log seq/action for WEBHOOK_SECRET_ROTATED

close #152 