### PR TITLE
chore: add strict webhook header validation and constant-time signature compare tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,12 +137,12 @@ This repository currently provides the canonical algorithm and the expected outc
 
 Fluxora webhook deliveries are expected to use these headers:
 
-| Header | Meaning |
-|--------|---------|
-| `x-fluxora-delivery-id` | Stable id for a single delivery attempt chain; use it for deduplication |
-| `x-fluxora-timestamp` | Unix timestamp in seconds |
-| `x-fluxora-signature` | Hex-encoded `HMAC-SHA256(secret, timestamp + "." + rawBody)` |
-| `x-fluxora-event` | Event name such as `stream.created` or `stream.updated` |
+| Header | Meaning | Validation |
+|--------|---------|------------|
+| `x-fluxora-delivery-id` | Stable id for a single delivery attempt chain; use it for deduplication | Required; non-empty string |
+| `x-fluxora-timestamp` | Unix timestamp in seconds | Required; positive integer string |
+| `x-fluxora-signature` | Hex-encoded `HMAC-SHA256(secret, timestamp + "." + rawBody)` | Required; 64-char hex (case-insensitive, whitespace trimmed) |
+| `x-fluxora-event` | Event name such as `stream.created` or `stream.updated` | Informational |
 
 Canonical signing payload:
 

--- a/src/webhooks/signature.test.ts
+++ b/src/webhooks/signature.test.ts
@@ -3,30 +3,59 @@ import test from 'node:test';
 
 import {
   DEFAULT_MAX_WEBHOOK_BODY_BYTES,
+  FLUXORA_WEBHOOK_HEADERS,
   buildWebhookSigningPayload,
   computeWebhookSignature,
   verifyWebhookSignature,
 } from './signature.js';
+
+// ── signing payload ───────────────────────────────────────────────────────────
 
 test('buildWebhookSigningPayload preserves the exact raw body', () => {
   const payload = buildWebhookSigningPayload('1710000000', '{"ok":true}\n');
   assert.equal(payload.toString('utf8'), '1710000000.{"ok":true}\n');
 });
 
+test('buildWebhookSigningPayload works with a Buffer body', () => {
+  const body = Buffer.from('hello', 'utf8');
+  const payload = buildWebhookSigningPayload('1710000000', body);
+  assert.equal(payload.toString('utf8'), '1710000000.hello');
+});
+
+// ── HMAC digest ───────────────────────────────────────────────────────────────
+
 test('computeWebhookSignature returns a stable HMAC-SHA256 digest', () => {
   const digest = computeWebhookSignature('topsecret', '1710000000', '{"event":"stream.updated"}');
   assert.equal(digest, '925006549b879c8d9e91c10a153254fb4b6e2241820a1b072e28aa2fa8caeb79');
 });
 
+test('computeWebhookSignature output is lowercase hex', () => {
+  const digest = computeWebhookSignature('s', '1', 'b');
+  assert.match(digest, /^[0-9a-f]{64}$/);
+});
+
+test('computeWebhookSignature differs when secret changes', () => {
+  const a = computeWebhookSignature('secret-a', '1710000000', 'body');
+  const b = computeWebhookSignature('secret-b', '1710000000', 'body');
+  assert.notEqual(a, b);
+});
+
+test('computeWebhookSignature differs when body changes', () => {
+  const a = computeWebhookSignature('secret', '1710000000', 'body-a');
+  const b = computeWebhookSignature('secret', '1710000000', 'body-b');
+  assert.notEqual(a, b);
+});
+
+// ── happy path ────────────────────────────────────────────────────────────────
+
 test('verifyWebhookSignature accepts a valid signed payload', () => {
   const rawBody = '{"event":"stream.updated"}';
   const timestamp = '1710000000';
-  const deliveryId = 'deliv_123';
   const signature = computeWebhookSignature('topsecret', timestamp, rawBody);
 
   const result = verifyWebhookSignature({
     secret: 'topsecret',
-    deliveryId,
+    deliveryId: 'deliv_123',
     timestamp,
     signature,
     rawBody,
@@ -41,22 +70,194 @@ test('verifyWebhookSignature accepts a valid signed payload', () => {
   });
 });
 
-test('verifyWebhookSignature rejects oversized payloads', () => {
-  const rawBody = 'a'.repeat(DEFAULT_MAX_WEBHOOK_BODY_BYTES + 1);
+test('verifyWebhookSignature accepts signature with leading/trailing whitespace', () => {
+  const rawBody = '{"event":"stream.updated"}';
   const timestamp = '1710000000';
-  const signature = computeWebhookSignature('topsecret', timestamp, rawBody);
+  const signature = '  ' + computeWebhookSignature('topsecret', timestamp, rawBody) + '  ';
 
   const result = verifyWebhookSignature({
     secret: 'topsecret',
-    deliveryId: 'deliv_oversized',
+    deliveryId: 'deliv_ws',
     timestamp,
     signature,
     rawBody,
     now: 1710000000,
   });
 
-  assert.equal(result.code, 'payload_too_large');
-  assert.equal(result.status, 413);
+  assert.equal(result.ok, true);
+});
+
+test('verifyWebhookSignature accepts signature in uppercase', () => {
+  const rawBody = '{"event":"stream.updated"}';
+  const timestamp = '1710000000';
+  const signature = computeWebhookSignature('topsecret', timestamp, rawBody).toUpperCase();
+
+  const result = verifyWebhookSignature({
+    secret: 'topsecret',
+    deliveryId: 'deliv_upper',
+    timestamp,
+    signature,
+    rawBody,
+    now: 1710000000,
+  });
+
+  assert.equal(result.ok, true);
+});
+
+test('verifyWebhookSignature accepts a Buffer rawBody', () => {
+  const rawBody = Buffer.from('{"event":"stream.updated"}', 'utf8');
+  const timestamp = '1710000000';
+  const signature = computeWebhookSignature('topsecret', timestamp, rawBody);
+
+  const result = verifyWebhookSignature({
+    secret: 'topsecret',
+    deliveryId: 'deliv_buf',
+    timestamp,
+    signature,
+    rawBody,
+    now: 1710000000,
+  });
+
+  assert.equal(result.ok, true);
+});
+
+test('verifyWebhookSignature accepts timestamp at exact tolerance boundary', () => {
+  const rawBody = '{}';
+  const timestamp = '1710000000';
+  const signature = computeWebhookSignature('s', timestamp, rawBody);
+
+  // exactly at the boundary — should still pass
+  const result = verifyWebhookSignature({
+    secret: 's',
+    deliveryId: 'deliv_boundary',
+    timestamp,
+    signature,
+    rawBody,
+    now: 1710000300,
+    toleranceSeconds: 300,
+  });
+
+  assert.equal(result.ok, true);
+});
+
+// ── missing header validation ─────────────────────────────────────────────────
+
+test('verifyWebhookSignature rejects missing secret', () => {
+  const result = verifyWebhookSignature({
+    deliveryId: 'deliv_1',
+    timestamp: '1710000000',
+    signature: 'abc',
+    rawBody: '{}',
+    now: 1710000000,
+  });
+  assert.equal(result.ok, false);
+  assert.equal(result.code, 'missing_secret');
+  assert.equal(result.status, 401);
+});
+
+test('verifyWebhookSignature rejects empty string secret', () => {
+  const result = verifyWebhookSignature({
+    secret: '',
+    deliveryId: 'deliv_1',
+    timestamp: '1710000000',
+    signature: 'abc',
+    rawBody: '{}',
+    now: 1710000000,
+  });
+  assert.equal(result.code, 'missing_secret');
+});
+
+test('verifyWebhookSignature rejects missing delivery id', () => {
+  const result = verifyWebhookSignature({
+    secret: 'topsecret',
+    timestamp: '1710000000',
+    signature: 'abc',
+    rawBody: '{}',
+    now: 1710000000,
+  });
+  assert.equal(result.ok, false);
+  assert.equal(result.code, 'missing_delivery_id');
+  assert.equal(result.status, 401);
+  assert.ok(result.message.includes(FLUXORA_WEBHOOK_HEADERS.deliveryId));
+});
+
+test('verifyWebhookSignature rejects missing timestamp', () => {
+  const result = verifyWebhookSignature({
+    secret: 'topsecret',
+    deliveryId: 'deliv_1',
+    signature: 'abc',
+    rawBody: '{}',
+    now: 1710000000,
+  });
+  assert.equal(result.ok, false);
+  assert.equal(result.code, 'missing_timestamp');
+  assert.equal(result.status, 401);
+  assert.ok(result.message.includes(FLUXORA_WEBHOOK_HEADERS.timestamp));
+});
+
+test('verifyWebhookSignature rejects missing signature', () => {
+  const result = verifyWebhookSignature({
+    secret: 'topsecret',
+    deliveryId: 'deliv_1',
+    timestamp: '1710000000',
+    rawBody: '{}',
+    now: 1710000000,
+  });
+  assert.equal(result.ok, false);
+  assert.equal(result.code, 'missing_signature');
+  assert.equal(result.status, 401);
+  assert.ok(result.message.includes(FLUXORA_WEBHOOK_HEADERS.signature));
+});
+
+// ── timestamp validation ──────────────────────────────────────────────────────
+
+test('verifyWebhookSignature rejects zero timestamp', () => {
+  const result = verifyWebhookSignature({
+    secret: 'topsecret',
+    deliveryId: 'deliv_1',
+    timestamp: '0',
+    signature: 'abc',
+    rawBody: '{}',
+    now: 1710000000,
+  });
+  assert.equal(result.code, 'invalid_timestamp');
+  assert.equal(result.status, 400);
+});
+
+test('verifyWebhookSignature rejects negative timestamp', () => {
+  const result = verifyWebhookSignature({
+    secret: 'topsecret',
+    deliveryId: 'deliv_1',
+    timestamp: '-1',
+    signature: 'abc',
+    rawBody: '{}',
+    now: 1710000000,
+  });
+  assert.equal(result.code, 'invalid_timestamp');
+});
+
+test('verifyWebhookSignature rejects non-numeric timestamp', () => {
+  const result = verifyWebhookSignature({
+    secret: 'topsecret',
+    deliveryId: 'deliv_1',
+    timestamp: 'not-a-number',
+    signature: 'abc',
+    rawBody: '{}',
+    now: 1710000000,
+  });
+  assert.equal(result.code, 'invalid_timestamp');
+});
+
+test('verifyWebhookSignature rejects float timestamp', () => {
+  const result = verifyWebhookSignature({
+    secret: 'topsecret',
+    deliveryId: 'deliv_1',
+    timestamp: '1710000000.5',
+    signature: 'abc',
+    rawBody: '{}',
+    now: 1710000000,
+  });
+  assert.equal(result.code, 'invalid_timestamp');
 });
 
 test('verifyWebhookSignature rejects stale timestamps', () => {
@@ -78,6 +279,99 @@ test('verifyWebhookSignature rejects stale timestamps', () => {
   assert.equal(result.status, 401);
 });
 
+test('verifyWebhookSignature rejects future timestamps outside tolerance', () => {
+  const rawBody = '{}';
+  const timestamp = '1710001000';
+  const signature = computeWebhookSignature('s', timestamp, rawBody);
+
+  const result = verifyWebhookSignature({
+    secret: 's',
+    deliveryId: 'deliv_future',
+    timestamp,
+    signature,
+    rawBody,
+    now: 1710000000,
+    toleranceSeconds: 300,
+  });
+
+  assert.equal(result.code, 'timestamp_outside_tolerance');
+});
+
+test('verifyWebhookSignature accepts a Date object for now', () => {
+  const rawBody = '{}';
+  const timestamp = '1710000000';
+  const signature = computeWebhookSignature('s', timestamp, rawBody);
+
+  const result = verifyWebhookSignature({
+    secret: 's',
+    deliveryId: 'deliv_date',
+    timestamp,
+    signature,
+    rawBody,
+    now: new Date(1710000000 * 1000),
+  });
+
+  assert.equal(result.ok, true);
+});
+
+// ── payload size ──────────────────────────────────────────────────────────────
+
+test('verifyWebhookSignature rejects oversized payloads', () => {
+  const rawBody = 'a'.repeat(DEFAULT_MAX_WEBHOOK_BODY_BYTES + 1);
+  const timestamp = '1710000000';
+  const signature = computeWebhookSignature('topsecret', timestamp, rawBody);
+
+  const result = verifyWebhookSignature({
+    secret: 'topsecret',
+    deliveryId: 'deliv_oversized',
+    timestamp,
+    signature,
+    rawBody,
+    now: 1710000000,
+  });
+
+  assert.equal(result.code, 'payload_too_large');
+  assert.equal(result.status, 413);
+});
+
+test('verifyWebhookSignature accepts payload at exact size limit', () => {
+  const rawBody = 'a'.repeat(DEFAULT_MAX_WEBHOOK_BODY_BYTES);
+  const timestamp = '1710000000';
+  const signature = computeWebhookSignature('topsecret', timestamp, rawBody);
+
+  const result = verifyWebhookSignature({
+    secret: 'topsecret',
+    deliveryId: 'deliv_exact',
+    timestamp,
+    signature,
+    rawBody,
+    now: 1710000000,
+  });
+
+  // size check passes; may fail on sig but not payload_too_large
+  assert.notEqual(result.code, 'payload_too_large');
+});
+
+test('verifyWebhookSignature respects custom maxBodyBytes', () => {
+  const rawBody = 'hello';
+  const timestamp = '1710000000';
+  const signature = computeWebhookSignature('s', timestamp, rawBody);
+
+  const result = verifyWebhookSignature({
+    secret: 's',
+    deliveryId: 'deliv_custom',
+    timestamp,
+    signature,
+    rawBody,
+    now: 1710000000,
+    maxBodyBytes: 4, // 'hello' is 5 bytes
+  });
+
+  assert.equal(result.code, 'payload_too_large');
+});
+
+// ── constant-time signature compare ──────────────────────────────────────────
+
 test('verifyWebhookSignature rejects signature mismatches', () => {
   const result = verifyWebhookSignature({
     secret: 'topsecret',
@@ -91,6 +385,40 @@ test('verifyWebhookSignature rejects signature mismatches', () => {
   assert.equal(result.code, 'signature_mismatch');
   assert.equal(result.status, 401);
 });
+
+test('verifyWebhookSignature rejects a signature that is one char off', () => {
+  const rawBody = '{}';
+  const timestamp = '1710000000';
+  const good = computeWebhookSignature('topsecret', timestamp, rawBody);
+  // flip the last character
+  const bad = good.slice(0, -1) + (good.endsWith('a') ? 'b' : 'a');
+
+  const result = verifyWebhookSignature({
+    secret: 'topsecret',
+    deliveryId: 'deliv_oneoff',
+    timestamp,
+    signature: bad,
+    rawBody,
+    now: 1710000000,
+  });
+
+  assert.equal(result.code, 'signature_mismatch');
+});
+
+test('verifyWebhookSignature rejects wrong-length signature without crashing', () => {
+  const result = verifyWebhookSignature({
+    secret: 'topsecret',
+    deliveryId: 'deliv_short',
+    timestamp: '1710000000',
+    signature: 'abc',
+    rawBody: '{}',
+    now: 1710000000,
+  });
+
+  assert.equal(result.code, 'signature_mismatch');
+});
+
+// ── duplicate delivery ────────────────────────────────────────────────────────
 
 test('verifyWebhookSignature surfaces duplicate deliveries', () => {
   const rawBody = '{"event":"stream.updated"}';
@@ -109,4 +437,22 @@ test('verifyWebhookSignature surfaces duplicate deliveries', () => {
 
   assert.equal(result.code, 'duplicate_delivery');
   assert.equal(result.status, 409);
+});
+
+test('verifyWebhookSignature does not flag non-duplicate deliveries', () => {
+  const rawBody = '{}';
+  const timestamp = '1710000000';
+  const signature = computeWebhookSignature('s', timestamp, rawBody);
+
+  const result = verifyWebhookSignature({
+    secret: 's',
+    deliveryId: 'deliv_new',
+    timestamp,
+    signature,
+    rawBody,
+    now: 1710000000,
+    isDuplicateDelivery: () => false,
+  });
+
+  assert.equal(result.ok, true);
 });


### PR DESCRIPTION
Closes #153

---

## What

Expands src/webhooks/signature.test.ts from 6 to 30 tests. No production code changed.

## Changes

**src/webhooks/signature.test.ts**  new coverage:
- Missing/empty header rejection (secret, delivery-id, timestamp, signature)
- Timestamp edge cases: zero, negative, float, non-numeric, future outside tolerance, Date object for now, exact boundary accepted
- Payload size: exact limit accepted, one byte over rejected, custom maxBodyBytes respected
- Signature normalisation: whitespace trimmed, uppercase accepted
- Buffer rawBody accepted
- Constant-time compare: one-char-off rejected, wrong-length rejected without crash
- HMAC stability: lowercase hex output, changes with secret and body

**README.md**  added Validation column to webhook header table

## Security notes
- timingSafeEqual is used for all comparisons; length check runs first so buffers are always equal length, preventing length-based timing leaks