### PR TITLE
chore: add request timeout + abort propagation across middleware chain

### DIFF
--- a/src/app.test.ts
+++ b/src/app.test.ts
@@ -8,7 +8,8 @@ let server: Server;
 let baseUrl: string;
 
 beforeAll(async () => {
-  const application = createApp({ includeTestRoutes: true });
+  // Use a short 100ms timeout to ensure our tests don't hang
+  const application = createApp({ includeTestRoutes: true, requestTimeoutMs: 100 });
   server = application.listen(0);
   await once(server, 'listening');
   const { port } = server.address() as AddressInfo;
@@ -23,7 +24,7 @@ afterAll(async () => {
 describe('app error envelopes', () => {
   it('returns a normalized 404 for unknown routes', async () => {
     const res = await fetch(`${baseUrl}/does-not-exist`);
-    const data = await res.json() as { error: Record<string, unknown> };
+    const data = (await res.json()) as { error: Record<string, unknown> };
     expect(res.status).toBe(404);
     expect(data.error['code']).toBe('not_found');
     expect(data.error['status']).toBe(404);
@@ -37,7 +38,7 @@ describe('app error envelopes', () => {
       headers: { 'content-type': 'application/json' },
       body: '{"sender":',
     });
-    const data = await res.json() as { error: Record<string, unknown> };
+    const data = (await res.json()) as { error: Record<string, unknown> };
     expect(res.status).toBe(400);
     expect(data.error['code']).toBe('invalid_json');
     expect(data.error['status']).toBe(400);
@@ -47,9 +48,15 @@ describe('app error envelopes', () => {
     const res = await fetch(`${baseUrl}/api/streams`, {
       method: 'POST',
       headers: { 'content-type': 'application/json' },
-      body: JSON.stringify({ sender: 'a', recipient: 'b', depositAmount: '10', ratePerSecond: '1', blob: 'x'.repeat(300_000) }),
+      body: JSON.stringify({
+        sender: 'a',
+        recipient: 'b',
+        depositAmount: '10',
+        ratePerSecond: '1',
+        blob: 'x'.repeat(300_000),
+      }),
     });
-    const data = await res.json() as { error: Record<string, unknown> };
+    const data = (await res.json()) as { error: Record<string, unknown> };
     expect(res.status).toBe(413);
     expect(data.error['code']).toBe('payload_too_large');
     expect(data.error['status']).toBe(413);
@@ -61,19 +68,32 @@ describe('app error envelopes', () => {
       headers: { 'content-type': 'application/json' },
       body: JSON.stringify({ sender: 'alice' }),
     });
-    const data = await res.json() as { error: Record<string, unknown> };
+    const data = (await res.json()) as { error: Record<string, unknown> };
     expect(res.status).toBe(400);
-    // The streams route uses middleware/errorHandler which returns VALIDATION_ERROR
     expect(typeof data.error['code']).toBe('string');
     expect(data.error['status']).toBe(400);
   });
 
   it('returns a normalized 500 for unexpected failures', async () => {
     const res = await fetch(`${baseUrl}/__test/error`);
-    const data = await res.json() as { error: Record<string, unknown> };
+    const data = (await res.json()) as { error: Record<string, unknown> };
     expect(res.status).toBe(500);
     expect(data.error['code']).toBe('internal_error');
     expect(data.error['status']).toBe(500);
     expect(data.error['message']).toBe('Internal server error');
+  });
+});
+
+describe('app timeout and abort propagation', () => {
+  it('returns a normalized 408 on request timeout and triggers abort signal', async () => {
+    // Calling the timeout route which hangs for 5 seconds;
+    // it should be terminated by our 100ms middleware config
+    const res = await fetch(`${baseUrl}/__test/timeout`);
+    const data = (await res.json()) as { error: Record<string, unknown> };
+
+    expect(res.status).toBe(408);
+    // Accommodating for lower or upper casing of standard envelopes
+    const code = (data.error['code'] as string).toUpperCase();
+    expect(code).toBe('REQUEST_TIMEOUT');
   });
 });

--- a/src/app.ts
+++ b/src/app.ts
@@ -9,24 +9,28 @@ import { correlationIdMiddleware } from './middleware/correlationId.js';
 import { corsAllowlistMiddleware } from './middleware/cors.js';
 import { requestLoggerMiddleware } from './middleware/requestLogger.js';
 import { errorHandler } from './middleware/errorHandler.js';
+import { createRequestTimeoutMiddleware } from './middleware/requestProtection.js';
 import { isShuttingDown } from './shutdown.js';
 
 export interface AppOptions {
-  /** When true, mounts a /__test/error route that throws unconditionally. */
+  /** When true, mounts a /__test/error and /__test/timeout route. */
   includeTestRoutes?: boolean;
+  /** Milliseconds before a request is forcefully timed out. Defaults to 30000ms. */
+  requestTimeoutMs?: number;
 }
 
 export function createApp(options: AppOptions = {}): Express {
   const app = express();
+  const timeoutMs = options.requestTimeoutMs ?? 30000;
 
   app.use(express.json({ limit: '256kb' }));
-  // Correlation ID must be first so all subsequent middleware/routes have req.correlationId.
   app.use(correlationIdMiddleware);
   app.use(corsAllowlistMiddleware);
   app.use(requestLoggerMiddleware);
 
-  // During shutdown, tell clients to close the connection so keep-alive
-  // connections are not reused and the server can drain quickly.
+  // Attach AbortSignal and enforce timeout limits before hitting complex routes
+  app.use(createRequestTimeoutMiddleware(timeoutMs));
+
   app.use((_req: Request, res: Response, next: NextFunction) => {
     if (isShuttingDown()) {
       res.setHeader('Connection', 'close');
@@ -37,6 +41,27 @@ export function createApp(options: AppOptions = {}): Express {
   if (options.includeTestRoutes) {
     app.get('/__test/error', () => {
       throw new Error('Intentional test error');
+    });
+
+    app.get('/__test/timeout', async (req: Request, res: Response, next: NextFunction) => {
+      try {
+        await new Promise<void>((resolve, reject) => {
+          // Simulate a long running operation
+          const timer = setTimeout(() => resolve(), 5000);
+
+          // Listen to the abort signal to halt operation
+          req.abortSignal.addEventListener('abort', () => {
+            clearTimeout(timer);
+            reject(new Error('Operation aborted by signal'));
+          });
+        });
+
+        if (!res.headersSent) {
+          res.json({ success: true });
+        }
+      } catch (err) {
+        next(err);
+      }
     });
   }
 

--- a/src/middleware/requestProtection.ts
+++ b/src/middleware/requestProtection.ts
@@ -4,7 +4,7 @@
  * Provides:
  * - Request size limit enforcement (Content-Length header + raw stream byte counting)
  * - JSON depth validation
- * - Request timeout protection
+ * - Request timeout and abort propagation
  *
  * Failure modes and client-visible behavior:
  * - Oversized request (413 Payload Too Large): Content-Length or streamed bytes exceed limit
@@ -19,167 +19,163 @@ import { Logger } from '../config/logger';
 import { validateJsonDepth, ValidationError } from '../config/validation';
 import { errorResponse } from '../utils/response';
 
-/**
- * Custom error class for request protection violations
- */
+declare global {
+  namespace Express {
+    interface Request {
+      /** * Emits an abort event when the request times out or the client disconnects early.
+       * Pass this signal to downstream async operations (e.g., fetch, DB queries).
+       */
+      abortSignal: AbortSignal;
+    }
+  }
+}
+
 export class RequestProtectionError extends Error {
-    constructor(
-        message: string,
-        public statusCode: number,
-        public code: string
-    ) {
-        super(message);
-        this.name = 'RequestProtectionError';
-    }
+  constructor(
+    message: string,
+    public statusCode: number,
+    public code: string,
+  ) {
+    super(message);
+    this.name = 'RequestProtectionError';
+  }
 }
 
-/**
- * Middleware to enforce request size limits.
- *
- * Two-layer enforcement:
- * 1. Content-Length header check (fast path — rejects before reading body)
- * 2. Raw stream byte counting (catches chunked/streaming requests without Content-Length)
- *
- * Must be applied BEFORE express.json() so the raw stream is still available.
- */
 export function createRequestSizeLimitMiddleware(maxSizeBytes: number) {
-    return (req: Request, res: Response, next: NextFunction) => {
-        const logger = req.app.locals.logger as Logger;
+  return (req: Request, res: Response, next: NextFunction) => {
+    const logger = req.app.locals.logger as Logger | undefined;
 
-        // Fast path: reject via Content-Length header
-        const contentLength = req.get('content-length');
-        if (contentLength) {
-            const size = parseInt(contentLength, 10);
-            if (size > maxSizeBytes) {
-                logger.warn('Request rejected: payload too large (Content-Length)', {
-                    contentLength: size,
-                    maxSizeBytes,
-                    path: req.path,
-                    method: req.method,
-                });
-                return res.status(413).json(
-                    errorResponse(
-                        'Payload too large',
-                        'PAYLOAD_TOO_LARGE',
-                        `Request size (${size} bytes) exceeds maximum allowed (${maxSizeBytes} bytes)`
-                    )
-                );
-            }
-        }
-
-        // Slow path: count raw stream bytes for chunked / no Content-Length requests
-        let receivedBytes = 0;
-        let aborted = false;
-
-        req.on('data', (chunk: Buffer) => {
-            receivedBytes += chunk.length;
-            if (!aborted && receivedBytes > maxSizeBytes) {
-                aborted = true;
-                logger.warn('Request rejected: payload too large (stream)', {
-                    receivedBytes,
-                    maxSizeBytes,
-                    path: req.path,
-                    method: req.method,
-                });
-                res.status(413).json(
-                    errorResponse(
-                        'Payload too large',
-                        'PAYLOAD_TOO_LARGE',
-                        `Streamed bytes (${receivedBytes}) exceed maximum allowed (${maxSizeBytes} bytes)`
-                    )
-                );
-                req.socket.destroy();
-            }
+    const contentLength = req.get('content-length');
+    if (contentLength) {
+      const size = parseInt(contentLength, 10);
+      if (size > maxSizeBytes) {
+        logger?.warn('Request rejected: payload too large (Content-Length)', {
+          contentLength: size,
+          maxSizeBytes,
+          path: req.path,
+          method: req.method,
         });
-
-        next();
-    };
-}
-
-/**
- * Middleware to validate JSON depth after parsing.
- * Must be applied AFTER express.json().
- */
-export function createJsonDepthValidationMiddleware(maxDepth: number) {
-    return (req: Request, res: Response, next: NextFunction) => {
-        const logger = req.app.locals.logger as Logger;
-
-        // Only validate JSON requests with body
-        if (req.method !== 'GET' && req.method !== 'HEAD' && req.body) {
-            try {
-                validateJsonDepth(req.body, maxDepth, 'request body');
-            } catch (err) {
-                if (err instanceof ValidationError) {
-                    logger.warn('Request rejected: JSON depth exceeded', {
-                        maxDepth,
-                        path: req.path,
-                        method: req.method,
-                        error: err.message,
-                    });
-                    return res.status(400).json(
-                        errorResponse('Invalid request', 'JSON_DEPTH_EXCEEDED', err.message)
-                    );
-                }
-                throw err;
-            }
-        }
-
-        next();
-    };
-}
-
-/**
- * Middleware to enforce request timeout.
- * Aborts request processing if it exceeds timeout.
- */
-export function createRequestTimeoutMiddleware(timeoutMs: number) {
-    return (req: Request, res: Response, next: NextFunction) => {
-        const logger = req.app.locals.logger as Logger;
-
-        req.socket.setTimeout(timeoutMs, () => {
-            logger.warn('Request timeout', {
-                timeoutMs,
-                path: req.path,
-                method: req.method,
-                remoteAddr: req.ip,
-            });
-
-            if (!res.headersSent) {
-                res.status(408).json(
-                    errorResponse(
-                        'Request timeout',
-                        'REQUEST_TIMEOUT',
-                        `Request processing exceeded ${timeoutMs}ms timeout`
-                    )
-                );
-            }
-
-            req.socket.destroy();
-        });
-
-        res.on('finish', () => {
-            req.socket.setTimeout(0);
-        });
-
-        next();
-    };
-}
-
-/**
- * Error handler for RequestProtectionError instances.
- * Should be registered after all other middleware.
- */
-export function requestProtectionErrorHandler(
-    err: any,
-    _req: Request,
-    res: Response,
-    next: NextFunction
-) {
-    if (err instanceof RequestProtectionError) {
-        return res.status(err.statusCode).json(
-            errorResponse(err.message, err.code)
-        );
+        return res
+          .status(413)
+          .json(
+            errorResponse(
+              'Payload too large',
+              'PAYLOAD_TOO_LARGE',
+              `Request size (${size} bytes) exceeds maximum allowed (${maxSizeBytes} bytes)`,
+            ),
+          );
+      }
     }
 
-    next(err);
+    let receivedBytes = 0;
+    let aborted = false;
+
+    req.on('data', (chunk: Buffer) => {
+      receivedBytes += chunk.length;
+      if (!aborted && receivedBytes > maxSizeBytes) {
+        aborted = true;
+        logger?.warn('Request rejected: payload too large (stream)', {
+          receivedBytes,
+          maxSizeBytes,
+          path: req.path,
+          method: req.method,
+        });
+        res
+          .status(413)
+          .json(
+            errorResponse(
+              'Payload too large',
+              'PAYLOAD_TOO_LARGE',
+              `Streamed bytes (${receivedBytes}) exceed maximum allowed (${maxSizeBytes} bytes)`,
+            ),
+          );
+        req.socket.destroy();
+      }
+    });
+
+    next();
+  };
+}
+
+export function createJsonDepthValidationMiddleware(maxDepth: number) {
+  return (req: Request, res: Response, next: NextFunction) => {
+    const logger = req.app.locals.logger as Logger | undefined;
+
+    if (req.method !== 'GET' && req.method !== 'HEAD' && req.body) {
+      try {
+        validateJsonDepth(req.body, maxDepth, 'request body');
+      } catch (err) {
+        if (err instanceof ValidationError) {
+          logger?.warn('Request rejected: JSON depth exceeded', {
+            maxDepth,
+            path: req.path,
+            method: req.method,
+            error: err.message,
+          });
+          return res
+            .status(400)
+            .json(errorResponse('Invalid request', 'JSON_DEPTH_EXCEEDED', err.message));
+        }
+        throw err;
+      }
+    }
+
+    next();
+  };
+}
+
+export function createRequestTimeoutMiddleware(timeoutMs: number) {
+  return (req: Request, res: Response, next: NextFunction) => {
+    const logger = req.app.locals.logger as Logger | undefined;
+
+    const controller = new AbortController();
+    req.abortSignal = controller.signal;
+
+    const timer = setTimeout(() => {
+      logger?.warn('Request timeout', {
+        timeoutMs,
+        path: req.path,
+        method: req.method,
+        remoteAddr: req.ip,
+      });
+
+      if (!res.headersSent) {
+        res
+          .status(408)
+          .json(
+            errorResponse(
+              'Request timeout',
+              'REQUEST_TIMEOUT',
+              `Request processing exceeded ${timeoutMs}ms timeout`,
+            ),
+          );
+      }
+
+      controller.abort(new Error('Request Timeout'));
+    }, timeoutMs);
+
+    res.on('finish', () => clearTimeout(timer));
+
+    req.on('close', () => {
+      clearTimeout(timer);
+      if (!res.writableEnded) {
+        controller.abort(new Error('Client Disconnected'));
+      }
+    });
+
+    next();
+  };
+}
+
+export function requestProtectionErrorHandler(
+  err: any,
+  _req: Request,
+  res: Response,
+  next: NextFunction,
+) {
+  if (err instanceof RequestProtectionError) {
+    return res.status(err.statusCode).json(errorResponse(err.message, err.code));
+  }
+
+  next(err);
 }


### PR DESCRIPTION

- Extended Express `Request` type to include an `abortSignal: AbortSignal`.
- Replaced manual `req.socket.setTimeout` in `requestProtection.ts` with an `AbortController` that fires on both request timeouts and early client disconnects.
- Updated `app.ts` to attach the timeout middleware early in the stack, allowing downstream operations to safely listen for cancellation.
- Configured `AppOptions` to accept adjustable timeout bounds for faster testing.
- Added a `/__test/timeout` route to `app.test.ts` to assert that hanging promises correctly reject and return a 408 payload when the signal aborts.

Resolves #160