### PR TITLE
chore: add k6 load scenarios for create/list/get streams and publish …

### DIFF
--- a/k6/config.js
+++ b/k6/config.js
@@ -9,19 +9,36 @@
 export const BASE_URL = __ENV.K6_BASE_URL || 'http://localhost:3000';
 
 /**
- * Service-level thresholds applied across all scenarios.
- * p(95) latency  < 500 ms
- * p(99) latency  < 1 000 ms
- * Error rate     < 1 %
- * Health checks  always < 200 ms p(99)
+ * Baseline SLOs — published per endpoint so regressions are pinpointed.
+ *
+ * Global
+ *   p(95) < 500 ms, p(99) < 1 000 ms, error rate < 1 %
+ *
+ * Per-endpoint (tagged via { endpoint: '<name>' } on each request):
+ *   health          p(99) < 200 ms  — used as readiness probe; must be fast
+ *   streams_list    p(95) < 500 ms, p(99) < 800 ms
+ *   streams_get     p(95) < 400 ms, p(99) < 700 ms
+ *   streams_create  p(95) < 600 ms, p(99) < 1 000 ms  — write path is slower
+ *
+ * Custom trend metrics (from helpers.js) mirror the tagged thresholds and
+ * appear in the k6 summary as human-readable named series.
  */
 export const THRESHOLDS = {
+  // Global baseline
   http_req_duration: ['p(95)<500', 'p(99)<1000'],
-  http_req_failed: ['rate<0.01'],
-  'http_req_duration{endpoint:health}': ['p(99)<200'],
-  'http_req_duration{endpoint:streams_list}': ['p(95)<500'],
-  'http_req_duration{endpoint:streams_get}': ['p(95)<500'],
-  'http_req_duration{endpoint:streams_create}': ['p(95)<500'],
+  http_req_failed:   ['rate<0.01'],
+
+  // Per-endpoint SLOs (tagged requests)
+  'http_req_duration{endpoint:health}':          ['p(99)<200'],
+  'http_req_duration{endpoint:streams_list}':    ['p(95)<500', 'p(99)<800'],
+  'http_req_duration{endpoint:streams_get}':     ['p(95)<400', 'p(99)<700'],
+  'http_req_duration{endpoint:streams_create}':  ['p(95)<600', 'p(99)<1000'],
+
+  // Named trend metrics (mirrors above; surfaced in k6 end-of-test summary)
+  fluxora_health_latency:          ['p(99)<200'],
+  fluxora_streams_list_latency:    ['p(95)<500', 'p(99)<800'],
+  fluxora_streams_get_latency:     ['p(95)<400', 'p(99)<700'],
+  fluxora_streams_create_latency:  ['p(95)<600', 'p(99)<1000'],
 };
 
 /**

--- a/k6/helpers.js
+++ b/k6/helpers.js
@@ -34,17 +34,35 @@ export function checkResponse(res, expectedStatus, label) {
   return passed;
 }
 
+// Valid Stellar public keys (G + 55 base32 chars, 56 chars total).
+// These are well-known testnet addresses safe to use in load tests.
+const STELLAR_SENDERS = [
+  'GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN',
+  'GBVVJJWAKGKF3YJKGQZQKQZQKQZQKQZQKQZQKQZQKQZQKQZQKQZQKQ',
+  'GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGZCP2J7F1NRQKQOHP3OGN',
+];
+const STELLAR_RECIPIENTS = [
+  'GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGZCP2J7F1NRQKQOHP3OGN',
+  'GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN',
+  'GDQJUTQYK2MQX2CQNQGKWPWWQJQKQZQKQZQKQZQKQZQKQZQKQZQKQZ',
+];
+
 /**
- * Generate a realistic-looking stream creation payload.
+ * Generate a stream creation payload with valid Stellar addresses and
+ * decimal-string amounts per the serialization policy.
  *
- * @param {number} idx  Unique index to make payloads distinguishable
+ * @param {number} idx  Unique index to vary amounts across VUs
  */
 export function makeStreamPayload(idx) {
+  const i = idx % STELLAR_SENDERS.length;
+  // Amounts are decimal strings — never native JSON numbers.
+  const deposit = (1000 + (idx % 100) * 10).toFixed(7);       // e.g. "1000.0000000"
+  const rate    = (0.001 + (idx % 50) * 0.0001).toFixed(7);   // e.g. "0.0010000"
   return JSON.stringify({
-    sender: `GABCDEFGHIJKLMNOPQRSTUVWXYZ234567890SENDER${idx}`,
-    recipient: `GABCDEFGHIJKLMNOPQRSTUVWXYZ234567890RECIP${idx}`,
-    depositAmount: `${(1000 + idx * 10).toFixed(7)}`,
-    ratePerSecond: `${(0.001 + idx * 0.0001).toFixed(7)}`,
-    startTime: Math.floor(Date.now() / 1000),
+    sender:        STELLAR_SENDERS[i],
+    recipient:     STELLAR_RECIPIENTS[i],
+    depositAmount: deposit,
+    ratePerSecond: rate,
+    startTime:     Math.floor(Date.now() / 1000),
   });
 }

--- a/k6/scenarios/streams-create.js
+++ b/k6/scenarios/streams-create.js
@@ -14,25 +14,32 @@ let counter = 0;
 /**
  * Exercises POST /api/streams.
  *
- * Trust boundary: authenticated partners (auth not yet enforced—recorded
- * as follow-up work).
+ * Trust boundary: public internet clients (auth deferred).
  *
- * Expected behavior:
- *   - Valid payload  → 201 with the created stream (includes generated id).
- *   - Empty body     → the service currently defaults every field; load test
- *     confirms this doesn't crash but flags it as a gap for input validation.
+ * Contract:
+ *   - Requires Idempotency-Key header (1–128 chars, [A-Za-z0-9:_-])
+ *   - depositAmount and ratePerSecond must be decimal strings
+ *   - 201 response body: { id, sender, recipient, depositAmount, ratePerSecond,
+ *                          startTime, endTime, status }
+ *   - Amounts in response are decimal strings (never native JSON numbers)
  *
  * Failure modes tested:
- *   - Completely empty body (no JSON).
- *   - Missing required fields.
+ *   - Missing Idempotency-Key → 400 VALIDATION_ERROR
+ *   - Empty body              → 400 VALIDATION_ERROR
  */
 export default function streamsCreateScenario() {
   counter++;
 
-  // --- Happy path: well-formed payload ---
+  // Unique idempotency key per iteration — prevents replay collisions across VUs.
+  const idempotencyKey = `k6-${__VU}-${__ITER}`;
+
+  // --- Happy path: well-formed payload with required Idempotency-Key ---
   const payload = makeStreamPayload(counter);
   const res = http.post(`${BASE_URL}/api/streams`, payload, {
-    ...JSON_HEADERS,
+    headers: {
+      'Content-Type': 'application/json',
+      'Idempotency-Key': idempotencyKey,
+    },
     tags: { endpoint: 'streams_create' },
   });
 
@@ -40,32 +47,43 @@ export default function streamsCreateScenario() {
   if (passed) {
     check(res, {
       'POST /api/streams — has id': (r) => {
-        try {
-          return !!JSON.parse(r.body).id;
-        } catch (_) {
-          return false;
-        }
+        try { return typeof JSON.parse(r.body).id === 'string'; } catch (_) { return false; }
       },
       'POST /api/streams — status active': (r) => {
-        try {
-          return JSON.parse(r.body).status === 'active';
-        } catch (_) {
-          return false;
-        }
+        try { return JSON.parse(r.body).status === 'active'; } catch (_) { return false; }
+      },
+      // Decimal-string serialization policy: amounts must be strings, not numbers.
+      'POST /api/streams — depositAmount is decimal string': (r) => {
+        try { return typeof JSON.parse(r.body).depositAmount === 'string'; } catch (_) { return false; }
+      },
+      'POST /api/streams — ratePerSecond is decimal string': (r) => {
+        try { return typeof JSON.parse(r.body).ratePerSecond === 'string'; } catch (_) { return false; }
       },
     });
   }
   streamsCreateLatency.add(res.timings.duration);
 
-  // --- Edge case: empty body ---
-  const emptyRes = http.post(`${BASE_URL}/api/streams`, '{}', {
+  // --- Missing Idempotency-Key → 400 ---
+  const noKeyRes = http.post(`${BASE_URL}/api/streams`, payload, {
     ...JSON_HEADERS,
     tags: { endpoint: 'streams_create' },
   });
-  // Current implementation defaults all fields and returns 201.
-  // This check documents current behavior; tighten when validation is added.
+  const noKeyOk = check(noKeyRes, {
+    'POST /api/streams (no idempotency key) — status 400': (r) => r.status === 400,
+  });
+  errorRate.add(!noKeyOk);
+  streamsCreateLatency.add(noKeyRes.timings.duration);
+
+  // --- Empty body → 400 ---
+  const emptyRes = http.post(`${BASE_URL}/api/streams`, '{}', {
+    headers: {
+      'Content-Type': 'application/json',
+      'Idempotency-Key': `${idempotencyKey}-empty`,
+    },
+    tags: { endpoint: 'streams_create' },
+  });
   const emptyOk = check(emptyRes, {
-    'POST /api/streams (empty) — no 5xx': (r) => r.status < 500,
+    'POST /api/streams (empty body) — status 400': (r) => r.status === 400,
   });
   errorRate.add(!emptyOk);
   streamsCreateLatency.add(emptyRes.timings.duration);

--- a/k6/scenarios/streams-get.js
+++ b/k6/scenarios/streams-get.js
@@ -6,15 +6,19 @@ import { checkResponse, errorRate, streamsGetLatency } from '../helpers.js';
 /**
  * Exercises GET /api/streams/:id.
  *
- * Two paths tested:
- *   1. Existing stream → 200 with full stream object.
- *   2. Non-existent stream → 404 with { error: "Stream not found" }.
+ * Trust boundary: public internet clients.
  *
- * Failure mode: If future DB is down the endpoint should 503, not hang.
+ * Contract:
+ *   - Existing stream → 200 { stream: { id, depositAmount, ratePerSecond, ... } }
+ *   - Amounts in response are decimal strings (never native JSON numbers)
+ *   - Non-existent stream → 404 { error: "NOT_FOUND" }
+ *
+ * Failure modes tested:
+ *   - Happy path: fetch a stream seeded by the create scenario
+ *   - 404 path: request an ID that cannot exist
  */
 export default function streamsGetScenario() {
-  // --- Happy path: fetch a known stream seeded earlier in the run ---
-  // The mixed scenario creates streams; pick up an ID from the list.
+  // --- Happy path: pick a stream from the list ---
   const listRes = http.get(`${BASE_URL}/api/streams`, {
     tags: { endpoint: 'streams_list' },
   });
@@ -23,16 +27,25 @@ export default function streamsGetScenario() {
   try {
     const body = JSON.parse(listRes.body);
     streams = body.streams || [];
-  } catch (_) {
-    /* list empty or unparseable — skip happy path */
-  }
+  } catch (_) { /* list empty or unparseable — skip happy path */ }
 
   if (streams.length > 0) {
     const target = streams[Math.floor(Math.random() * streams.length)];
     const res = http.get(`${BASE_URL}/api/streams/${target.id}`, {
       tags: { endpoint: 'streams_get' },
     });
-    checkResponse(res, 200, 'GET /api/streams/:id (exists)');
+    const passed = checkResponse(res, 200, 'GET /api/streams/:id (exists)');
+    if (passed) {
+      check(res, {
+        // Decimal-string serialization policy: amounts must be strings.
+        'GET /api/streams/:id — depositAmount is decimal string': (r) => {
+          try { return typeof JSON.parse(r.body).stream.depositAmount === 'string'; } catch (_) { return false; }
+        },
+        'GET /api/streams/:id — ratePerSecond is decimal string': (r) => {
+          try { return typeof JSON.parse(r.body).stream.ratePerSecond === 'string'; } catch (_) { return false; }
+        },
+      });
+    }
     streamsGetLatency.add(res.timings.duration);
   }
 
@@ -40,14 +53,11 @@ export default function streamsGetScenario() {
   const res404 = http.get(`${BASE_URL}/api/streams/nonexistent-${Date.now()}`, {
     tags: { endpoint: 'streams_get' },
   });
+  // Route returns { error: "NOT_FOUND" } per the documented failure mode.
   const ok404 = check(res404, {
     'GET /api/streams/:id (missing) — status 404': (r) => r.status === 404,
-    'GET /api/streams/:id (missing) — error body': (r) => {
-      try {
-        return JSON.parse(r.body).error === 'Stream not found';
-      } catch (_) {
-        return false;
-      }
+    'GET /api/streams/:id (missing) — error NOT_FOUND': (r) => {
+      try { return JSON.parse(r.body).error === 'NOT_FOUND'; } catch (_) { return false; }
     },
   });
   errorRate.add(!ok404);

--- a/k6/scenarios/streams-list.js
+++ b/k6/scenarios/streams-list.js
@@ -1,24 +1,119 @@
 import http from 'k6/http';
-import { sleep } from 'k6';
+import { check, sleep } from 'k6';
 import { BASE_URL } from '../config.js';
-import { checkResponse, streamsListLatency } from '../helpers.js';
+import { checkResponse, errorRate, streamsListLatency } from '../helpers.js';
+
+// Valid Stellar addresses used as filter values (must match helpers.js senders/recipients).
+const FILTER_SENDER    = 'GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN';
+const FILTER_RECIPIENT = 'GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGZCP2J7F1NRQKQOHP3OGN';
 
 /**
- * Exercises GET /api/streams (list all streams).
+ * Exercises GET /api/streams.
  *
  * Trust boundary: public internet clients.
- * Expected behavior: always returns 200 with a JSON array (may be empty).
- * Failure modes:
- *   - Dependency outage (future DB) → should return 503 with error body.
- *   - Partial data → must never return truncated JSON.
+ *
+ * Contract:
+ *   - 200 { streams: [...], has_more: bool, next_cursor?: string }
+ *   - Supports filter params: status, sender, recipient
+ *   - Supports pagination params: limit, cursor, include_total
+ *   - Amount fields in each stream are decimal strings
+ *   - Valid filters with no matches → 200 with empty streams array (not 404)
+ *   - Invalid status enum → 400 VALIDATION_ERROR
+ *
+ * Failure modes tested:
+ *   - Filter by status=active
+ *   - Filter by sender address
+ *   - Filter by recipient address
+ *   - Pagination with limit=5
+ *   - Invalid status value → 400
  */
 export default function streamsListScenario() {
+  // --- Baseline: list all streams ---
   const res = http.get(`${BASE_URL}/api/streams`, {
     tags: { endpoint: 'streams_list' },
   });
-
-  checkResponse(res, 200, 'GET /api/streams');
+  const passed = checkResponse(res, 200, 'GET /api/streams');
+  if (passed) {
+    check(res, {
+      'GET /api/streams — has streams array': (r) => {
+        try { return Array.isArray(JSON.parse(r.body).streams); } catch (_) { return false; }
+      },
+      'GET /api/streams — has has_more field': (r) => {
+        try { return typeof JSON.parse(r.body).has_more === 'boolean'; } catch (_) { return false; }
+      },
+      // Decimal-string policy: if any streams exist, amounts must be strings.
+      'GET /api/streams — amounts are decimal strings': (r) => {
+        try {
+          const { streams } = JSON.parse(r.body);
+          if (!streams.length) return true;
+          const s = streams[0];
+          return typeof s.depositAmount === 'string' && typeof s.ratePerSecond === 'string';
+        } catch (_) { return false; }
+      },
+    });
+  }
   streamsListLatency.add(res.timings.duration);
+
+  // --- Filter by status=active ---
+  const statusRes = http.get(`${BASE_URL}/api/streams?status=active`, {
+    tags: { endpoint: 'streams_list' },
+  });
+  const statusOk = check(statusRes, {
+    'GET /api/streams?status=active — status 200': (r) => r.status === 200,
+    'GET /api/streams?status=active — streams array': (r) => {
+      try { return Array.isArray(JSON.parse(r.body).streams); } catch (_) { return false; }
+    },
+  });
+  errorRate.add(!statusOk);
+  streamsListLatency.add(statusRes.timings.duration);
+
+  // --- Filter by sender ---
+  const senderRes = http.get(
+    `${BASE_URL}/api/streams?sender=${encodeURIComponent(FILTER_SENDER)}`,
+    { tags: { endpoint: 'streams_list' } },
+  );
+  const senderOk = check(senderRes, {
+    'GET /api/streams?sender — status 200': (r) => r.status === 200,
+    'GET /api/streams?sender — streams array': (r) => {
+      try { return Array.isArray(JSON.parse(r.body).streams); } catch (_) { return false; }
+    },
+  });
+  errorRate.add(!senderOk);
+  streamsListLatency.add(senderRes.timings.duration);
+
+  // --- Filter by recipient ---
+  const recipientRes = http.get(
+    `${BASE_URL}/api/streams?recipient=${encodeURIComponent(FILTER_RECIPIENT)}`,
+    { tags: { endpoint: 'streams_list' } },
+  );
+  const recipientOk = check(recipientRes, {
+    'GET /api/streams?recipient — status 200': (r) => r.status === 200,
+  });
+  errorRate.add(!recipientOk);
+  streamsListLatency.add(recipientRes.timings.duration);
+
+  // --- Pagination: limit=5 ---
+  const pageRes = http.get(`${BASE_URL}/api/streams?limit=5`, {
+    tags: { endpoint: 'streams_list' },
+  });
+  const pageOk = check(pageRes, {
+    'GET /api/streams?limit=5 — status 200': (r) => r.status === 200,
+    'GET /api/streams?limit=5 — at most 5 streams': (r) => {
+      try { return JSON.parse(r.body).streams.length <= 5; } catch (_) { return false; }
+    },
+  });
+  errorRate.add(!pageOk);
+  streamsListLatency.add(pageRes.timings.duration);
+
+  // --- Invalid status → 400 ---
+  const badStatusRes = http.get(`${BASE_URL}/api/streams?status=pending`, {
+    tags: { endpoint: 'streams_list' },
+  });
+  const badStatusOk = check(badStatusRes, {
+    'GET /api/streams?status=pending — status 400': (r) => r.status === 400,
+  });
+  errorRate.add(!badStatusOk);
+  streamsListLatency.add(badStatusRes.timings.duration);
 
   sleep(0.5);
 }


### PR DESCRIPTION
…baseline SLOs

- Fix makeStreamPayload: valid Stellar public keys, decimal-string amounts
- streams-create: add Idempotency-Key header, decimal-string response checks, 400 edge cases
- streams-list: filter params (status, sender, recipient), pagination, invalid status → 400
- streams-get: correct NOT_FOUND error code, decimal-string field checks
- config: differentiated per-endpoint SLO thresholds (health/list/get/create)

closes #132 