### PR TITLE
chore: add startup migration guard  fail fast if migrations pending

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -46,6 +46,23 @@ services:
       - redis
       - full
 
+  # One-shot migration runner — exits 0 on success, non-zero on failure.
+  # The app service depends on this completing successfully.
+  migrate:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    container_name: fluxora-migrate
+    command: ["node", "dist/scripts/run-migrations.js"]
+    environment:
+      DATABASE_URL: postgresql://${POSTGRES_USER:-fluxora}:${POSTGRES_PASSWORD:-fluxora_password}@postgres:5432/${POSTGRES_DB:-fluxora}
+    depends_on:
+      postgres:
+        condition: service_healthy
+    networks:
+      - fluxora-network
+    restart: "no"
+
   # Fluxora Backend Application
   app:
     build:
@@ -83,6 +100,8 @@ services:
     depends_on:
       postgres:
         condition: service_healthy
+      migrate:
+        condition: service_completed_successfully
     healthcheck:
       test: ["CMD", "node", "-e", "fetch('http://127.0.0.1:3000/health').then(r => process.exit(r.ok ? 0 : 1)).catch(() => process.exit(1))"]
       interval: 30s

--- a/src/db/migrate.ts
+++ b/src/db/migrate.ts
@@ -1,18 +1,128 @@
 /**
- * Database migration runner
+ * Database migration runner and startup guard.
  *
  * Uses node-pg-migrate to apply migrations to PostgreSQL.
+ * Provides checkPendingMigrations() for fail-fast startup validation.
  *
  * @module db/migrate
  */
 
 import { runner } from 'node-pg-migrate';
+import fs from 'fs';
+import pg from 'pg';
 import { info, error as logError } from '../utils/logger.js';
 import path from 'path';
 import { fileURLToPath } from 'url';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
+
+const MIGRATIONS_DIR = path.join(__dirname, '../../migrations');
+const MIGRATIONS_TABLE = 'pgmigrations';
+
+/**
+ * Thrown when the database has unapplied migrations at startup.
+ * The server refuses to start until migrations are applied.
+ */
+export class PendingMigrationsError extends Error {
+  constructor(public readonly pending: string[]) {
+    super(
+      `Database has ${pending.length} pending migration(s). ` +
+        `Run migrations before starting the server.\n` +
+        `Pending: ${pending.join(', ')}`,
+    );
+    this.name = 'PendingMigrationsError';
+  }
+}
+
+/**
+ * Derive the migration name that node-pg-migrate stores in pgmigrations
+ * from a filename (strips the file extension).
+ */
+function migrationNameFromFile(filename: string): string {
+  return filename.replace(/\.(js|ts|mjs|cjs)$/, '');
+}
+
+/**
+ * Read migration filenames from disk and return their canonical names.
+ */
+function getMigrationNamesOnDisk(): string[] {
+  if (!fs.existsSync(MIGRATIONS_DIR)) {
+    return [];
+  }
+  return fs
+    .readdirSync(MIGRATIONS_DIR)
+    .filter((f) => /\.(js|ts|mjs|cjs)$/.test(f))
+    .sort()
+    .map(migrationNameFromFile);
+}
+
+/**
+ * Query the pgmigrations table for applied migration names.
+ * Returns an empty array if the table does not yet exist (fresh DB).
+ */
+async function getAppliedMigrationNames(databaseUrl: string): Promise<string[]> {
+  const client = new pg.Client({ connectionString: databaseUrl });
+  await client.connect();
+  try {
+    // Check whether the migrations table exists before querying it.
+    const tableCheck = await client.query<{ exists: boolean }>(
+      `SELECT EXISTS (
+         SELECT 1 FROM information_schema.tables
+         WHERE table_name = $1
+       ) AS exists`,
+      [MIGRATIONS_TABLE],
+    );
+    if (!tableCheck.rows[0]?.exists) {
+      return [];
+    }
+    const result = await client.query<{ name: string }>(
+      `SELECT name FROM ${MIGRATIONS_TABLE} ORDER BY name`,
+    );
+    return result.rows.map((r) => r.name);
+  } finally {
+    await client.end();
+  }
+}
+
+/**
+ * Startup migration guard — fail fast if any migrations are pending.
+ *
+ * Compares migration files on disk against the pgmigrations table.
+ * Throws PendingMigrationsError if unapplied migrations are found so
+ * the server never starts against a stale schema.
+ *
+ * @throws {Error} When DATABASE_URL is not set.
+ * @throws {PendingMigrationsError} When unapplied migrations exist.
+ */
+export async function checkPendingMigrations(): Promise<void> {
+  const databaseUrl = process.env.DATABASE_URL;
+  if (!databaseUrl) {
+    throw new Error('DATABASE_URL environment variable is required');
+  }
+
+  info('Checking for pending migrations...');
+
+  const onDisk = getMigrationNamesOnDisk();
+
+  // No migration files on disk — nothing to check.
+  if (onDisk.length === 0) {
+    info('No migration files found — schema check skipped');
+    return;
+  }
+
+  const applied = await getAppliedMigrationNames(databaseUrl);
+  const appliedSet = new Set(applied);
+  const pending = onDisk.filter((name) => !appliedSet.has(name));
+
+  if (pending.length > 0) {
+    const err = new PendingMigrationsError(pending);
+    logError(err.message);
+    throw err;
+  }
+
+  info(`All ${onDisk.length} migration(s) applied — schema is up to date`);
+}
 
 /**
  * Run all pending migrations
@@ -29,9 +139,9 @@ export async function migrate(): Promise<void> {
 
     await runner({
       databaseUrl,
-      dir: path.join(__dirname, '../../migrations'),
+      dir: MIGRATIONS_DIR,
       direction: 'up',
-      migrationsTable: 'pgmigrations',
+      migrationsTable: MIGRATIONS_TABLE,
       count: Infinity,
       logger: {
         info: (msg: string) => info(msg),

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,7 +13,7 @@ import http from 'node:http';
 import { createApp } from './app.js';
 import { gracefulShutdown, addShutdownHook } from './shutdown.js';
 import { logger } from './lib/logger.js';
-import { initializeMigrations } from './db/migrate.js';
+import { checkPendingMigrations } from './db/migrate.js';
 import { getPool } from './db/pool.js';
 import { createStreamHub, getStreamHub } from './ws/hub.js';
 
@@ -26,8 +26,9 @@ const NODE_ENV = process.env.NODE_ENV || 'development';
 
 async function startServer() {
   try {
-    // Run migrations before starting the server
-    await initializeMigrations();
+    // Guard: fail fast if any migrations are pending.
+    // Migrations must be applied (e.g. via `pnpm migrate`) before starting.
+    await checkPendingMigrations();
 
     const app = createApp();
     const server = http.createServer(app);

--- a/tests/migrate-guard.test.ts
+++ b/tests/migrate-guard.test.ts
@@ -1,0 +1,201 @@
+/**
+ * Tests for checkPendingMigrations (src/db/migrate.ts)
+ *
+ * Covers:
+ *  - Missing DATABASE_URL → throws immediately
+ *  - All migrations applied → resolves
+ *  - No migration files on disk → resolves (short-circuit, no DB call)
+ *  - Migrations directory absent → resolves (short-circuit, no DB call)
+ *  - One or more unapplied migrations → throws PendingMigrationsError
+ *  - PendingMigrationsError carries the pending names list
+ *  - pgmigrations table absent + files on disk → throws PendingMigrationsError
+ *  - DB connection error → propagates
+ *
+ * All fs and pg calls are mocked — no real database or filesystem access.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+// ── fs mock ───────────────────────────────────────────────────────────────────
+// vi.mock is hoisted by vitest so it runs before any imports below.
+
+vi.mock('fs', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('fs')>()
+  const existsSync = vi.fn()
+  const readdirSync = vi.fn()
+  // Patch both named exports and the default export object so that
+  // `import fs from 'fs'` and `import { existsSync } from 'fs'` both see mocks.
+  const patched = { ...actual, existsSync, readdirSync }
+  patched.default = { ...actual.default, existsSync, readdirSync }
+  return patched
+})
+
+// ── pg mock ───────────────────────────────────────────────────────────────────
+// Shared mock handles — the same object is returned by every `new pg.Client()`.
+
+const pgClientMocks = {
+  connect: vi.fn().mockResolvedValue(undefined),
+  end: vi.fn().mockResolvedValue(undefined),
+  query: vi.fn(),
+}
+
+vi.mock('pg', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('pg')>()
+  // Must be a regular function (not arrow) so it can be called with `new`.
+  function MockClient() {
+    return pgClientMocks
+  }
+  return { ...actual, default: { ...actual.default, Client: MockClient } }
+})
+
+// ── Imports (after mocks are registered) ─────────────────────────────────────
+
+import { checkPendingMigrations, PendingMigrationsError } from '../src/db/migrate.js'
+import * as fsModule from 'fs'
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+/** Configure the fs mock to expose a set of migration filenames on disk. */
+function mockMigrationsOnDisk(files: string[]) {
+  ;(fsModule.existsSync as ReturnType<typeof vi.fn>).mockReturnValue(true)
+  ;(fsModule.readdirSync as ReturnType<typeof vi.fn>).mockReturnValue(files)
+}
+
+/**
+ * Configure the pg.Client mock to report a set of applied migration names.
+ * First query: table-existence check → exists: true
+ * Second query: SELECT name FROM pgmigrations
+ */
+function mockAppliedMigrations(names: string[]) {
+  pgClientMocks.query
+    .mockResolvedValueOnce({ rows: [{ exists: true }] })
+    .mockResolvedValueOnce({ rows: names.map((name) => ({ name })) })
+}
+
+/** Configure the pg.Client mock to simulate a missing pgmigrations table. */
+function mockNoMigrationsTable() {
+  pgClientMocks.query.mockResolvedValueOnce({ rows: [{ exists: false }] })
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe('checkPendingMigrations', () => {
+  const ORIGINAL_ENV = process.env.DATABASE_URL
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    pgClientMocks.connect.mockResolvedValue(undefined)
+    pgClientMocks.end.mockResolvedValue(undefined)
+    process.env.DATABASE_URL = 'postgres://user:pass@localhost:5432/fluxora'
+  })
+
+  afterEach(() => {
+    if (ORIGINAL_ENV === undefined) {
+      delete process.env.DATABASE_URL
+    } else {
+      process.env.DATABASE_URL = ORIGINAL_ENV
+    }
+  })
+
+  // ── Missing env var ─────────────────────────────────────────────────────────
+
+  it('throws when DATABASE_URL is not set', async () => {
+    delete process.env.DATABASE_URL
+    await expect(checkPendingMigrations()).rejects.toThrow('DATABASE_URL')
+  })
+
+  // ── All applied ─────────────────────────────────────────────────────────────
+
+  it('resolves when all migrations on disk are applied', async () => {
+    mockMigrationsOnDisk(['001_create_streams.ts', '002_add_audit.ts'])
+    mockAppliedMigrations(['001_create_streams', '002_add_audit'])
+    await expect(checkPendingMigrations()).resolves.toBeUndefined()
+  })
+
+  // ── Short-circuit paths (no DB call) ────────────────────────────────────────
+
+  it('resolves without querying DB when no migration files exist on disk', async () => {
+    mockMigrationsOnDisk([])
+    await expect(checkPendingMigrations()).resolves.toBeUndefined()
+    // pg.Client.connect must not have been called
+    expect(pgClientMocks.connect).not.toHaveBeenCalled()
+  })
+
+  it('resolves without querying DB when migrations directory does not exist', async () => {
+    ;(fsModule.existsSync as ReturnType<typeof vi.fn>).mockReturnValue(false)
+    await expect(checkPendingMigrations()).resolves.toBeUndefined()
+    expect(pgClientMocks.connect).not.toHaveBeenCalled()
+  })
+
+  // ── Pending migrations ──────────────────────────────────────────────────────
+
+  it('throws PendingMigrationsError when one migration is unapplied', async () => {
+    mockMigrationsOnDisk(['001_create_streams.ts', '002_add_audit.ts'])
+    mockAppliedMigrations(['001_create_streams']) // 002 is missing
+
+    await expect(checkPendingMigrations()).rejects.toThrow(PendingMigrationsError)
+  })
+
+  it('PendingMigrationsError.pending lists only the unapplied names', async () => {
+    mockMigrationsOnDisk(['001_create_streams.ts', '002_add_audit.ts'])
+    mockAppliedMigrations(['001_create_streams'])
+
+    let caught: unknown
+    try {
+      await checkPendingMigrations()
+    } catch (err) {
+      caught = err
+    }
+
+    expect(caught).toBeInstanceOf(PendingMigrationsError)
+    const err = caught as PendingMigrationsError
+    expect(err.pending).toEqual(['002_add_audit'])
+    expect(err.message).toContain('002_add_audit')
+    expect(err.message).toContain('1 pending migration')
+  })
+
+  it('PendingMigrationsError.pending includes all unapplied names', async () => {
+    mockMigrationsOnDisk(['001_create_streams.ts', '002_add_audit.ts', '003_webhooks.ts'])
+    mockAppliedMigrations([]) // none applied
+
+    let caught: unknown
+    try {
+      await checkPendingMigrations()
+    } catch (err) {
+      caught = err
+    }
+
+    expect(caught).toBeInstanceOf(PendingMigrationsError)
+    const err = caught as PendingMigrationsError
+    expect(err.pending).toHaveLength(3)
+    expect(err.pending).toContain('001_create_streams')
+    expect(err.pending).toContain('002_add_audit')
+    expect(err.pending).toContain('003_webhooks')
+  })
+
+  // ── Missing pgmigrations table ──────────────────────────────────────────────
+
+  it('throws PendingMigrationsError when pgmigrations table is absent but files exist', async () => {
+    mockMigrationsOnDisk(['001_create_streams.ts'])
+    mockNoMigrationsTable()
+
+    await expect(checkPendingMigrations()).rejects.toThrow(PendingMigrationsError)
+  })
+
+  // ── DB errors ───────────────────────────────────────────────────────────────
+
+  it('propagates DB connection errors', async () => {
+    mockMigrationsOnDisk(['001_create_streams.ts'])
+    pgClientMocks.connect.mockRejectedValueOnce(new Error('ECONNREFUSED'))
+
+    await expect(checkPendingMigrations()).rejects.toThrow('ECONNREFUSED')
+  })
+
+  it('closes the DB client even when a query throws', async () => {
+    mockMigrationsOnDisk(['001_create_streams.ts'])
+    pgClientMocks.query.mockRejectedValueOnce(new Error('query error'))
+
+    await expect(checkPendingMigrations()).rejects.toThrow('query error')
+    expect(pgClientMocks.end).toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
## Summary

Implements a startup migration guard that prevents the server from starting when unapplied database migrations exist. The server now fails fast with a clear error instead of silently auto-running migrations or starting against a stale schema.

## Changes

### \src/db/migrate.ts\
- Added \PendingMigrationsError\  extends \Error\, carries a \pending: string[]\ list of unapplied migration names for structured error handling
- Added \checkPendingMigrations()\  reads migration filenames from disk, queries the \pgmigrations\ table via a short-lived \pg.Client\, computes the diff, and throws \PendingMigrationsError\ if any are unapplied
- Short-circuits with no DB call when there are no migration files on disk
- Handles missing \pgmigrations\ table (fresh DB + files  throws; fresh DB + no files  resolves)
- Existing \migrate()\ / \initializeMigrations()\ are untouched

### \src/index.ts\
- Replaced \initializeMigrations()\ with \checkPendingMigrations()\ in \startServer()\
- Server exits with code 1 if migrations are pending

### \docker-compose.yml\
- Added a \migrate\ one-shot service that runs migrations before the app starts
- \pp\ now declares \depends_on: migrate: condition: service_completed_successfully\

### \	ests/migrate-guard.test.ts\ (new  10 tests)
- Missing \DATABASE_URL\  throws immediately
- All migrations applied  resolves
- No migration files on disk  resolves, no DB call made
- Migrations directory absent  resolves, no DB call made
- One unapplied migration  throws \PendingMigrationsError\
- Multiple unapplied migrations  \pending\ lists all names
- \pgmigrations\ table absent + files on disk  throws \PendingMigrationsError\
- DB connection error  propagates
- Query error  propagates, \pg.Client\ closed in \inally\

## Test output

\\\
Test Files  1 passed (1)
     Tests  10 passed (10)
  Duration  837ms
\\\

## Security notes
- No credentials or connection strings are logged
- \pg.Client\ always closed in a \inally\ block  no connection leaks
- Guard prevents running application code against a stale schema
- Decimal-string serialization for chain/API amount fields is unaffected  no schema or serialization logic was modified

closes #126 