### PR TITLE
fix: ensure reorg rollback prevents duplicate webhooks and WS events

### DIFF
--- a/src/indexer/service.ts
+++ b/src/indexer/service.ts
@@ -43,6 +43,28 @@ type IndexerState = {
   reorgHeight?: number | undefined;
 };
 
+/**
+ * Tracks ledgers that were rolled back due to a reorg.
+ * Webhook dispatcher and WS hub check this before emitting events
+ * so rolled-back events are never delivered to consumers.
+ */
+const rolledBackLedgers = new Set<number>();
+
+/** Returns true if the given ledger was rolled back and not yet re-confirmed. */
+export function isLedgerRolledBack(ledger: number): boolean {
+  return rolledBackLedgers.has(ledger);
+}
+
+/** Clear rolled-back ledger tracking (called after re-ingestion confirms the new chain). */
+function clearRolledBackLedger(ledger: number): void {
+  rolledBackLedgers.delete(ledger);
+}
+
+/** Reset all rolled-back ledger state (for testing). */
+export function _resetRolledBackLedgers(): void {
+  rolledBackLedgers.clear();
+}
+
 function isPlainObject(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value);
 }
@@ -181,6 +203,7 @@ export class IndexerIngestionService {
     this.state.lastSafeLedger = 0;
     this.state.reorgDetected = false;
     this.state.reorgHeight = undefined;
+    rolledBackLedgers.clear();
   }
 
   getHealthSnapshot(): IndexerHealthSnapshot {
@@ -249,9 +272,12 @@ export class IndexerIngestionService {
           actor: context.actor,
           requestId: context.requestId,
         });
-        
+
         this.state.reorgDetected = true;
         this.state.reorgHeight = ledger;
+        // Mark this ledger as rolled back so dispatcher and hub suppress
+        // any in-flight events that belong to the orphaned chain branch.
+        rolledBackLedgers.add(ledger);
         info('Indexer reorgDetected flag set to true', { ledger, requestId: context.requestId });
         await this.store.rollbackBeforeLedger(ledger);
         this.state.lastFailureAt = new Date().toISOString();
@@ -275,11 +301,12 @@ export class IndexerIngestionService {
 
       // Reset reorg detected flag once we are significantly past the reorg height
       if (this.state.reorgDetected && this.state.reorgHeight !== undefined && maxLedgerInBatch > this.state.reorgHeight + 5) {
-          info('Indexer reorgDetected flag reset to false', { 
-            maxLedgerInBatch, 
+          info('Indexer reorgDetected flag reset to false', {
+            maxLedgerInBatch,
             reorgHeight: this.state.reorgHeight,
-            requestId: context.requestId 
+            requestId: context.requestId
           });
+          clearRolledBackLedger(this.state.reorgHeight);
           this.state.reorgDetected = false;
           this.state.reorgHeight = undefined;
       }

--- a/src/webhooks/dispatcher.ts
+++ b/src/webhooks/dispatcher.ts
@@ -1,5 +1,6 @@
 import crypto from 'crypto';
 import { info, error } from '../utils/logger.js';
+import { isLedgerRolledBack } from '../indexer/service.js';
 
 export interface WebhookOptions {
   url: string;
@@ -7,14 +8,25 @@ export interface WebhookOptions {
   event: string;
   payload: any;
   retryCount?: number;
+  /** Ledger this event originated from — used to suppress rolled-back events. */
+  ledger?: number;
 }
 
 /**
  * Dispatches a webhook notification with HMAC-SHA256 signature.
+ * Skips dispatch if the originating ledger was rolled back due to a reorg.
  * Implements exponential backoff for 5xx errors.
  */
 export async function dispatchWebhook(options: WebhookOptions): Promise<void> {
-  const { url, secret, event, payload, retryCount = 0 } = options;
+  const { url, secret, event, payload, retryCount = 0, ledger } = options;
+
+  // Suppress events from rolled-back ledgers to prevent duplicate delivery
+  // after a chain reorg.
+  if (ledger !== undefined && isLedgerRolledBack(ledger)) {
+    info('Webhook suppressed: ledger was rolled back', { url, event, ledger });
+    return;
+  }
+
   const timestamp = Math.floor(Date.now() / 1000);
   const signaturePayload = `${timestamp}.${event}.${JSON.stringify(payload)}`;
   const signature = crypto.createHmac('sha256', secret).update(signaturePayload).digest('hex');
@@ -32,7 +44,7 @@ export async function dispatchWebhook(options: WebhookOptions): Promise<void> {
       method: 'POST',
       headers,
       body: JSON.stringify({ event, timestamp, payload }),
-      signal: AbortSignal.timeout(10000), // 10s timeout
+      signal: AbortSignal.timeout(10000),
     });
 
     if (!response.ok) {

--- a/src/ws/hub.ts
+++ b/src/ws/hub.ts
@@ -19,6 +19,7 @@
 import { WebSocket, WebSocketServer } from 'ws';
 import type { IncomingMessage } from 'http';
 import type { Server } from 'http';
+import { isLedgerRolledBack } from '../indexer/service.js';
 
 // ── Constants ─────────────────────────────────────────────────────────────────
 
@@ -41,6 +42,8 @@ export interface StreamUpdateEvent {
   /** Unique event identifier used for deduplication. */
   eventId: string;
   payload: unknown;
+  /** Ledger this event originated from — used to suppress rolled-back events. */
+  ledger?: number;
 }
 
 interface ClientState {
@@ -224,7 +227,13 @@ export class StreamHub {
    * the RPC layer replays events.
    */
   broadcast(event: StreamUpdateEvent): void {
-    const { streamId, eventId, payload } = event;
+    const { streamId, eventId, payload, ledger } = event;
+
+    // Suppress events from rolled-back ledgers to prevent duplicate WS delivery
+    // after a chain reorg.
+    if (ledger !== undefined && isLedgerRolledBack(ledger)) {
+      return;
+    }
 
     if (this.dedup.has(streamId, eventId)) {
       return; // already delivered

--- a/tests/reorg.test.ts
+++ b/tests/reorg.test.ts
@@ -6,15 +6,10 @@ import {
   setIndexerEventStore,
   setIndexerIngestAuthToken,
 } from '../src/routes/indexer.js';
+import { isLedgerRolledBack, _resetRolledBackLedgers } from '../src/indexer/service.js';
+import { dispatchWebhook } from '../src/webhooks/dispatcher.js';
 
 const INDEXER_TOKEN = 'test-reorg-token';
-const ENDPOINT = '/internal/indexer/contract-events';
-
-let idempotencyKeyCounter = 0;
-function nextIdempotencyKey(): string {
-  idempotencyKeyCounter += 1;
-  return `test-reorg-idempotency-${idempotencyKeyCounter}`;
-}
 
 function buildEvent(eventId: string, ledger: number, ledgerHash: string) {
   return {
@@ -51,52 +46,157 @@ describe('Indexer Reorg Handling and Chain Tip Safety', () => {
 
   it('reports lastSafeLedger as (maxLedger - 1)', async () => {
     await postEvents([buildEvent('evt-1', 100, 'hash-100')]).expect(200);
-    
     const response = await request(app).get('/health').expect(200);
     expect(response.body.dependencies.indexer.lastSafeLedger).toBe(99);
     expect(response.body.dependencies.indexer.reorgDetected).toBe(false);
   });
 
   it('detects a reorg and rolls back the store', async () => {
-    // Ingest ledger 100
     await postEvents([buildEvent('evt-100', 100, 'hash-100')]).expect(200);
-    // Ingest ledger 101
     await postEvents([buildEvent('evt-101', 101, 'hash-101')]).expect(200);
-    
     expect(store.all().length).toBe(2);
 
-    // Ingest ledger 101 with DIFFERENT hash (reorg)
     const reorgResponse = await postEvents([buildEvent('evt-101-new', 101, 'hash-101-reorg')]).expect(200);
-    
     expect(reorgResponse.body.insertedCount).toBe(1);
-    
-    // Ledger 101 should have been rolled back and re-inserted
+
     const records = store.all();
     expect(records.length).toBe(2);
     expect(records.find(r => r.ledger === 101)?.ledgerHash).toBe('hash-101-reorg');
     expect(records.find(r => r.ledger === 101)?.eventId).toBe('evt-101-new');
 
     const health = await request(app).get('/health').expect(200);
-    if (!health.body.dependencies.indexer.reorgDetected) {
-      console.log('REORG DETECTED FAIL. Health body:', JSON.stringify(health.body, null, 2));
-    }
     expect(health.body.dependencies.indexer.reorgDetected).toBe(true);
     expect(health.body.dependencies.indexer.lastSafeLedger).toBe(100);
   });
 
   it('resets reorgDetected flag once past the reorg point', async () => {
-    // Trigger reorg at ledger 100
     await postEvents([buildEvent('evt-100', 100, 'hash-100')]).expect(200);
     await postEvents([buildEvent('evt-100-new', 100, 'hash-100-reorg')]).expect(200);
-    
+
     let health = await request(app).get('/health').expect(200);
     expect(health.body.dependencies.indexer.reorgDetected).toBe(true);
 
-    // Ingest ledger 110 (vastly past 100 + 5 buffer)
     await postEvents([buildEvent('evt-110', 110, 'hash-110')]).expect(200);
-    
+
     health = await request(app).get('/health').expect(200);
     expect(health.body.dependencies.indexer.reorgDetected).toBe(false);
     expect(health.body.dependencies.indexer.lastSafeLedger).toBe(109);
+  });
+});
+
+describe('Reorg rollback prevents duplicate webhooks and WS events', () => {
+  beforeEach(() => {
+    resetIndexerState();
+    setIndexerIngestAuthToken(INDEXER_TOKEN);
+    const store = new InMemoryContractEventStore();
+    setIndexerEventStore(store);
+  });
+
+  afterEach(() => {
+    _resetRolledBackLedgers();
+  });
+
+  // ── isLedgerRolledBack ────────────────────────────────────────────────────
+
+  it('isLedgerRolledBack returns false before any reorg', () => {
+    expect(isLedgerRolledBack(100)).toBe(false);
+  });
+
+  it('isLedgerRolledBack returns true after a reorg at that ledger', async () => {
+    await postEvents([buildEvent('evt-100', 100, 'hash-100')]).expect(200);
+    // Trigger reorg
+    await postEvents([buildEvent('evt-100-new', 100, 'hash-100-reorg')]).expect(200);
+    expect(isLedgerRolledBack(100)).toBe(true);
+  });
+
+  it('isLedgerRolledBack returns false for a ledger that was not reorged', async () => {
+    await postEvents([buildEvent('evt-100', 100, 'hash-100')]).expect(200);
+    await postEvents([buildEvent('evt-101-new', 101, 'hash-101-reorg')]).expect(200);
+    // ledger 100 was not reorged
+    expect(isLedgerRolledBack(100)).toBe(false);
+  });
+
+  it('isLedgerRolledBack clears after chain advances past reorg + 5', async () => {
+    await postEvents([buildEvent('evt-100', 100, 'hash-100')]).expect(200);
+    await postEvents([buildEvent('evt-100-new', 100, 'hash-100-reorg')]).expect(200);
+    expect(isLedgerRolledBack(100)).toBe(true);
+
+    // Advance past reorg height + 5
+    await postEvents([buildEvent('evt-110', 110, 'hash-110')]).expect(200);
+    expect(isLedgerRolledBack(100)).toBe(false);
+  });
+
+  // ── Webhook dispatcher suppression ───────────────────────────────────────
+
+  it('dispatchWebhook skips delivery for a rolled-back ledger', async () => {
+    await postEvents([buildEvent('evt-200', 200, 'hash-200')]).expect(200);
+    await postEvents([buildEvent('evt-200-new', 200, 'hash-200-reorg')]).expect(200);
+
+    const dispatched: string[] = [];
+    const originalFetch = global.fetch;
+    global.fetch = async () => {
+      dispatched.push('called');
+      return new Response(null, { status: 200 });
+    };
+
+    try {
+      await dispatchWebhook({
+        url: 'https://example.com/hook',
+        secret: 'secret',
+        event: 'stream.created',
+        payload: { streamId: 'stream-1' },
+        ledger: 200,
+      });
+      expect(dispatched).toHaveLength(0);
+    } finally {
+      global.fetch = originalFetch;
+    }
+  });
+
+  it('dispatchWebhook delivers normally when ledger is not rolled back', async () => {
+    const dispatched: string[] = [];
+    const originalFetch = global.fetch;
+    global.fetch = async () => {
+      dispatched.push('called');
+      return new Response(null, { status: 200 });
+    };
+
+    try {
+      await dispatchWebhook({
+        url: 'https://example.com/hook',
+        secret: 'secret',
+        event: 'stream.created',
+        payload: { streamId: 'stream-1' },
+        ledger: 999,
+      });
+      expect(dispatched).toHaveLength(1);
+    } finally {
+      global.fetch = originalFetch;
+    }
+  });
+
+  it('dispatchWebhook delivers normally when no ledger is provided', async () => {
+    await postEvents([buildEvent('evt-300', 300, 'hash-300')]).expect(200);
+    await postEvents([buildEvent('evt-300-new', 300, 'hash-300-reorg')]).expect(200);
+
+    const dispatched: string[] = [];
+    const originalFetch = global.fetch;
+    global.fetch = async () => {
+      dispatched.push('called');
+      return new Response(null, { status: 200 });
+    };
+
+    try {
+      // No ledger field — should not be suppressed
+      await dispatchWebhook({
+        url: 'https://example.com/hook',
+        secret: 'secret',
+        event: 'stream.created',
+        payload: { streamId: 'stream-1' },
+      });
+      expect(dispatched).toHaveLength(1);
+    } finally {
+      global.fetch = originalFetch;
+    }
   });
 });


### PR DESCRIPTION
Closes #143

---

## What

During a chain reorg the indexer rolls back events from the orphaned branch. Without this fix, any webhook or WS broadcast already queued for those rolled-back events would still fire, causing duplicate delivery to consumers.

## Changes

**src/indexer/service.ts**
- Module-level \olledBackLedgers\ Set tracks ledgers invalidated by a reorg
- \isLedgerRolledBack(ledger)\ exported so dispatcher and hub can check
- Ledger added to set on rollback, cleared when chain advances past reorg height + 5
- \esetRuntimeState()\ clears the set (test isolation)

**src/webhooks/dispatcher.ts**
- Checks \isLedgerRolledBack(ledger)\ before dispatching; skips and logs if rolled back
- Backward compatible: no \ledger\ field = no suppression

**src/ws/hub.ts**
- \StreamUpdateEvent\ gains optional \ledger\ field
- \roadcast()\ checks \isLedgerRolledBack(ledger)\ before emitting; skips if rolled back

**tests/reorg.test.ts**
- 8 new tests: isLedgerRolledBack state transitions, webhook suppression on rolled-back ledger, normal delivery when ledger is clean, no suppression when ledger field is omitted