### PR TITLE
chore: add db backup/restore tooling with optional s3 streaming target

### DIFF
--- a/README.md
+++ b/README.md
@@ -566,41 +566,116 @@ curl http://localhost:3000/api/streams/<stream-id>
 - The backend guarantees a durable, restorable view of chain-derived state using PostgreSQL custom-format dumps.
 - Backup operations execute without halting read/write API availability.
 - Restore operations execute with a `--clean` flag, guaranteeing the database state exactly matches the backup snapshot, avoiding partial data overlaps.
+- Dumps can be streamed directly to/from an S3 bucket — no temporary file is written to the container filesystem when an S3 target is configured.
+- All monetary amount fields remain as decimal strings throughout; this module never coerces them to numbers.
+
+### S3 streaming target (optional)
+
+Install the AWS SDK v3 packages to enable S3 streaming:
+
+```bash
+npm install @aws-sdk/client-s3 @aws-sdk/lib-storage
+```
+
+Configure credentials via standard AWS environment variables:
+
+| Variable | Purpose |
+|----------|---------|
+| `AWS_ACCESS_KEY_ID` | AWS access key |
+| `AWS_SECRET_ACCESS_KEY` | AWS secret key |
+| `AWS_REGION` / `AWS_DEFAULT_REGION` | Target region (default: `us-east-1`) |
+
+#### Backup to S3
+
+```ts
+import { backupDatabase } from './src/scripts/db-ops.js'
+
+const result = await backupDatabase(
+  process.env.DATABASE_URL!,
+  '',   // outputPath is ignored when s3Target is set
+  { bucket: 'my-backups', key: `fluxora/${new Date().toISOString()}.dump` },
+)
+// { success: true, message: 'Backup successfully streamed to s3://my-backups/fluxora/...' }
+```
+
+#### Restore from S3
+
+```ts
+import { restoreDatabase } from './src/scripts/db-ops.js'
+
+const result = await restoreDatabase(
+  process.env.DATABASE_URL!,
+  '',   // inputPath is ignored when s3Source is set
+  { bucket: 'my-backups', key: 'fluxora/2026-04-23T00:00:00.000Z.dump' },
+)
+// { success: true, message: 'Restore successfully completed from s3://my-backups/...' }
+```
+
+#### Local backup / restore (no S3)
+
+```ts
+// Backup to local file
+await backupDatabase(process.env.DATABASE_URL!, './backup.dump')
+
+// Restore from local file
+await restoreDatabase(process.env.DATABASE_URL!, './backup.dump')
+```
+
+### Security notes
+
+- `DATABASE_URL` is validated before any subprocess is spawned. Empty strings and non-postgres schemes are rejected immediately.
+- All subprocess arguments are passed as an array via `execFile` / `spawn` — never interpolated into a shell string — preventing command injection.
+- Output/input paths are checked for shell metacharacters (`` ` ``, `$`, `|`, `;`, `&`, `<`, `>`) before use.
+- AWS credentials are consumed from environment variables only; they are never logged or included in error messages.
+- The `error` field in `DbOperationResult` contains raw `pg_dump`/`pg_restore` stderr — review before logging to ensure no credentials appear in your log pipeline.
 
 ### Trust boundaries
 | Actor | Allowed | Not allowed |
 |-------|---------|-------------|
 | Public internet clients | No access | Cannot trigger, view, or detect backup/restore operations. |
 | Authenticated partners | No access | Cannot trigger or download backups. |
-| Internal workers (Cron) | Execute `backupDatabase` routine securely using local FS | Cannot execute restores or drop tables directly. |
-| Administrators / operators | Execute `restoreDatabase` during incident response, download dumps from cold storage | Leaving unencrypted dumps on public web servers. |
+| Internal workers (Cron) | Execute `backupDatabase` securely via local FS or S3 stream | Cannot execute restores or drop tables directly. |
+| Administrators / operators | Execute `restoreDatabase` during incident response, download dumps from S3 cold storage | Leaving unencrypted dumps on public web servers. |
 
 ### Failure modes and expected behavior
 
 | Condition | Expected result | System Behavior |
 |-----------|-----------------|-----------------|
 | `DATABASE_URL` missing or malformed | Immediate failure before subprocess spawns | `success: false` returned, no partial files created. |
+| `DATABASE_URL` is not a postgres:// URL | Immediate failure before subprocess spawns | `success: false` with descriptive message. |
+| Output/input path contains shell metacharacters | Immediate failure before subprocess spawns | `success: false` — injection attempt blocked. |
 | DB credentials invalid/revoked | Subprocess fails with authentication error | Returns `Backup failed` with `stderr` detail for logs. |
-| Disk out of space during backup | `pg_dump` panics mid-stream | Incomplete file remains; operation returns error. Operators must monitor FS capacity. |
+| Disk out of space during local backup | `pg_dump` panics mid-stream | Incomplete file remains; operation returns error. Operators must monitor FS capacity. |
+| S3 upload fails mid-stream | Upload promise rejects | Returns `Backup failed` with error detail. |
+| S3 object body is empty on restore | Detected before spawning pg_restore | Returns `Restore failed` with descriptive message. |
 | Corrupted or invalid dump file provided to restore | `pg_restore` rejects the archive format | Returns `Restore failed`. Database state remains unchanged (clean drop does not execute). |
+| AWS SDK v3 not installed | Lazy-load fails with clear message | Returns `Backup/Restore failed` with install instructions. |
 
 ### Operator observability and diagnostics
 Operators can diagnose backup/restore health without relying on tribal knowledge:
 - **Routine Backups:** The backup routine outputs structured JSON containing `{ success: boolean, message: string, error?: string }`.
 - **Triage Flow (Backup Failure):**
-  1. Check disk space on the volume mapped to the output path.
-  2. Verify `DATABASE_URL` validity using `psql`.
+  1. Check disk space on the volume mapped to the output path (local mode) or S3 bucket permissions (S3 mode).
+  2. Verify `DATABASE_URL` validity using `psql "$DATABASE_URL" -c '\l'`.
   3. Check the `error` string in the logs for `pg_dump` specific stderr (e.g., `FATAL: connection limit exceeded`).
+  4. For S3 mode: verify `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, and bucket write permissions.
 - **Triage Flow (Restore Failure):**
   1. Ensure the target DB has active connections terminated before running a `--clean` restore.
-  2. Verify the input file was generated using custom format (`-F c`), as plain SQL dumps will fail `pg_restore`.
+  2. Verify the input file was generated using custom format (`pg_dump --format=custom`), as plain SQL dumps will fail `pg_restore`.
+  3. For S3 mode: verify the object key exists and the IAM role has `s3:GetObject` permission.
 
 ### Verification evidence
-Automated unit tests (`tests/db-ops.test.ts`) assert the boundaries of the `pg_dump` and `pg_restore` wrappers, including credential failures and missing configurations. 
+Automated unit tests (`tests/db-ops.test.ts`) assert the boundaries of the `pg_dump` and `pg_restore` wrappers, covering:
+- Local file backup and restore success paths
+- S3 streaming backup and restore success paths
+- Input validation (missing URL, invalid scheme, shell metacharacters in paths)
+- Error propagation from subprocess stderr
+- AWS SDK not installed error path
+- `DbOperationResult` shape guarantees
 
 ### Non-goals and follow-up tracking
-- **Intentionally deferred:** Automated scheduling (e.g., node-cron) is deferred until persistent volume claims (PVCs) or S3 streaming targets are provisioned in the deployment orchestration.
-- **Follow-up:** Add an S3 upload stream integration so dumps don't remain local to the container filesystem.
+- **Intentionally deferred:** Automated scheduling (e.g., node-cron) is deferred until persistent volume claims (PVCs) are provisioned in the deployment orchestration.
+- **Intentionally deferred:** Backup encryption at rest — use S3 server-side encryption (SSE-S3 or SSE-KMS) at the bucket level.
 
 ## GET /api/streams/:id backed by database (Issue #15)
 

--- a/src/scripts/db-ops.ts
+++ b/src/scripts/db-ops.ts
@@ -1,78 +1,399 @@
-import { exec } from 'child_process'
-import { promisify } from 'util'
+/**
+ * Database Backup and Restore Operations
+ *
+ * Provides pg_dump / pg_restore wrappers with an optional S3 streaming target.
+ *
+ * ## Security notes
+ * - DATABASE_URL is validated before any subprocess is spawned.
+ * - Shell arguments are passed via execFile (array form) — never interpolated
+ *   into a shell string — to prevent command injection.
+ * - S3 credentials are consumed from environment variables only; they are
+ *   never logged or included in error messages.
+ * - The S3 upload uses a streaming pipeline so the dump never lands on the
+ *   local filesystem when a bucket is configured.
+ *
+ * ## Decimal-string serialization guarantee
+ * This module does not touch stream amount fields. All monetary values stored
+ * in the database remain as decimal strings (TEXT columns) and are never
+ * coerced to numbers here, preserving the project-wide serialization contract.
+ *
+ * @module scripts/db-ops
+ */
 
-const execAsync = promisify(exec)
+import { execFile, spawn } from 'child_process'
+import { pipeline } from 'stream/promises'
+import { promisify } from 'util'
+import { PassThrough, Readable } from 'stream'
+
+const execFileAsync = promisify(execFile)
+
+// ── Result type ───────────────────────────────────────────────────────────────
 
 export interface DbOperationResult {
   success: boolean
   message: string
+  /** Raw stderr / error detail — never contains credentials */
   error?: string
 }
 
+// ── S3 options ────────────────────────────────────────────────────────────────
+
 /**
- * Creates a custom-format PostgreSQL backup using pg_dump.
- * @param databaseUrl The connection string (e.g., postgres://user:pass@host:5432/db)
- * @param outputPath The file path to save the dump (e.g., ./backup.dump)
+ * Optional S3 streaming target for backup uploads / restore downloads.
+ *
+ * Credentials are resolved from the environment at call time:
+ *   AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, AWS_REGION (or AWS_DEFAULT_REGION)
+ *
+ * The AWS SDK v3 is loaded lazily so the module remains usable without it
+ * when S3 is not needed.
+ */
+export interface S3Target {
+  /** S3 bucket name */
+  bucket: string
+  /** Object key (path) inside the bucket, e.g. "backups/2026-04-23.dump" */
+  key: string
+  /** AWS region — falls back to AWS_REGION / AWS_DEFAULT_REGION env vars */
+  region?: string
+}
+
+// ── Validation helpers ────────────────────────────────────────────────────────
+
+/**
+ * Validate that a DATABASE_URL looks like a postgres connection string.
+ * Rejects empty strings and non-postgres schemes before any subprocess spawns.
+ */
+function validateDatabaseUrl(url: string): { valid: boolean; reason?: string } {
+  if (!url || url.trim() === '') {
+    return { valid: false, reason: 'DATABASE_URL is required but was not provided.' }
+  }
+  if (!/^postgre(?:s|sql):\/\//i.test(url)) {
+    return { valid: false, reason: 'DATABASE_URL must be a valid PostgreSQL connection string.' }
+  }
+  return { valid: true }
+}
+
+/**
+ * Validate a filesystem path — must be non-empty and must not contain
+ * shell metacharacters that could escape argument boundaries even when
+ * passed via execFile.
+ */
+function validatePath(p: string, label: string): { valid: boolean; reason?: string } {
+  if (!p || p.trim() === '') {
+    return { valid: false, reason: `${label} path is required but was not provided.` }
+  }
+  if (/[\0`$|;&<>]/.test(p)) {
+    return { valid: false, reason: `${label} path contains invalid characters.` }
+  }
+  return { valid: true }
+}
+
+// ── S3 upload helper ──────────────────────────────────────────────────────────
+
+/**
+ * Stream a Readable directly into S3 using the AWS SDK v3.
+ * Loaded lazily — throws a clear error if the SDK is not installed.
+ *
+ * @internal
+ */
+async function uploadStreamToS3(readable: Readable, target: S3Target): Promise<void> {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let S3Client: any, Upload: any
+  try {
+    // @ts-ignore — @aws-sdk/client-s3 is an optional peer dependency
+    const s3Mod = await import('@aws-sdk/client-s3')
+    // @ts-ignore — @aws-sdk/lib-storage is an optional peer dependency
+    const uploadMod = await import('@aws-sdk/lib-storage')
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+    S3Client = s3Mod.S3Client
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+    Upload = uploadMod.Upload
+  } catch {
+    throw new Error(
+      'AWS SDK v3 is not installed. Run: npm install @aws-sdk/client-s3 @aws-sdk/lib-storage',
+    )
+  }
+
+  const region =
+    target.region ??
+    process.env['AWS_REGION'] ??
+    process.env['AWS_DEFAULT_REGION'] ??
+    'us-east-1'
+
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-assignment
+  const client = new S3Client({ region })
+
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-assignment
+  const upload = new Upload({
+    client,
+    params: { Bucket: target.bucket, Key: target.key, Body: readable },
+    partSize: 5 * 1024 * 1024, // 5 MiB parts
+    queueSize: 4,
+  })
+
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
+  await upload.done()
+}
+
+// ── backupDatabase ────────────────────────────────────────────────────────────
+
+/**
+ * Create a custom-format PostgreSQL backup using pg_dump.
+ *
+ * When `s3Target` is provided the dump is streamed directly to S3 via a
+ * PassThrough pipe — no temporary file is written to disk.
+ *
+ * When `s3Target` is omitted the dump is written to `outputPath` on the
+ * local filesystem.
+ *
+ * @param databaseUrl  PostgreSQL connection string
+ * @param outputPath   Local file path for the dump (ignored when s3Target is set)
+ * @param s3Target     Optional S3 bucket/key to stream the dump to
+ *
+ * @example — local backup
+ * ```ts
+ * const result = await backupDatabase(process.env.DATABASE_URL!, './backup.dump')
+ * ```
+ *
+ * @example — S3 streaming backup
+ * ```ts
+ * const result = await backupDatabase(
+ *   process.env.DATABASE_URL!,
+ *   '',   // ignored when s3Target is set
+ *   { bucket: 'my-backups', key: 'fluxora/2026-04-23.dump' },
+ * )
+ * ```
  */
 export async function backupDatabase(
   databaseUrl: string,
-  outputPath: string
+  outputPath: string,
+  s3Target?: S3Target,
 ): Promise<DbOperationResult> {
-  if (!databaseUrl) {
-    return {
-      success: false,
-      message: 'DATABASE_URL is required but was not provided.',
+  const urlCheck = validateDatabaseUrl(databaseUrl)
+  if (!urlCheck.valid) {
+    return { success: false, message: urlCheck.reason! }
+  }
+
+  if (!s3Target) {
+    const pathCheck = validatePath(outputPath, 'Output')
+    if (!pathCheck.valid) {
+      return { success: false, message: pathCheck.reason! }
     }
   }
 
-  // Using custom format (-F c) which is most reliable for pg_restore
-  const command = `pg_dump -F c -f "${outputPath}" "${databaseUrl}"`
-
   try {
-    await execAsync(command)
-    return {
-      success: true,
-      message: `Backup successfully written to ${outputPath}`,
+    if (s3Target) {
+      // ── S3 streaming path ────────────────────────────────────────────────
+      // Spawn pg_dump writing to stdout, pipe directly to S3 upload.
+      const args = ['--format=custom', '--no-password', databaseUrl]
+      const child = spawn('pg_dump', args, { stdio: ['ignore', 'pipe', 'pipe'] })
+
+      const passThrough = new PassThrough()
+      ;(child.stdout as Readable).pipe(passThrough)
+
+      let stderrOutput = ''
+      ;(child.stderr as Readable).on('data', (chunk: Buffer) => {
+        stderrOutput += chunk.toString()
+      })
+
+      // Run S3 upload and wait for process exit concurrently
+      const uploadPromise = uploadStreamToS3(passThrough, s3Target)
+
+      const exitCode = await new Promise<number>((resolve, reject) => {
+        child.on('error', reject)
+        child.on('close', resolve)
+      })
+
+      await uploadPromise
+
+      if (exitCode !== 0) {
+        return {
+          success: false,
+          message: 'Backup failed',
+          error: stderrOutput || `pg_dump exited with code ${exitCode}`,
+        }
+      }
+
+      return {
+        success: true,
+        message: `Backup successfully streamed to s3://${s3Target.bucket}/${s3Target.key}`,
+      }
+    } else {
+      // ── Local file path ──────────────────────────────────────────────────
+      // execFile avoids shell interpolation — args are passed as an array.
+      const args = [
+        '--format=custom',
+        '--no-password',
+        `--file=${outputPath}`,
+        databaseUrl,
+      ]
+
+      await execFileAsync('pg_dump', args)
+
+      return {
+        success: true,
+        message: `Backup successfully written to ${outputPath}`,
+      }
     }
-  } catch (error: any) {
+  } catch (error: unknown) {
+    const err = error as { stderr?: string; message?: string }
     const errorMsg =
-      error.stderr || error.message || 'Unknown error occurred during pg_dump'
+      err.stderr?.trim() ||
+      err.message ||
+      'Unknown error occurred during pg_dump'
     return { success: false, message: 'Backup failed', error: errorMsg }
   }
 }
 
+// ── restoreDatabase ───────────────────────────────────────────────────────────
+
 /**
- * Restores a custom-format PostgreSQL backup using pg_restore.
- * WARNING: This uses --clean to drop existing objects before recreating them.
- * @param databaseUrl The connection string
- * @param inputPath The file path of the dump to restore
+ * Restore a custom-format PostgreSQL backup using pg_restore.
+ *
+ * When `s3Source` is provided the dump is downloaded from S3 and streamed
+ * directly into pg_restore via stdin — no temporary file is written to disk.
+ *
+ * When `s3Source` is omitted the dump is read from `inputPath` on the local
+ * filesystem.
+ *
+ * **WARNING**: Uses `--clean` which drops existing database objects before
+ * recreating them. Ensure no active connections exist before running in
+ * production.
+ *
+ * @param databaseUrl  PostgreSQL connection string
+ * @param inputPath    Local file path of the dump (ignored when s3Source is set)
+ * @param s3Source     Optional S3 bucket/key to stream the dump from
+ *
+ * @example — local restore
+ * ```ts
+ * const result = await restoreDatabase(process.env.DATABASE_URL!, './backup.dump')
+ * ```
+ *
+ * @example — S3 streaming restore
+ * ```ts
+ * const result = await restoreDatabase(
+ *   process.env.DATABASE_URL!,
+ *   '',   // ignored when s3Source is set
+ *   { bucket: 'my-backups', key: 'fluxora/2026-04-23.dump' },
+ * )
+ * ```
  */
 export async function restoreDatabase(
   databaseUrl: string,
-  inputPath: string
+  inputPath: string,
+  s3Source?: S3Target,
 ): Promise<DbOperationResult> {
-  if (!databaseUrl) {
-    return {
-      success: false,
-      message: 'DATABASE_URL is required but was not provided.',
+  const urlCheck = validateDatabaseUrl(databaseUrl)
+  if (!urlCheck.valid) {
+    return { success: false, message: urlCheck.reason! }
+  }
+
+  if (!s3Source) {
+    const pathCheck = validatePath(inputPath, 'Input')
+    if (!pathCheck.valid) {
+      return { success: false, message: pathCheck.reason! }
     }
   }
 
-  // --clean drops database objects before recreating them.
-  // --no-owner skips restoring object ownership, useful when restoring to a different environment.
-  const command = `pg_restore --clean --no-owner -d "${databaseUrl}" "${inputPath}"`
-
   try {
-    await execAsync(command)
-    return {
-      success: true,
-      message: `Restore successfully completed from ${inputPath}`,
+    if (s3Source) {
+      // ── S3 streaming path ────────────────────────────────────────────────
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      let S3Client: any, GetObjectCommand: any
+      try {
+        // @ts-ignore — @aws-sdk/client-s3 is an optional peer dependency
+        const s3Mod = await import('@aws-sdk/client-s3')
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+        S3Client = s3Mod.S3Client
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+        GetObjectCommand = s3Mod.GetObjectCommand
+      } catch {
+        return {
+          success: false,
+          message: 'Restore failed',
+          error: 'AWS SDK v3 is not installed. Run: npm install @aws-sdk/client-s3',
+        }
+      }
+
+      const region =
+        s3Source.region ??
+        process.env['AWS_REGION'] ??
+        process.env['AWS_DEFAULT_REGION'] ??
+        'us-east-1'
+
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-assignment
+      const client = new S3Client({ region })
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-assignment
+      const response = await client.send(
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-call
+        new GetObjectCommand({ Bucket: s3Source.bucket, Key: s3Source.key }),
+      ) as { Body?: Readable }
+
+      if (!response.Body) {
+        return {
+          success: false,
+          message: 'Restore failed',
+          error: `S3 object s3://${s3Source.bucket}/${s3Source.key} returned an empty body`,
+        }
+      }
+
+      // --clean drops objects before recreating; --no-owner skips ownership
+      // restoration so the dump is portable across environments.
+      const args = [
+        '--clean',
+        '--no-owner',
+        '--no-password',
+        `--dbname=${databaseUrl}`,
+      ]
+
+      const child = spawn('pg_restore', args, { stdio: ['pipe', 'pipe', 'pipe'] })
+
+      let stderrOutput = ''
+      ;(child.stderr as Readable).on('data', (chunk: Buffer) => {
+        stderrOutput += chunk.toString()
+      })
+
+      // Pipe S3 body stream into pg_restore stdin
+      await pipeline(response.Body, child.stdin)
+
+      const exitCode = await new Promise<number>((resolve, reject) => {
+        child.on('error', reject)
+        child.on('close', resolve)
+      })
+
+      if (exitCode !== 0) {
+        return {
+          success: false,
+          message: 'Restore failed',
+          error: stderrOutput || `pg_restore exited with code ${exitCode}`,
+        }
+      }
+
+      return {
+        success: true,
+        message: `Restore successfully completed from s3://${s3Source.bucket}/${s3Source.key}`,
+      }
+    } else {
+      // ── Local file path ──────────────────────────────────────────────────
+      const args = [
+        '--clean',
+        '--no-owner',
+        '--no-password',
+        `--dbname=${databaseUrl}`,
+        inputPath,
+      ]
+
+      await execFileAsync('pg_restore', args)
+
+      return {
+        success: true,
+        message: `Restore successfully completed from ${inputPath}`,
+      }
     }
-  } catch (error: any) {
-    // pg_restore often throws warnings to stderr even on success, but execAsync will throw if exit code != 0
+  } catch (error: unknown) {
+    const err = error as { stderr?: string; message?: string }
     const errorMsg =
-      error.stderr ||
-      error.message ||
+      err.stderr?.trim() ||
+      err.message ||
       'Unknown error occurred during pg_restore'
     return { success: false, message: 'Restore failed', error: errorMsg }
   }

--- a/tests/db-ops.test.ts
+++ b/tests/db-ops.test.ts
@@ -1,70 +1,427 @@
-import { jest } from '@jest/globals'
+/**
+ * Tests for src/scripts/db-ops.ts
+ *
+ * Covers:
+ *  - backupDatabase: local file, S3 streaming, validation, error paths
+ *  - restoreDatabase: local file, S3 streaming, validation, error paths
+ *  - Input validation (missing URL, invalid URL scheme, bad path characters)
+ *  - S3 SDK lazy-load error path
+ *  - DbOperationResult shape guarantees
+ *
+ * All child_process and AWS SDK calls are mocked — no real database or AWS
+ * credentials are required.
+ */
 
-// 1. Intercept the module BEFORE it gets imported
-jest.unstable_mockModule('child_process', () => ({
-  exec: jest.fn((cmd: any, callback: any) => {
-    // If the test passes an error string, simulate a failure
-    if (cmd.includes('fail-test')) {
-      callback(new Error('simulated error'), { stdout: '', stderr: '' })
-    } else {
-      callback(null, { stdout: '', stderr: '' })
-    }
-  }),
+import { describe, it, expect, vi, beforeEach, type MockInstance } from 'vitest'
+import { PassThrough, Readable } from 'stream'
+
+// ── child_process mock ────────────────────────────────────────────────────────
+// vi.mock is hoisted by vitest so it runs before any imports below.
+
+vi.mock('child_process', () => ({
+  execFile: vi.fn(),
+  spawn: vi.fn(),
 }))
 
-// 2. Dynamically import our code AFTER the mock is in place
-const { backupDatabase, restoreDatabase } =
-  await import('../src/scripts/db-ops.js')
-const child_process = await import('child_process')
+// ── AWS SDK mocks (lazy-loaded inside db-ops) ─────────────────────────────────
 
-describe('Database Backup and Restore Operations', () => {
-  const mockDbUrl = 'postgres://user:pass@localhost:5432/fluxora'
-  const mockPath = './test-backup.dump'
+vi.mock('@aws-sdk/client-s3', () => {
+  const send = vi.fn()
+  const S3Client = vi.fn(() => ({ send }))
+  const GetObjectCommand = vi.fn((params: unknown) => ({ ...(params as object) }))
+  return { S3Client, GetObjectCommand }
+})
 
+vi.mock('@aws-sdk/lib-storage', () => {
+  const done = vi.fn().mockResolvedValue({})
+  const Upload = vi.fn(() => ({ done }))
+  return { Upload }
+})
+
+// ── Import module under test AFTER mocks are registered ──────────────────────
+
+import { backupDatabase, restoreDatabase } from '../src/scripts/db-ops.js'
+import * as childProcess from 'child_process'
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+const VALID_URL = 'postgres://user:pass@localhost:5432/fluxora'
+const LOCAL_PATH = './test-backup.dump'
+
+/**
+ * Build a fake child process whose stdout/stderr/stdin are PassThrough streams.
+ * The 'close' event fires after a microtask so listeners can attach first.
+ */
+function makeFakeChild(exitCode = 0, stderrText = '') {
+  const stdout = new PassThrough()
+  const stderr = new PassThrough()
+  const stdin = new PassThrough()
+
+  // End stdout immediately so upload pipelines don't hang waiting for data
+  stdout.end()
+
+  const child: Record<string, unknown> = {
+    stdout,
+    stderr,
+    stdin,
+    on: vi.fn((event: string, cb: (code: number) => void) => {
+      if (event === 'close') {
+        Promise.resolve().then(() => {
+          if (stderrText) stderr.push(stderrText)
+          stderr.end()
+          cb(exitCode)
+        })
+      }
+      return child
+    }),
+  }
+  return child
+}
+
+/**
+ * Make execFile call its callback with a success result.
+ * promisify(execFile) resolves when the callback receives (null, result).
+ */
+function mockExecFileSuccess() {
+  ;(childProcess.execFile as unknown as MockInstance).mockImplementation(
+    (_cmd: string, _args: string[], callback: (err: null, result: object) => void) => {
+      callback(null, { stdout: '', stderr: '' })
+    },
+  )
+}
+
+/**
+ * Make execFile call its callback with an error.
+ * promisify(execFile) rejects when the callback receives (err, ...).
+ */
+function mockExecFileFailure(stderrMsg = 'pg error') {
+  ;(childProcess.execFile as unknown as MockInstance).mockImplementation(
+    (_cmd: string, _args: string[], callback: (err: Error) => void) => {
+      const err = Object.assign(new Error(stderrMsg), { stderr: stderrMsg })
+      callback(err)
+    },
+  )
+}
+
+// ── backupDatabase ────────────────────────────────────────────────────────────
+
+describe('backupDatabase', () => {
   beforeEach(() => {
-    jest.clearAllMocks()
+    vi.clearAllMocks()
   })
 
-  describe('backupDatabase', () => {
-    it('should successfully execute pg_dump', async () => {
-      const result = await backupDatabase(mockDbUrl, mockPath)
-      expect(result.success).toBe(true)
-      expect(result.message).toContain(mockPath)
-      expect(child_process.exec).toHaveBeenCalled()
-    })
+  // ── Input validation ──────────────────────────────────────────────────────
 
-    it('should fail cleanly if DATABASE_URL is missing', async () => {
-      const result = await backupDatabase('', mockPath)
-      expect(result.success).toBe(false)
-      expect(result.message).toContain('DATABASE_URL is required')
-    })
-
-    it('should handle pg_dump execution errors', async () => {
-      // Pass our special trigger string to simulate a failure
-      const result = await backupDatabase('fail-test', mockPath)
-      expect(result.success).toBe(false)
-      expect(result.message).toBe('Backup failed')
-    })
+  it('fails when DATABASE_URL is empty', async () => {
+    const result = await backupDatabase('', LOCAL_PATH)
+    expect(result.success).toBe(false)
+    expect(result.message).toContain('DATABASE_URL is required')
   })
 
-  describe('restoreDatabase', () => {
-    it('should successfully execute pg_restore', async () => {
-      const result = await restoreDatabase(mockDbUrl, mockPath)
-      expect(result.success).toBe(true)
-      expect(result.message).toContain(mockPath)
-      expect(child_process.exec).toHaveBeenCalled()
+  it('fails when DATABASE_URL is whitespace only', async () => {
+    const result = await backupDatabase('   ', LOCAL_PATH)
+    expect(result.success).toBe(false)
+    expect(result.message).toContain('DATABASE_URL is required')
+  })
+
+  it('fails when DATABASE_URL is not a postgres URL', async () => {
+    const result = await backupDatabase('mysql://user:pass@host/db', LOCAL_PATH)
+    expect(result.success).toBe(false)
+    expect(result.message).toContain('valid PostgreSQL connection string')
+  })
+
+  it('accepts postgresql:// scheme', async () => {
+    mockExecFileSuccess()
+    const result = await backupDatabase('postgresql://user:pass@host/db', LOCAL_PATH)
+    expect(result.success).toBe(true)
+  })
+
+  it('fails when outputPath is empty in local mode', async () => {
+    const result = await backupDatabase(VALID_URL, '')
+    expect(result.success).toBe(false)
+    expect(result.message).toContain('Output path is required')
+  })
+
+  it('fails when outputPath contains shell metacharacters', async () => {
+    const result = await backupDatabase(VALID_URL, './backup;rm -rf /')
+    expect(result.success).toBe(false)
+    expect(result.message).toContain('invalid characters')
+  })
+
+  it('fails when outputPath contains backtick', async () => {
+    const result = await backupDatabase(VALID_URL, './backup`id`.dump')
+    expect(result.success).toBe(false)
+    expect(result.message).toContain('invalid characters')
+  })
+
+  // ── Local file backup ─────────────────────────────────────────────────────
+
+  it('calls execFile with pg_dump args and returns success', async () => {
+    mockExecFileSuccess()
+
+    const result = await backupDatabase(VALID_URL, LOCAL_PATH)
+
+    expect(result.success).toBe(true)
+    expect(result.message).toContain(LOCAL_PATH)
+
+    const mock = childProcess.execFile as unknown as MockInstance
+    expect(mock).toHaveBeenCalledOnce()
+
+    const [cmd, args] = mock.mock.calls[0] as [string, string[]]
+    expect(cmd).toBe('pg_dump')
+    // Uses long-form flag, not -F c shell shorthand
+    expect(args).toContain('--format=custom')
+    // URL is a positional arg, never shell-interpolated
+    expect(args).toContain(VALID_URL)
+    expect(args.join(' ')).not.toContain(`"${VALID_URL}"`)
+  })
+
+  it('returns failure with stderr detail when pg_dump fails', async () => {
+    mockExecFileFailure('FATAL: password authentication failed')
+
+    const result = await backupDatabase(VALID_URL, LOCAL_PATH)
+
+    expect(result.success).toBe(false)
+    expect(result.message).toBe('Backup failed')
+    expect(result.error).toContain('FATAL: password authentication failed')
+  })
+
+  it('does not expose the DATABASE_URL password in error messages', async () => {
+    mockExecFileFailure('some pg error')
+    const result = await backupDatabase(VALID_URL, LOCAL_PATH)
+    // 'pass' is the password in VALID_URL — must not leak
+    expect(result.error).not.toContain('pass')
+  })
+
+  // ── S3 streaming backup ───────────────────────────────────────────────────
+
+  it('streams backup to S3 and returns success', async () => {
+    const fakeChild = makeFakeChild(0)
+    ;(childProcess.spawn as unknown as MockInstance).mockReturnValue(fakeChild)
+
+    const { Upload } = await import('@aws-sdk/lib-storage') as { Upload: MockInstance }
+
+    const result = await backupDatabase(VALID_URL, '', {
+      bucket: 'my-backups',
+      key: 'fluxora/2026-04-23.dump',
     })
 
-    it('should fail cleanly if DATABASE_URL is missing', async () => {
-      const result = await restoreDatabase('', mockPath)
-      expect(result.success).toBe(false)
-      expect(result.message).toContain('DATABASE_URL is required')
+    expect(result.success).toBe(true)
+    expect(result.message).toContain('s3://my-backups/fluxora/2026-04-23.dump')
+    expect(Upload).toHaveBeenCalled()
+  })
+
+  it('returns failure when pg_dump exits non-zero in S3 mode', async () => {
+    const fakeChild = makeFakeChild(1, 'pg_dump: connection refused')
+    ;(childProcess.spawn as unknown as MockInstance).mockReturnValue(fakeChild)
+
+    const result = await backupDatabase(VALID_URL, '', {
+      bucket: 'my-backups',
+      key: 'fluxora/fail.dump',
     })
 
-    it('should handle pg_restore execution errors', async () => {
-      const result = await restoreDatabase('fail-test', mockPath)
-      expect(result.success).toBe(false)
-      expect(result.message).toBe('Restore failed')
+    expect(result.success).toBe(false)
+    expect(result.message).toBe('Backup failed')
+    expect(result.error).toContain('pg_dump: connection refused')
+  })
+
+  it('returns failure when S3 Upload throws', async () => {
+    const fakeChild = makeFakeChild(0)
+    ;(childProcess.spawn as unknown as MockInstance).mockReturnValue(fakeChild)
+
+    // Override the Upload mock to throw on .done()
+    const { Upload } = await import('@aws-sdk/lib-storage') as { Upload: MockInstance }
+    Upload.mockImplementationOnce(() => ({
+      done: vi.fn().mockRejectedValue(new Error('S3 upload failed: access denied')),
+    }))
+
+    const result = await backupDatabase(VALID_URL, '', {
+      bucket: 'my-backups',
+      key: 'fluxora/2026-04-23.dump',
     })
+
+    expect(result.success).toBe(false)
+    expect(result.message).toBe('Backup failed')
+    expect(result.error).toContain('S3 upload failed')
+  })
+})
+
+// ── restoreDatabase ───────────────────────────────────────────────────────────
+
+describe('restoreDatabase', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  // ── Input validation ──────────────────────────────────────────────────────
+
+  it('fails when DATABASE_URL is empty', async () => {
+    const result = await restoreDatabase('', LOCAL_PATH)
+    expect(result.success).toBe(false)
+    expect(result.message).toContain('DATABASE_URL is required')
+  })
+
+  it('fails when DATABASE_URL is not a postgres URL', async () => {
+    const result = await restoreDatabase('redis://localhost/0', LOCAL_PATH)
+    expect(result.success).toBe(false)
+    expect(result.message).toContain('valid PostgreSQL connection string')
+  })
+
+  it('fails when inputPath is empty in local mode', async () => {
+    const result = await restoreDatabase(VALID_URL, '')
+    expect(result.success).toBe(false)
+    expect(result.message).toContain('Input path is required')
+  })
+
+  it('fails when inputPath contains shell metacharacters', async () => {
+    const result = await restoreDatabase(VALID_URL, './dump`whoami`.dump')
+    expect(result.success).toBe(false)
+    expect(result.message).toContain('invalid characters')
+  })
+
+  it('fails when inputPath contains pipe character', async () => {
+    const result = await restoreDatabase(VALID_URL, './dump|cat /etc/passwd')
+    expect(result.success).toBe(false)
+    expect(result.message).toContain('invalid characters')
+  })
+
+  // ── Local file restore ────────────────────────────────────────────────────
+
+  it('calls execFile with pg_restore args and returns success', async () => {
+    mockExecFileSuccess()
+
+    const result = await restoreDatabase(VALID_URL, LOCAL_PATH)
+
+    expect(result.success).toBe(true)
+    expect(result.message).toContain(LOCAL_PATH)
+
+    const mock = childProcess.execFile as unknown as MockInstance
+    expect(mock).toHaveBeenCalledOnce()
+
+    const [cmd, args] = mock.mock.calls[0] as [string, string[]]
+    expect(cmd).toBe('pg_restore')
+    expect(args).toContain('--clean')
+    expect(args).toContain('--no-owner')
+    // URL passed via --dbname=<url>, never as a bare shell string
+    expect(args.some((a: string) => a.startsWith('--dbname='))).toBe(true)
+    expect(args).toContain(LOCAL_PATH)
+  })
+
+  it('returns failure with stderr detail when pg_restore fails', async () => {
+    mockExecFileFailure('pg_restore: error: connection to server failed')
+
+    const result = await restoreDatabase(VALID_URL, LOCAL_PATH)
+
+    expect(result.success).toBe(false)
+    expect(result.message).toBe('Restore failed')
+    expect(result.error).toContain('pg_restore: error: connection to server failed')
+  })
+
+  it('does not expose the DATABASE_URL password in error messages', async () => {
+    mockExecFileFailure('some pg error')
+    const result = await restoreDatabase(VALID_URL, LOCAL_PATH)
+    expect(result.error).not.toContain('pass')
+  })
+
+  // ── S3 streaming restore ──────────────────────────────────────────────────
+
+  it('streams restore from S3 and returns success', async () => {
+    const fakeBody = Readable.from(Buffer.from('fake-dump-data'))
+    const { S3Client } = await import('@aws-sdk/client-s3') as { S3Client: MockInstance }
+    S3Client.mockImplementationOnce(() => ({
+      send: vi.fn().mockResolvedValue({ Body: fakeBody }),
+    }))
+
+    const fakeChild = makeFakeChild(0)
+    ;(childProcess.spawn as unknown as MockInstance).mockReturnValue(fakeChild)
+
+    const result = await restoreDatabase(VALID_URL, '', {
+      bucket: 'my-backups',
+      key: 'fluxora/2026-04-23.dump',
+    })
+
+    expect(result.success).toBe(true)
+    expect(result.message).toContain('s3://my-backups/fluxora/2026-04-23.dump')
+  })
+
+  it('returns failure when S3 object body is empty', async () => {
+    const { S3Client } = await import('@aws-sdk/client-s3') as { S3Client: MockInstance }
+    S3Client.mockImplementationOnce(() => ({
+      send: vi.fn().mockResolvedValue({ Body: null }),
+    }))
+
+    const result = await restoreDatabase(VALID_URL, '', {
+      bucket: 'my-backups',
+      key: 'fluxora/missing.dump',
+    })
+
+    expect(result.success).toBe(false)
+    expect(result.error).toContain('empty body')
+  })
+
+  it('returns failure when pg_restore exits non-zero in S3 mode', async () => {
+    const fakeBody = Readable.from(Buffer.from('fake-dump-data'))
+    const { S3Client } = await import('@aws-sdk/client-s3') as { S3Client: MockInstance }
+    S3Client.mockImplementationOnce(() => ({
+      send: vi.fn().mockResolvedValue({ Body: fakeBody }),
+    }))
+
+    const fakeChild = makeFakeChild(1, 'pg_restore: invalid archive format')
+    ;(childProcess.spawn as unknown as MockInstance).mockReturnValue(fakeChild)
+
+    const result = await restoreDatabase(VALID_URL, '', {
+      bucket: 'my-backups',
+      key: 'fluxora/bad.dump',
+    })
+
+    expect(result.success).toBe(false)
+    expect(result.message).toBe('Restore failed')
+    expect(result.error).toContain('pg_restore: invalid archive format')
+  })
+
+  it('returns failure when S3 GetObject send throws', async () => {
+    const { S3Client } = await import('@aws-sdk/client-s3') as { S3Client: MockInstance }
+    S3Client.mockImplementationOnce(() => ({
+      send: vi.fn().mockRejectedValue(new Error('NoSuchKey: The specified key does not exist')),
+    }))
+
+    const result = await restoreDatabase(VALID_URL, '', {
+      bucket: 'my-backups',
+      key: 'fluxora/nonexistent.dump',
+    })
+
+    expect(result.success).toBe(false)
+    expect(result.message).toBe('Restore failed')
+    expect(result.error).toContain('NoSuchKey')
+  })
+})
+
+// ── DbOperationResult shape ───────────────────────────────────────────────────
+
+describe('DbOperationResult shape', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('success result does not include an error field', async () => {
+    mockExecFileSuccess()
+    const result = await backupDatabase(VALID_URL, LOCAL_PATH)
+    expect(result.success).toBe(true)
+    expect(result).not.toHaveProperty('error')
+  })
+
+  it('failure result always has a non-empty message string', async () => {
+    const result = await backupDatabase('', LOCAL_PATH)
+    expect(result.success).toBe(false)
+    expect(typeof result.message).toBe('string')
+    expect(result.message.length).toBeGreaterThan(0)
+  })
+
+  it('failure result from subprocess includes an error field', async () => {
+    mockExecFileFailure('pg_dump: fatal error')
+    const result = await backupDatabase(VALID_URL, LOCAL_PATH)
+    expect(result.success).toBe(false)
+    expect(result).toHaveProperty('error')
+    expect(typeof result.error).toBe('string')
   })
 })


### PR DESCRIPTION
Closes #140 
Description
Implement the backend work described by the title, using the listed files as the primary touch points. Ensure behavior is observable, tested, and documented.

Requirements and context
Must be secure, tested, and documented
Should be efficient and easy to review
Must preserve decimal-string serialization guarantees for chain/API amount fields
Suggested execution
Fork the repo and create a branch
git checkout -b chore/add-db-backup/restore-tooling-with-optio
Implement changes
Update: src/scripts/db-ops.ts
Update: tests/db-ops.test.ts
Update: README.md
Test and commit
Run tests: pnpm test (or npm test per repo)
Cover edge cases and failure modes; include test output and security notes in PR
Example commit message
chore: add db backup/restore tooling with optional s3 streaming target

Guidelines