### PR TITLE
Feature/admin endpoint test coverage

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,0 +1,39 @@
+# Fluxora Integration Testing: Admin Routes
+
+This document provides a concise overview of the integration test suites covering the administrative route surface in `src/routes/admin.ts` and the Dead-Letter Queue (DLQ) surface in `src/routes/dlq.ts`.
+
+## Structure
+
+Admin integration tests are divided into isolated vitest suites under `tests/routes/`:
+- `admin.pause.test.ts`: Toggling operational pause flags and read-only status.
+- `admin.reindex.test.ts`: Triggering and checking background reindexing.
+- `admin.apiKeys.test.ts`: Creating, listing, and revoking API keys.
+- `admin.dlq.test.ts`: Standard operator access to the Dead-Letter Queue.
+
+## Authentication Patterns
+
+Administrative and operational endpoints require credentials depending on their mounting context:
+1. **General Admin Endpoints (`/api/admin/*`)**:
+   Protected by `requireAdminAuth`, verifying that a request's `Authorization: Bearer <ADMIN_API_KEY>` matches `process.env.ADMIN_API_KEY`.
+2. **Dead-Letter Queue Endpoints (`/admin/dlq/*`)**:
+   Protected by `authenticate`, `requireAuth`, and `requireOperator`, requiring a valid JWT issued to an address with `role: 'operator'`.
+
+## State Isolation & Resets
+
+To ensure deterministic behavior and prevent test-to-test side effects, in-process state is initialized and purged in `beforeEach`/`afterEach` hooks:
+- **Pause & Reindex State**: Cleared using `_resetForTest()` from `src/state/adminState.ts`.
+- **API Key Records**: Cleared using `_resetApiKeyStoreForTest()` from `src/lib/apiKey.ts`.
+- **DLQ Entries**: Cleared using `_resetDlq()` from `src/routes/dlq.ts`.
+
+## Supertest Integration
+
+All endpoints are tested by running requests against the in-process Express application (`app` from `src/app.js`):
+
+```typescript
+import request from 'supertest';
+import { app } from '../../src/app.js';
+
+const res = await request(app)
+  .get('/api/admin/pause')
+  .set('Authorization', `Bearer \${process.env.ADMIN_API_KEY}`);
+```

--- a/tests/routes/admin.apiKeys.test.ts
+++ b/tests/routes/admin.apiKeys.test.ts
@@ -1,0 +1,141 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import request from 'supertest';
+import { app } from '../../src/app.js';
+import { _resetApiKeyStoreForTest } from '../../src/lib/apiKey.js';
+
+const ADMIN_KEY = 'test-admin-key-for-apikey-routes';
+
+function authed(req: request.Test): request.Test {
+  return req.set('Authorization', `Bearer ${ADMIN_KEY}`);
+}
+
+describe('admin API key routes', () => {
+  let originalKey: string | undefined;
+
+  beforeEach(() => {
+    originalKey = process.env.ADMIN_API_KEY;
+    process.env.ADMIN_API_KEY = ADMIN_KEY;
+    _resetApiKeyStoreForTest();
+  });
+
+  afterEach(() => {
+    if (originalKey !== undefined) {
+      process.env.ADMIN_API_KEY = originalKey;
+    } else {
+      delete process.env.ADMIN_API_KEY;
+    }
+  });
+
+  // 1. unauthorized requests → 401
+  it('rejects unauthenticated GET to API keys list with 401', async () => {
+    const res = await request(app).get('/api/admin/api-keys');
+    expect(res.status).toBe(401);
+  });
+
+  it('rejects unauthenticated POST to create API key with 401', async () => {
+    const res = await request(app).post('/api/admin/api-keys').send({ name: 'test' });
+    expect(res.status).toBe(401);
+  });
+
+  // 2. invalid credentials → 403
+  it('rejects GET with bad credentials to API keys list with 403', async () => {
+    const res = await request(app)
+      .get('/api/admin/api-keys')
+      .set('Authorization', 'Bearer wrong-key');
+    expect(res.status).toBe(403);
+  });
+
+  // 3. authenticated API-key creation
+  it('creates an API key with 201 when authenticated', async () => {
+    const res = await authed(
+      request(app)
+        .post('/api/admin/api-keys')
+        .send({ name: 'service-a' })
+    );
+    expect(res.status).toBe(201);
+    expect(res.body).toHaveProperty('id');
+    expect(res.body.name).toBe('service-a');
+    expect(res.body).toHaveProperty('key'); // Raw key should be returned
+    expect(res.body.key).toMatch(/^flx_/);
+  });
+
+  it('rejects creation when name is missing or invalid with 400', async () => {
+    const res = await authed(
+      request(app)
+        .post('/api/admin/api-keys')
+        .send({})
+    );
+    expect(res.status).toBe(400);
+  });
+
+  // 4. authenticated API-key listing
+  it('lists API keys when authenticated', async () => {
+    // First seed a key
+    await authed(
+      request(app)
+        .post('/api/admin/api-keys')
+        .send({ name: 'service-a' })
+    );
+
+    const res = await authed(request(app).get('/api/admin/api-keys'));
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveProperty('apiKeys');
+    expect(res.body.apiKeys).toHaveLength(1);
+    expect(res.body.apiKeys[0].name).toBe('service-a');
+    expect(res.body.apiKeys[0]).not.toHaveProperty('key'); // Raw key must never be listed
+    expect(res.body.apiKeys[0]).toHaveProperty('keyHash');
+  });
+
+  // 5. authenticated API-key deletion
+  it('revokes an API key with 204 when authenticated', async () => {
+    const createRes = await authed(
+      request(app)
+        .post('/api/admin/api-keys')
+        .send({ name: 'service-a' })
+    );
+    const keyId = createRes.body.id;
+
+    // Delete (revoke) key
+    const deleteRes = await authed(
+      request(app).delete(`/api/admin/api-keys/${keyId}`)
+    );
+    expect(deleteRes.status).toBe(204);
+
+    // Verify it is deactivated in listing
+    const listRes = await authed(request(app).get('/api/admin/api-keys'));
+    expect(listRes.body.apiKeys[0].active).toBe(false);
+  });
+
+  it('returns 404 when revoking non-existent API key', async () => {
+    const res = await authed(
+      request(app).delete('/api/admin/api-keys/does-not-exist')
+    );
+    expect(res.status).toBe(404);
+  });
+
+  // 6. duplicate API-key name handling
+  it('handles duplicate API-key name gracefully', async () => {
+    // Create first key
+    const res1 = await authed(
+      request(app)
+        .post('/api/admin/api-keys')
+        .send({ name: 'service-a' })
+    );
+    expect(res1.status).toBe(201);
+
+    // Create second key with duplicate name
+    const res2 = await authed(
+      request(app)
+        .post('/api/admin/api-keys')
+        .send({ name: 'service-a' })
+    );
+    expect(res2.status).toBe(201);
+    expect(res2.body.id).not.toBe(res1.body.id);
+
+    // Verify both are present in the list
+    const listRes = await authed(request(app).get('/api/admin/api-keys'));
+    expect(listRes.body.apiKeys).toHaveLength(2);
+    expect(listRes.body.apiKeys[0].name).toBe('service-a');
+    expect(listRes.body.apiKeys[1].name).toBe('service-a');
+  });
+});

--- a/tests/routes/admin.dlq.test.ts
+++ b/tests/routes/admin.dlq.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect, beforeEach, beforeAll, afterEach } from 'vitest';
+import request from 'supertest';
+import { app } from '../../src/app.js';
+import { _resetDlq, enqueueDeadLetter } from '../../src/routes/dlq.js';
+import { generateToken } from '../../src/lib/auth.js';
+import { initializeConfig } from '../../src/config/env.js';
+
+let operatorToken: string;
+let viewerToken: string;
+
+beforeAll(() => {
+  process.env.NODE_ENV = 'test';
+  process.env.JWT_SECRET = 'a-very-long-secret-key-for-testing-only-12345';
+  initializeConfig();
+  operatorToken = generateToken({ address: 'GOPERATOR', role: 'operator' });
+  viewerToken = generateToken({ address: 'GVIEWER', role: 'viewer' });
+});
+
+describe('admin DLQ routes', () => {
+  beforeEach(() => {
+    _resetDlq();
+  });
+
+  afterEach(() => {
+    _resetDlq();
+  });
+
+  // 1. Unauthorized Access
+  it('rejects unauthenticated GET to DLQ list with 401', async () => {
+    const res = await request(app).get('/admin/dlq');
+    expect(res.status).toBe(401);
+  });
+
+  // 2. Invalid Credentials
+  it('rejects GET with viewer role to DLQ list with 403', async () => {
+    const res = await request(app)
+      .get('/admin/dlq')
+      .set('Authorization', `Bearer ${viewerToken}`);
+    expect(res.status).toBe(403);
+  });
+
+  // 3. DLQ List Endpoint
+  it('allows authenticated GET to DLQ list with 200 and valid shape', async () => {
+    // Seed one entry
+    enqueueDeadLetter({
+      topic: 'stream.created',
+      payload: { id: 'test-stream' },
+      error: 'timeout error',
+      attempts: 1,
+    });
+
+    const res = await request(app)
+      .get('/admin/dlq')
+      .set('Authorization', `Bearer ${operatorToken}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(res.body.data).toHaveProperty('entries');
+    expect(Array.isArray(res.body.data.entries)).toBe(true);
+    expect(res.body.data.entries).toHaveLength(1);
+    expect(res.body.data.entries[0].topic).toBe('stream.created');
+  });
+
+  // 4. Delete Existing DLQ Entry
+  it('allows authenticated operator to delete DLQ entry with 200', async () => {
+    const entry = enqueueDeadLetter({
+      topic: 'stream.created',
+      payload: {},
+      error: 'some error',
+      attempts: 2,
+    });
+
+    const res = await request(app)
+      .delete(`/admin/dlq/${entry.id}`)
+      .set('Authorization', `Bearer ${operatorToken}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(res.body.data.id).toBe(entry.id);
+  });
+
+  // 5. Delete Non-Existent DLQ Entry
+  it('returns 404 when deleting a non-existent DLQ entry', async () => {
+    const res = await request(app)
+      .delete('/admin/dlq/non-existent-id')
+      .set('Authorization', `Bearer ${operatorToken}`);
+
+    expect(res.status).toBe(404);
+    expect(res.body.success).toBe(false);
+    expect(res.body.error.code).toBe('NOT_FOUND');
+  });
+});

--- a/tests/routes/admin.pause.test.ts
+++ b/tests/routes/admin.pause.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import request from 'supertest';
+import { app } from '../../src/app.js';
+import { _resetForTest } from '../../src/state/adminState.js';
+
+const ADMIN_KEY = 'test-admin-key-for-pause-routes';
+
+function authed(req: request.Test): request.Test {
+  return req.set('Authorization', `Bearer ${ADMIN_KEY}`);
+}
+
+describe('admin pause routes', () => {
+  let originalKey: string | undefined;
+
+  beforeEach(() => {
+    originalKey = process.env.ADMIN_API_KEY;
+    process.env.ADMIN_API_KEY = ADMIN_KEY;
+    _resetForTest();
+  });
+
+  afterEach(() => {
+    if (originalKey !== undefined) {
+      process.env.ADMIN_API_KEY = originalKey;
+    } else {
+      delete process.env.ADMIN_API_KEY;
+    }
+  });
+
+  // 1. Unauthorized request
+  it('rejects unauthenticated requests to pause endpoint with 401', async () => {
+    const res = await request(app).get('/api/admin/pause');
+    expect(res.status).toBe(401);
+  });
+
+  // 2. Forbidden request
+  it('rejects bad credentials to pause endpoint with 403', async () => {
+    const res = await request(app)
+      .get('/api/admin/pause')
+      .set('Authorization', 'Bearer wrong-key');
+    expect(res.status).toBe(403);
+  });
+
+  // 3. Successful GET
+  it('allows authenticated GET to pause endpoint with 200', async () => {
+    const res = await authed(request(app).get('/api/admin/pause'));
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ streamCreation: false, ingestion: false });
+  });
+
+  it('allows unauthenticated GET to read-only status endpoint with 200', async () => {
+    const res = await request(app).get('/api/admin/status/read-only');
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveProperty('pauseFlags');
+  });
+
+  // 4. Successful PUT toggle
+  it('allows authenticated PUT to toggle streamCreation with 200', async () => {
+    const res = await authed(
+      request(app)
+        .put('/api/admin/pause')
+        .send({ streamCreation: true })
+    );
+    expect(res.status).toBe(200);
+    expect(res.body.pauseFlags.streamCreation).toBe(true);
+    expect(res.body.pauseFlags.ingestion).toBe(false);
+  });
+});

--- a/tests/routes/admin.reindex.test.ts
+++ b/tests/routes/admin.reindex.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import request from 'supertest';
+import { app } from '../../src/app.js';
+import { _resetForTest } from '../../src/state/adminState.js';
+
+const ADMIN_KEY = 'test-admin-key-for-reindex-routes';
+
+function authed(req: request.Test): request.Test {
+  return req.set('Authorization', `Bearer ${ADMIN_KEY}`);
+}
+
+describe('admin reindex routes', () => {
+  let originalKey: string | undefined;
+
+  beforeEach(() => {
+    originalKey = process.env.ADMIN_API_KEY;
+    process.env.ADMIN_API_KEY = ADMIN_KEY;
+    _resetForTest();
+  });
+
+  afterEach(() => {
+    if (originalKey !== undefined) {
+      process.env.ADMIN_API_KEY = originalKey;
+    } else {
+      delete process.env.ADMIN_API_KEY;
+    }
+  });
+
+  // 1. Unauthorized Request
+  it('rejects unauthenticated POST to reindex with 401', async () => {
+    const res = await request(app).post('/api/admin/reindex');
+    expect(res.status).toBe(401);
+  });
+
+  // 2. Forbidden Request
+  it('rejects POST to reindex with bad credentials with 403', async () => {
+    const res = await request(app)
+      .post('/api/admin/reindex')
+      .set('Authorization', 'Bearer wrong-key');
+    expect(res.status).toBe(403);
+  });
+
+  // 3. Successful Reindex Trigger
+  it('triggers a reindex operation with 202 when authenticated', async () => {
+    const res = await authed(request(app).post('/api/admin/reindex'));
+    expect(res.status).toBe(202);
+    expect(res.body.message).toBe('Reindex started.');
+    expect(res.body.reindex.status).toBe('running');
+  });
+
+  // 4. Reindex While Pause Active
+  it('allows triggering reindex even when pause flags are active', async () => {
+    // Set pause flags first
+    await authed(
+      request(app)
+        .put('/api/admin/pause')
+        .send({ streamCreation: true, ingestion: true })
+    );
+
+    // Trigger reindex
+    const res = await authed(request(app).post('/api/admin/reindex'));
+    expect(res.status).toBe(202);
+    expect(res.body.reindex.status).toBe('running');
+  });
+});


### PR DESCRIPTION
Adds focused integration coverage for the admin route surface, including:

* pause/read-only endpoints
* API-key lifecycle routes
* DLQ management routes
* reindex operation routes

Also includes:

* authentication and authorization coverage
* edge-case handling for invalid/non-existent resources
* minimal admin testing documentation updates

All tests were validated individually and against the full Vitest suite to ensure no regressions.


Closes #245