### PR TITLE
feat(observability): implement custom business metrics for streams, w…

### DIFF
--- a/docs/observability.md
+++ b/docs/observability.md
@@ -1,0 +1,37 @@
+# Observability Metrics
+
+The application exposes the following Prometheus business metrics at the `/metrics` endpoint.
+
+## Custom Business Metrics
+
+### 1. Stream Creation Rate
+- **Metric Name**: `fluxora_streams_created_total`
+- **Type**: Counter
+- **Labels**:
+  - `status`: The initial status of the created stream (e.g., `active`).
+- **Meaning**: Total number of treasury streams successfully created.
+
+### 2. Webhook Delivery Throughput
+- **Metric Name**: `fluxora_webhook_deliveries_total`
+- **Type**: Counter
+- **Labels**:
+  - `outcome`: The outcome of the webhook dispatch (`success` or `failed`).
+- **Meaning**: Total number of webhook delivery attempts.
+
+### 3. Webhook Delivery Duration
+- **Metric Name**: `fluxora_webhook_delivery_duration_seconds`
+- **Type**: Histogram
+- **Buckets**: `[0.01, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10]`
+- **Meaning**: Latency duration of webhook delivery attempts in seconds.
+
+### 4. Indexer Ingestion Throughput
+- **Metric Name**: `fluxora_indexer_events_ingested_total`
+- **Type**: Counter
+- **Labels**: None
+- **Meaning**: Total number of contract events successfully ingested and persisted by the indexer.
+
+### 5. Indexer Ingestion Lag
+- **Metric Name**: `fluxora_indexer_lag_seconds`
+- **Type**: Gauge
+- **Labels**: None
+- **Meaning**: Ingestion lag of the indexer in seconds, calculated as the difference between current time and the latest ledger event timestamp (`happenedAt`) in the ingested batch.

--- a/src/indexer/service.ts
+++ b/src/indexer/service.ts
@@ -9,6 +9,7 @@ import {
   IngestContractEventsResult,
 } from './types.js';
 import { StreamEventReplayFilter, StreamEventReplayResult } from '../db/types.js';
+import { indexerEventsIngestedTotal, indexerLagSeconds } from '../metrics/businessMetrics.js';
 
 const MAX_EVENTS_PER_BATCH = 100;
 const MAX_EVENT_ID_LENGTH = 128;
@@ -303,6 +304,13 @@ export class IndexerIngestionService {
       this.state.acceptedEventCount += result.insertedEventIds.length;
       this.state.duplicateEventCount += result.duplicateEventIds.length;
       this.state.lastSafeLedger = reportedSafeLedger;
+
+      indexerEventsIngestedTotal.inc(result.insertedEventIds.length);
+      if (events.length > 0) {
+        const maxHappenedAt = Math.max(...events.map(e => Date.parse(e.happenedAt)));
+        const lagSeconds = (Date.now() - maxHappenedAt) / 1000;
+        indexerLagSeconds.set(lagSeconds);
+      }
 
       // Reset reorg detected flag once we are significantly past the reorg height
       if (this.state.reorgDetected && this.state.reorgHeight !== undefined && maxLedgerInBatch > this.state.reorgHeight + 5) {

--- a/src/metrics/businessMetrics.ts
+++ b/src/metrics/businessMetrics.ts
@@ -1,0 +1,54 @@
+import { Counter, Histogram, Gauge } from 'prom-client';
+import { registry } from '../metrics.js';
+
+export const streamsCreatedTotal =
+  (registry.getSingleMetric('fluxora_streams_created_total') as Counter<'status'>) ||
+  new Counter({
+    name: 'fluxora_streams_created_total',
+    help: 'Total number of treasury streams created',
+    labelNames: ['status'] as const,
+    registers: [registry],
+  });
+
+export const webhookDeliveriesTotal =
+  (registry.getSingleMetric('fluxora_webhook_deliveries_total') as Counter<'outcome'>) ||
+  new Counter({
+    name: 'fluxora_webhook_deliveries_total',
+    help: 'Total number of webhook deliveries',
+    labelNames: ['outcome'] as const,
+    registers: [registry],
+  });
+
+export const webhookDeliveryDurationSeconds =
+  (registry.getSingleMetric('fluxora_webhook_delivery_duration_seconds') as Histogram) ||
+  new Histogram({
+    name: 'fluxora_webhook_delivery_duration_seconds',
+    help: 'Duration of webhook delivery attempts in seconds',
+    buckets: [0.01, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10],
+    registers: [registry],
+  });
+
+export const indexerEventsIngestedTotal =
+  (registry.getSingleMetric('fluxora_indexer_events_ingested_total') as Counter) ||
+  new Counter({
+    name: 'fluxora_indexer_events_ingested_total',
+    help: 'Total number of contract events ingested by the indexer',
+    registers: [registry],
+  });
+
+export const indexerLagSeconds =
+  (registry.getSingleMetric('fluxora_indexer_lag_seconds') as Gauge) ||
+  new Gauge({
+    name: 'fluxora_indexer_lag_seconds',
+    help: 'Ingestion lag of the indexer in seconds',
+    registers: [registry],
+  });
+
+/** Clean helper to de-register metrics between test runs. */
+export function deRegisterBusinessMetrics(): void {
+  registry.removeSingleMetric('fluxora_streams_created_total');
+  registry.removeSingleMetric('fluxora_webhook_deliveries_total');
+  registry.removeSingleMetric('fluxora_webhook_delivery_duration_seconds');
+  registry.removeSingleMetric('fluxora_indexer_events_ingested_total');
+  registry.removeSingleMetric('fluxora_indexer_lag_seconds');
+}

--- a/src/routes/streams.ts
+++ b/src/routes/streams.ts
@@ -73,6 +73,7 @@ import {
   formatZodIssues,
 } from '../validation/schemas.js';
 import type { StreamStatus, StreamFilter } from '../db/types.js';
+import { streamsCreatedTotal } from '../metrics/businessMetrics.js';
 
 export const streamsRouter = Router();
 
@@ -522,6 +523,8 @@ streamsRouter.post(
       sender:        normalizedInput.sender,
       recipient:     normalizedInput.recipient,
     });
+
+    streamsCreatedTotal.inc({ status: stream.status });
 
     res.set('Idempotency-Key', idempotencyKey);
     res.set('Idempotency-Replayed', 'false');

--- a/src/webhooks/service.ts
+++ b/src/webhooks/service.ts
@@ -15,8 +15,9 @@ import type {
 } from './types.js';
 import { DEFAULT_RETRY_POLICY } from './types.js';
 import { webhookDeliveryStore } from './store.js';
-import { calculateNextRetryTime, shouldRetry } from './retry.js';
 import { computeWebhookSignature } from './signature.js';
+import { calculateNextRetryTime, shouldRetry } from './retry.js';
+import { webhookDeliveriesTotal, webhookDeliveryDurationSeconds } from '../metrics/businessMetrics.js';
 
 export class WebhookService {
   private policy: WebhookRetryPolicy;
@@ -89,6 +90,7 @@ export class WebhookService {
       timestamp: Date.now(),
     };
 
+    const startTime = Date.now();
     try {
       const response = await this.sendWebhook(
         delivery.endpointUrl,
@@ -111,6 +113,7 @@ export class WebhookService {
           statusCode: response.status,
           attempt: attemptNumber,
         });
+        webhookDeliveriesTotal.inc({ outcome: 'success' });
       } else {
         // Handle non-2xx responses
         if (shouldRetry(attempt, attemptNumber, this.policy)) {
@@ -135,6 +138,7 @@ export class WebhookService {
 
         delivery.attempts.push(attempt);
         webhookDeliveryStore.store(delivery);
+        webhookDeliveriesTotal.inc({ outcome: 'failed' });
       }
     } catch (error) {
       // Network error or timeout
@@ -165,6 +169,10 @@ export class WebhookService {
 
       delivery.attempts.push(attempt);
       webhookDeliveryStore.store(delivery);
+      webhookDeliveriesTotal.inc({ outcome: 'failed' });
+    } finally {
+      const durationSeconds = (Date.now() - startTime) / 1000;
+      webhookDeliveryDurationSeconds.observe(durationSeconds);
     }
   }
 

--- a/tests/metrics/businessMetrics.test.ts
+++ b/tests/metrics/businessMetrics.test.ts
@@ -1,0 +1,199 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import request from 'supertest';
+import { app } from '../../src/app.js';
+import { registry } from '../../src/metrics.js';
+import {
+  streamsCreatedTotal,
+  webhookDeliveriesTotal,
+  webhookDeliveryDurationSeconds,
+  indexerEventsIngestedTotal,
+  indexerLagSeconds,
+  deRegisterBusinessMetrics,
+} from '../../src/metrics/businessMetrics.js';
+import { WebhookService } from '../../src/webhooks/service.js';
+import { IndexerIngestionService } from '../../src/indexer/service.js';
+import { InMemoryContractEventStore } from '../../src/indexer/store.js';
+
+// Setup fresh metrics before each test in this suite
+beforeEach(() => {
+  // Reset existing metrics if they are still registered
+  try {
+    streamsCreatedTotal.reset();
+    webhookDeliveriesTotal.reset();
+    webhookDeliveryDurationSeconds.reset();
+    indexerEventsIngestedTotal.reset();
+    indexerLagSeconds.reset();
+  } catch {
+    // no-op if already de-registered
+  }
+});
+
+describe('Business Metrics Integration', () => {
+  // 1. Webhook Service Delivery Metrics Observation
+  describe('Webhook Service metrics', () => {
+    let originalFetch = global.fetch;
+
+    afterEach(() => {
+      global.fetch = originalFetch;
+    });
+
+    it('records success outcome and latency on 2xx responses', async () => {
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+      } as Response);
+
+      const service = new WebhookService();
+      const delivery = {
+        id: 'deliv-1',
+        deliveryId: 'd1',
+        eventId: 'evt-1',
+        eventType: 'stream.created',
+        endpointUrl: 'http://test-endpoint.local',
+        status: 'pending' as const,
+        attempts: [],
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+        payload: '{}',
+      };
+
+      await service.attemptDelivery(delivery, 'test-secret', '123456');
+
+      // Verify counter
+      const counterVal = await webhookDeliveriesTotal.get();
+      expect(counterVal.values).toHaveLength(1);
+      expect(counterVal.values[0]?.labels).toEqual({ outcome: 'success' });
+      expect(counterVal.values[0]?.value).toBe(1);
+
+      // Verify histogram
+      const histVal = await webhookDeliveryDurationSeconds.get();
+      expect(histVal.values.length).toBeGreaterThan(0);
+    });
+
+    it('records failed outcome on non-2xx responses', async () => {
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: false,
+        status: 500,
+      } as Response);
+
+      const service = new WebhookService({
+        maxAttempts: 1,
+        initialDelayMs: 1,
+        backoffMultiplier: 1.5,
+        timeoutMs: 10,
+      });
+      const delivery = {
+        id: 'deliv-2',
+        deliveryId: 'd2',
+        eventId: 'evt-2',
+        eventType: 'stream.created',
+        endpointUrl: 'http://test-endpoint.local',
+        status: 'pending' as const,
+        attempts: [],
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+        payload: '{}',
+      };
+
+      await service.attemptDelivery(delivery, 'test-secret', '123456');
+
+      // Verify counter
+      const counterVal = await webhookDeliveriesTotal.get();
+      expect(counterVal.values).toHaveLength(1);
+      expect(counterVal.values[0]?.labels).toEqual({ outcome: 'failed' });
+      expect(counterVal.values[0]?.value).toBe(1);
+    });
+
+    it('records failed outcome on network exception', async () => {
+      global.fetch = vi.fn().mockRejectedValue(new Error('Network disconnected'));
+
+      const service = new WebhookService({
+        maxAttempts: 1,
+        initialDelayMs: 1,
+        backoffMultiplier: 1.5,
+        timeoutMs: 10,
+      });
+      const delivery = {
+        id: 'deliv-3',
+        deliveryId: 'd3',
+        eventId: 'evt-3',
+        eventType: 'stream.created',
+        endpointUrl: 'http://test-endpoint.local',
+        status: 'pending' as const,
+        attempts: [],
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+        payload: '{}',
+      };
+
+      await service.attemptDelivery(delivery, 'test-secret', '123456');
+
+      // Verify counter still observed failure
+      const counterVal = await webhookDeliveriesTotal.get();
+      expect(counterVal.values).toHaveLength(1);
+      expect(counterVal.values[0]?.labels).toEqual({ outcome: 'failed' });
+      expect(counterVal.values[0]?.value).toBe(1);
+    });
+  });
+
+  // 2. Indexer Service Metrics Observation
+  describe('Indexer Ingestion Service metrics', () => {
+    it('records ingested count and updates lag seconds gauge', async () => {
+      const store = new InMemoryContractEventStore();
+      const service = new IndexerIngestionService(store);
+
+      const happenedAt = new Date(Date.now() - 10000).toISOString(); // 10s lag
+      const rawEvents = {
+        events: [
+          {
+            eventId: 'evt-idx-1',
+            ledger: 100,
+            contractId: 'C1',
+            topic: 'stream.created',
+            txHash: 'tx1',
+            txIndex: 0,
+            operationIndex: 0,
+            eventIndex: 0,
+            payload: {},
+            happenedAt,
+            ledgerHash: 'hash100',
+          },
+        ],
+      };
+
+      await service.ingest(rawEvents, { actor: 'test-actor' });
+
+      // Verify count counter
+      const countVal = await indexerEventsIngestedTotal.get();
+      expect(countVal.values).toHaveLength(1);
+      expect(countVal.values[0]?.value).toBe(1);
+
+      // Verify lag gauge is set to approx 10s (allow range due to execution time)
+      const lagVal = await indexerLagSeconds.get();
+      expect(lagVal.values).toHaveLength(1);
+      expect(lagVal.values[0]?.value).toBeGreaterThanOrEqual(9.5);
+      expect(lagVal.values[0]?.value).toBeLessThanOrEqual(15);
+    });
+  });
+
+  // 3. Scrape integration
+  it('exposes custom business metrics in /metrics endpoint', async () => {
+    streamsCreatedTotal.inc({ status: 'active' });
+
+    const res = await request(app).get('/metrics');
+    expect(res.status).toBe(200);
+    expect(res.text).toContain('fluxora_streams_created_total');
+    expect(res.text).toContain('status="active"');
+  });
+
+  // 4. Double Registration & De-registration protection
+  it('guards against duplicate registration on multiple loads and supports de-registration', () => {
+    // Attempting to look up or get standard metrics returns the exact instances
+    const streamsMetric = registry.getSingleMetric('fluxora_streams_created_total');
+    expect(streamsMetric).toBe(streamsCreatedTotal);
+
+    // Verify calling deRegister removes them
+    deRegisterBusinessMetrics();
+    expect(registry.getSingleMetric('fluxora_streams_created_total')).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

Adds custom Prometheus business metrics for stream creation, webhook delivery health, and indexer ingestion observability.

## Changes

* Added `src/metrics/businessMetrics.ts` with singleton-safe metric registration using `registry.getSingleMetric(...)`
* Added stream creation metrics instrumentation in `src/routes/streams.ts`
* Added webhook delivery success/failure and latency instrumentation in `src/webhooks/service.ts`
* Added indexer ingestion count and lag instrumentation in `src/indexer/service.ts`
* Added dedicated metric integration tests in `tests/metrics/businessMetrics.test.ts`
* Added concise observability documentation in `docs/observability.md`

## Metrics Added

* `fluxora_streams_created_total`
* `fluxora_webhook_deliveries_total`
* `fluxora_webhook_delivery_duration_seconds`
* `fluxora_indexer_events_ingested_total`
* `fluxora_indexer_lag_seconds`

## Notes

* Instrumentation is strictly passive and does not alter existing runtime flow control
* Metrics are protected against duplicate registration during Vitest runs and repeated module imports
* Full Vitest suite passes successfully after instrumentation changes

Closes #237