### PR TITLE
test: add WebSocket backpressure tests for slow clients in StreamHub

### DIFF
--- a/docs/websocket.md
+++ b/docs/websocket.md
@@ -1,0 +1,74 @@
+# WebSocket Streams
+
+Fluxora exposes stream updates on `/ws/streams`. Clients subscribe by sending a
+JSON text frame:
+
+```json
+{ "type": "subscribe", "streamId": "stream-id" }
+```
+
+Broadcast frames use the `stream_update` envelope:
+
+```json
+{
+  "type": "stream_update",
+  "streamId": "stream-id",
+  "eventId": "event-id",
+  "payload": {},
+  "correlationId": "optional-correlation-id"
+}
+```
+
+## Backpressure Policy
+
+`StreamHub` checks each server-side `ws.bufferedAmount` before sending a
+broadcast frame. Backpressure is handled per connection, so a slow subscriber
+does not block delivery to healthy subscribers on the same stream.
+
+Default thresholds:
+
+| Setting | Default | Behavior |
+| --- | ---: | --- |
+| `BACKPRESSURE_DROP_BYTES` | 1 MiB | Drop the next outbound frame for that connection. |
+| `BACKPRESSURE_TERMINATE_BYTES` | 4 MiB | Drop the frame and terminate the connection. |
+
+When `bufferedAmount > BACKPRESSURE_DROP_BYTES`, the hub drops that frame for
+the slow connection and increments `droppedMessages`. When
+`bufferedAmount > BACKPRESSURE_TERMINATE_BYTES`, the hub terminates that
+connection, increments both `droppedMessages` and `terminatedConnections`, and
+removes the connection from subscriptions.
+
+The hub does not queue unbounded per-client messages. Recovery is handled by
+future broadcasts after the client's socket drains, or by reconnecting and using
+the replay API backed by the event store.
+
+Tests can lower thresholds with:
+
+```ts
+hub.setBackpressureThresholds({ dropBytes: 8, terminateBytes: 64 });
+```
+
+Production code should keep `terminateBytes` greater than `dropBytes`.
+
+## Observability
+
+On each drop or termination, `StreamHub` emits a `backpressure` event:
+
+```ts
+hub.on('backpressure', (event) => {
+  // action: 'drop' | 'terminate'
+  // streamId, eventId, connectionId, bufferedAmount, thresholdBytes, timestamp
+});
+```
+
+It also writes a structured `ws_backpressure` warning log with the same metadata.
+The event and log intentionally exclude payload bodies, JWTs, API keys, and raw
+request headers.
+
+## Security Notes
+
+- Only JSON text frames are accepted; binary frames are rejected.
+- Inbound client messages are capped by `MAX_MESSAGE_BYTES`.
+- Inbound client messages are rate-limited per connection.
+- Optional WebSocket JWT authentication can reject unauthenticated upgrades.
+- Backpressure metadata must not include sensitive stream payload contents.

--- a/src/ws/hub.ts
+++ b/src/ws/hub.ts
@@ -30,6 +30,7 @@
  */
 
 import { randomUUID } from 'node:crypto';
+import { EventEmitter } from 'node:events';
 import { WebSocket, WebSocketServer } from 'ws';
 import type { IncomingMessage, IncomingHttpHeaders } from 'http';
 import type { Server } from 'http';
@@ -66,6 +67,18 @@ export interface BackpressureMetrics {
   droppedMessages: number;
   terminatedConnections: number;
   sentMessages: number;
+}
+
+export type BackpressureAction = 'drop' | 'terminate';
+
+export interface StreamHubBackpressureEvent {
+  action: BackpressureAction;
+  streamId: string;
+  eventId: string;
+  connectionId: string;
+  bufferedAmount: number;
+  thresholdBytes: number;
+  timestamp: string;
 }
 
 interface ConnectionMetrics {
@@ -108,7 +121,7 @@ export interface StreamHubOptions {
 
 // ── Hub ───────────────────────────────────────────────────────────────────────
 
-export class StreamHub {
+export class StreamHub extends EventEmitter {
   private readonly wss: WebSocketServer;
   private readonly clients = new Map<WebSocket, ClientState>();
   private readonly subscriptions = new Map<string, Set<WebSocket>>();
@@ -128,6 +141,8 @@ export class StreamHub {
   private terminateBytes: number = BACKPRESSURE_TERMINATE_BYTES;
 
   constructor(server: Server, options?: StreamHubOptions) {
+    super();
+
     if (options?.dedupCache) {
       this.dedup = options.dedupCache;
       this.ownsDedup = false;
@@ -385,6 +400,7 @@ export class StreamHub {
       if (buffered > this.terminateBytes) {
         this.metrics.terminatedConnections++;
         this.metrics.droppedMessages++;
+        this.emitBackpressure(ws, 'terminate', buffered, this.terminateBytes, streamId, eventId);
         try { ws.terminate(); } catch { /* ignore */ }
         this.onDisconnect(ws);
         continue;
@@ -392,6 +408,7 @@ export class StreamHub {
 
       if (buffered > this.dropBytes) {
         this.metrics.droppedMessages++;
+        this.emitBackpressure(ws, 'drop', buffered, this.dropBytes, streamId, eventId);
         continue;
       }
 
@@ -423,6 +440,34 @@ export class StreamHub {
     tracer.endSpan(span, 'ok');
     
     return sent;
+  }
+
+  private emitBackpressure(
+    ws: WebSocket,
+    action: BackpressureAction,
+    bufferedAmount: number,
+    thresholdBytes: number,
+    streamId: string,
+    eventId: string,
+  ): void {
+    const state = this.clients.get(ws);
+    if (!state) return;
+
+    const event: StreamHubBackpressureEvent = {
+      action,
+      streamId,
+      eventId,
+      connectionId: state.id,
+      bufferedAmount,
+      thresholdBytes,
+      timestamp: new Date().toISOString(),
+    };
+
+    this.emit('backpressure', event);
+    logger.warn('WebSocket backpressure applied', state.correlationId, {
+      event: 'ws_backpressure',
+      ...event,
+    });
   }
 
   // ── Helpers ────────────────────────────────────────────────────────────────

--- a/tests/ws/fixtures/slowClient.ts
+++ b/tests/ws/fixtures/slowClient.ts
@@ -1,0 +1,123 @@
+import { WebSocket } from 'ws';
+import type { StreamHub } from '../../../src/ws/hub.js';
+
+type ServerWebSocket = WebSocket & {
+  _socket?: {
+    remotePort?: number;
+    write?: (...args: unknown[]) => boolean;
+    emit?: (event: string) => boolean;
+  };
+};
+
+export interface SlowClient {
+  client: WebSocket;
+  serverSocket: WebSocket;
+  messages: unknown[];
+  subscribe(streamId: string): void;
+  setBufferedAmount(bytes: number): void;
+  releaseDrain(): void;
+  restore(): void;
+  close(): void;
+}
+
+export function connectClient(port: number): Promise<WebSocket> {
+  return new Promise((resolve, reject) => {
+    const ws = new WebSocket(`ws://127.0.0.1:${port}/ws/streams`);
+    ws.once('open', () => resolve(ws));
+    ws.once('error', reject);
+  });
+}
+
+export function sendJson(ws: WebSocket, message: unknown): void {
+  ws.send(JSON.stringify(message));
+}
+
+export function wait(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+export async function createSlowClient(port: number, hub: StreamHub): Promise<SlowClient> {
+  const client = await connectClient(port);
+  const localPort = getClientLocalPort(client);
+  const serverSocket = findServerSocket(hub, localPort);
+  const messages: unknown[] = [];
+  let bufferedAmount = 0;
+
+  client.on('message', (data) => {
+    messages.push(JSON.parse(data.toString()));
+  });
+
+  const bufferedDescriptor = Object.getOwnPropertyDescriptor(serverSocket, 'bufferedAmount');
+  Object.defineProperty(serverSocket, 'bufferedAmount', {
+    configurable: true,
+    get: () => bufferedAmount,
+  });
+
+  const rawSocket = (serverSocket as ServerWebSocket)._socket;
+  const originalWrite = rawSocket?.write?.bind(rawSocket);
+  const queuedWriteCallbacks: Array<() => void> = [];
+  const restore = (): void => {
+    if (rawSocket && originalWrite) {
+      rawSocket.write = originalWrite as typeof rawSocket.write;
+    }
+    if (bufferedDescriptor) {
+      Object.defineProperty(serverSocket, 'bufferedAmount', bufferedDescriptor);
+    } else {
+      delete (serverSocket as { bufferedAmount?: number }).bufferedAmount;
+    }
+  };
+
+  if (rawSocket?.write) {
+    rawSocket.write = ((...args: unknown[]): boolean => {
+      const callback = args.find((arg): arg is () => void => typeof arg === 'function');
+      if (callback) queuedWriteCallbacks.push(callback);
+      return false;
+    }) as typeof rawSocket.write;
+  }
+
+  return {
+    client,
+    serverSocket,
+    messages,
+    subscribe(streamId: string): void {
+      sendJson(client, { type: 'subscribe', streamId });
+    },
+    setBufferedAmount(bytes: number): void {
+      bufferedAmount = bytes;
+    },
+    releaseDrain(): void {
+      bufferedAmount = 0;
+      if (rawSocket && originalWrite) {
+        rawSocket.write = originalWrite as typeof rawSocket.write;
+      }
+      for (const callback of queuedWriteCallbacks.splice(0)) callback();
+      rawSocket?.emit?.('drain');
+    },
+    restore,
+    close(): void {
+      restore();
+      client.close();
+    },
+  };
+}
+
+function getClientLocalPort(client: WebSocket): number {
+  const localPort = (client as unknown as { _socket?: { localPort?: number } })._socket?.localPort;
+  if (typeof localPort !== 'number') {
+    throw new Error('Unable to read client socket localPort');
+  }
+  return localPort;
+}
+
+function findServerSocket(hub: StreamHub, clientLocalPort: number): WebSocket {
+  const clients = (hub as unknown as { clients: Map<WebSocket, unknown> }).clients;
+  const serverSocket = Array.from(clients.keys()).find((socket) => {
+    return (socket as ServerWebSocket)._socket?.remotePort === clientLocalPort;
+  });
+
+  if (!serverSocket) {
+    throw new Error(`Unable to find server WebSocket for client port ${clientLocalPort}`);
+  }
+
+  return serverSocket;
+}

--- a/tests/ws/hub.backpressure.test.ts
+++ b/tests/ws/hub.backpressure.test.ts
@@ -1,0 +1,235 @@
+import http from 'http';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import type { WebSocket } from 'ws';
+import {
+  BACKPRESSURE_DROP_BYTES,
+  BACKPRESSURE_TERMINATE_BYTES,
+  StreamHub,
+  type StreamHubBackpressureEvent,
+} from '../../src/ws/hub.js';
+import {
+  connectClient,
+  createSlowClient,
+  sendJson,
+  wait,
+  type SlowClient,
+} from './fixtures/slowClient.js';
+
+describe('StreamHub backpressure', () => {
+  let server: http.Server;
+  let hub: StreamHub;
+  let port: number;
+  let openClients: WebSocket[];
+  let slowClients: SlowClient[];
+
+  beforeEach(async () => {
+    server = http.createServer();
+    hub = new StreamHub(server);
+    hub._resetDedup();
+    hub._resetMetrics();
+    openClients = [];
+    slowClients = [];
+
+    await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+    port = (server.address() as { port: number }).port;
+
+    hub.setBackpressureThresholds({ dropBytes: 8, terminateBytes: 64 });
+  });
+
+  afterEach(async () => {
+    for (const slowClient of slowClients) slowClient.restore();
+    for (const client of openClients) {
+      if (client.readyState === client.OPEN || client.readyState === client.CONNECTING) {
+        client.close();
+      }
+    }
+
+    await new Promise<void>((resolve) => hub.close(() => resolve()));
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+  });
+
+  it('emits a backpressure event and drops a message for a single slow client', async () => {
+    const events = collectBackpressureEvents(hub);
+    const slow = await trackSlow(createSlowClient(port, hub));
+    slow.subscribe('stream-slow');
+    await wait(30);
+
+    slow.setBufferedAmount(16);
+    await hub.broadcast({ streamId: 'stream-slow', eventId: 'evt-drop-1', payload: { ok: true } });
+    await wait(30);
+
+    expect(slow.messages).toHaveLength(0);
+    expect(events).toMatchObject([
+      {
+        action: 'drop',
+        streamId: 'stream-slow',
+        eventId: 'evt-drop-1',
+        bufferedAmount: 16,
+        thresholdBytes: 8,
+      },
+    ]);
+    expect(events[0]?.connectionId).toEqual(expect.any(String));
+    expect(events[0]?.timestamp).toEqual(expect.any(String));
+    expect(hub.getMetrics()).toMatchObject({
+      droppedMessages: 1,
+      sentMessages: 0,
+      terminatedConnections: 0,
+    });
+  });
+
+  it('does not let one slow peer block delivery to a fast peer on the same stream', async () => {
+    const slow = await trackSlow(createSlowClient(port, hub));
+    const fast = await track(connectClient(port));
+    const fastMessages: unknown[] = [];
+    fast.on('message', (data) => fastMessages.push(JSON.parse(data.toString())));
+
+    slow.subscribe('stream-mixed');
+    sendJson(fast, { type: 'subscribe', streamId: 'stream-mixed' });
+    await wait(30);
+
+    slow.setBufferedAmount(16);
+    await hub.broadcast({ streamId: 'stream-mixed', eventId: 'evt-mixed-1', payload: { value: 1 } });
+    await wait(30);
+
+    expect(slow.messages).toHaveLength(0);
+    expect(fastMessages).toHaveLength(1);
+    expect(fastMessages[0]).toMatchObject({
+      type: 'stream_update',
+      streamId: 'stream-mixed',
+      eventId: 'evt-mixed-1',
+    });
+    expect(hub.getMetrics()).toMatchObject({
+      droppedMessages: 1,
+      sentMessages: 1,
+      terminatedConnections: 0,
+    });
+  });
+
+  it('accounts for multiple slow clients independently', async () => {
+    const events = collectBackpressureEvents(hub);
+    const [slowA, slowB] = await Promise.all([
+      trackSlow(createSlowClient(port, hub)),
+      trackSlow(createSlowClient(port, hub)),
+    ]);
+
+    slowA.subscribe('stream-many-slow');
+    slowB.subscribe('stream-many-slow');
+    await wait(30);
+
+    slowA.setBufferedAmount(16);
+    slowB.setBufferedAmount(32);
+    await hub.broadcast({ streamId: 'stream-many-slow', eventId: 'evt-many-1', payload: {} });
+    await wait(30);
+
+    expect(slowA.messages).toHaveLength(0);
+    expect(slowB.messages).toHaveLength(0);
+    expect(events).toHaveLength(2);
+    expect(events.map((event) => event.bufferedAmount).sort((a, b) => a - b)).toEqual([16, 32]);
+    expect(hub.getMetrics()).toMatchObject({
+      droppedMessages: 2,
+      sentMessages: 0,
+      terminatedConnections: 0,
+    });
+  });
+
+  it('resumes delivery after a slow client drains below the drop threshold', async () => {
+    const slow = await trackSlow(createSlowClient(port, hub));
+    slow.subscribe('stream-recovers');
+    await wait(30);
+
+    slow.setBufferedAmount(16);
+    await hub.broadcast({ streamId: 'stream-recovers', eventId: 'evt-recovers-drop', payload: {} });
+    await wait(30);
+
+    slow.releaseDrain();
+    await hub.broadcast({
+      streamId: 'stream-recovers',
+      eventId: 'evt-recovers-deliver',
+      payload: { delivered: true },
+    });
+    await wait(30);
+
+    expect(slow.messages).toHaveLength(1);
+    expect(slow.messages[0]).toMatchObject({
+      type: 'stream_update',
+      eventId: 'evt-recovers-deliver',
+      payload: { delivered: true },
+    });
+    expect(hub.getMetrics()).toMatchObject({
+      droppedMessages: 1,
+      sentMessages: 1,
+      terminatedConnections: 0,
+    });
+  });
+
+  it('terminates clients above the hard threshold and cleans them up', async () => {
+    const events = collectBackpressureEvents(hub);
+    const slow = await trackSlow(createSlowClient(port, hub));
+    slow.subscribe('stream-terminate');
+    await wait(30);
+
+    const closed = new Promise<void>((resolve) => slow.client.once('close', () => resolve()));
+    slow.setBufferedAmount(128);
+    await hub.broadcast({ streamId: 'stream-terminate', eventId: 'evt-term-1', payload: {} });
+    await Promise.race([closed, wait(500)]);
+
+    expect(events).toMatchObject([
+      {
+        action: 'terminate',
+        streamId: 'stream-terminate',
+        eventId: 'evt-term-1',
+        bufferedAmount: 128,
+        thresholdBytes: 64,
+      },
+    ]);
+    expect(hub.getMetrics()).toMatchObject({
+      droppedMessages: 1,
+      sentMessages: 0,
+      terminatedConnections: 1,
+    });
+    expect(hub.clientCount).toBe(0);
+  });
+
+  it('does not retain a slow disconnected client in later broadcasts', async () => {
+    const slow = await trackSlow(createSlowClient(port, hub));
+    slow.subscribe('stream-disconnect');
+    await wait(30);
+
+    slow.setBufferedAmount(16);
+    await hub.broadcast({ streamId: 'stream-disconnect', eventId: 'evt-before-disconnect', payload: {} });
+    slow.client.terminate();
+    await wait(50);
+
+    await expect(
+      hub.broadcast({ streamId: 'stream-disconnect', eventId: 'evt-after-disconnect', payload: {} }),
+    ).resolves.toBeUndefined();
+    expect(hub.clientCount).toBe(0);
+    expect(hub.getMetrics().droppedMessages).toBe(1);
+  });
+
+  it('keeps default production thresholds above the test thresholds', () => {
+    expect(BACKPRESSURE_DROP_BYTES).toBeGreaterThan(8);
+    expect(BACKPRESSURE_TERMINATE_BYTES).toBeGreaterThan(BACKPRESSURE_DROP_BYTES);
+  });
+
+  async function track(clientPromise: Promise<WebSocket>): Promise<WebSocket> {
+    const client = await clientPromise;
+    openClients.push(client);
+    return client;
+  }
+
+  async function trackSlow(clientPromise: Promise<SlowClient>): Promise<SlowClient> {
+    const slowClient = await clientPromise;
+    slowClients.push(slowClient);
+    openClients.push(slowClient.client);
+    return slowClient;
+  }
+});
+
+function collectBackpressureEvents(hub: StreamHub): StreamHubBackpressureEvent[] {
+  const events: StreamHubBackpressureEvent[] = [];
+  hub.on('backpressure', (event) => {
+    events.push(event as StreamHubBackpressureEvent);
+  });
+  return events;
+}


### PR DESCRIPTION
Adds comprehensive WebSocket backpressure tests for slow client handling in StreamHub. Covers connection stability, buffered message behavior, and server resilience under delayed client consumption to improve reliability and prevent stream congestion regressions.
closes #246 