### PR TITLE
feat: implement live webhook outbox dispatcher with at-least-once delivery

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -65,6 +65,8 @@ METRICS_ENABLED=true
 # =============================================================================
 WEBHOOK_URL=
 WEBHOOK_SECRET=
+WEBHOOK_POLL_INTERVAL_MS=10000
+WEBHOOK_BATCH_SIZE=10
 
 # Database configuration
 DATABASE_URL=postgresql://user:password@localhost:5432/fluxora

--- a/docs/webhooks.md
+++ b/docs/webhooks.md
@@ -1,0 +1,38 @@
+# Webhooks
+
+## Outbox dispatcher
+
+Stream writes enqueue rows in `webhook_outbox` inside the same database transaction as the stream update. The live dispatcher in `src/webhooks/service.ts` polls that table and sends each event to the configured consumer endpoint.
+
+Required configuration:
+
+- `WEBHOOK_URL`: HTTPS endpoint that receives webhook `POST` requests.
+- `WEBHOOK_SECRET`: HMAC signing secret used for `x-fluxora-signature`.
+- `WEBHOOK_POLL_INTERVAL_MS`: polling interval in milliseconds. Defaults to `10000`.
+- `WEBHOOK_BATCH_SIZE`: rows claimed per poll. Defaults to `10`.
+
+The service startup path starts the dispatcher after migrations are checked. Shutdown registers the dispatcher as a drainable service, so SIGTERM/SIGINT stops future polls and waits for the in-flight batch before closing database connections.
+
+## Delivery guarantees
+
+The dispatcher claims rows with:
+
+```sql
+SELECT ...
+FROM webhook_outbox
+WHERE processed = false
+  AND created_at <= NOW()
+ORDER BY created_at ASC, id ASC
+LIMIT $1
+FOR UPDATE SKIP LOCKED
+```
+
+`FOR UPDATE SKIP LOCKED` lets multiple API instances run dispatchers concurrently without claiming the same row at the same time. A row is marked `processed = true` only after the HTTP attempt is complete. If the process exits before commit, PostgreSQL releases the lock and the row remains unprocessed for another worker to deliver, which provides at-least-once delivery.
+
+Failed retryable deliveries are delegated to `src/webhooks/retry.ts`. The original row is marked processed and a new unprocessed row is inserted with `created_at` set to the next retry time. The dispatcher only claims rows whose `created_at` is due, so retries remain durable in PostgreSQL without holding process memory.
+
+## Security notes
+
+Webhook requests are signed with the configured secret and include delivery metadata headers. Production endpoints must use HTTPS unless they target loopback for local deployments. URLs with embedded credentials are rejected.
+
+Consumers must treat webhook delivery as at-least-once: verify the signature, deduplicate by `x-fluxora-delivery-id`, and make handlers idempotent.

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,11 +11,12 @@
 
 import http from 'node:http';
 import { createApp } from './app.js';
-import { gracefulShutdown, addShutdownHook } from './shutdown.js';
+import { gracefulShutdown, addShutdownHook, addDrainableShutdownHook } from './shutdown.js';
 import { logger } from './lib/logger.js';
 import { checkPendingMigrations } from './db/migrate.js';
 import { getPool } from './db/pool.js';
 import { createStreamHub, getStreamHub } from './ws/hub.js';
+import { webhookDispatcher } from './webhooks/service.js';
 
 // Export a pre-built app instance for use in tests and other consumers.
 export { app } from './app.js';
@@ -38,6 +39,9 @@ async function startServer() {
     logger.info('WebSocket hub initialized', undefined, { path: '/ws/streams' });
 
     // Register shutdown hooks
+    webhookDispatcher.start();
+    addDrainableShutdownHook(webhookDispatcher);
+
     addShutdownHook(async () => {
       logger.info('Closing database connections...');
       const pool = getPool();

--- a/src/shutdown.ts
+++ b/src/shutdown.ts
@@ -24,6 +24,10 @@ import { logger } from './lib/logger.js';
 let shuttingDown = false;
 const hooks: Array<() => Promise<void> | void> = [];
 
+export interface DrainableService {
+  stop(): Promise<void> | void;
+}
+
 /**
  * Returns true if a graceful shutdown is currently in progress.
  */
@@ -37,6 +41,14 @@ export function isShuttingDown(): boolean {
  */
 export function addShutdownHook(fn: () => Promise<void> | void): void {
   hooks.push(fn);
+}
+
+/**
+ * Register a service that must stop accepting new work and drain in-flight
+ * operations during graceful shutdown.
+ */
+export function addDrainableShutdownHook(service: DrainableService): void {
+  addShutdownHook(() => service.stop());
 }
 
 /**

--- a/src/webhooks/retry.ts
+++ b/src/webhooks/retry.ts
@@ -23,6 +23,22 @@ export interface RetrySchedule {
   retryAt: number;
 }
 
+export interface WebhookOutboxRetryInput {
+  streamId: string;
+  eventType: string;
+  payload: unknown;
+  attemptNumber: number;
+  policy?: EnhancedRetryPolicy;
+  now?: number;
+}
+
+export interface WebhookOutboxRetryPlan {
+  shouldRetry: boolean;
+  attemptNumber: number;
+  retryAt: Date | null;
+  payload: unknown;
+}
+
 /**
  * Calculate backoff delay based on strategy and algorithm
  */
@@ -94,6 +110,49 @@ export function calculateNextRetryTime(
   const jitteredDelay = applyJitter(baseDelay, policy);
   
   return now + jitteredDelay;
+}
+
+/**
+ * Build the durable retry row data for a failed webhook_outbox delivery.
+ *
+ * The outbox table does not have dedicated retry columns, so retries are
+ * represented as a new unprocessed row with created_at set to the next due
+ * time. The dispatcher only claims rows whose created_at is in the past.
+ */
+export function scheduleWebhookOutboxRetry(
+  input: WebhookOutboxRetryInput,
+): WebhookOutboxRetryPlan {
+  const policy = input.policy ?? DEFAULT_RETRY_POLICY;
+  const nextAttemptNumber = input.attemptNumber + 1;
+
+  if (input.attemptNumber >= policy.maxAttempts) {
+    return {
+      shouldRetry: false,
+      attemptNumber: input.attemptNumber,
+      retryAt: null,
+      payload: input.payload,
+    };
+  }
+
+  const now = input.now ?? Date.now();
+  const retryAt = new Date(calculateNextRetryTime(input.attemptNumber, policy, now));
+  const sourcePayload =
+    typeof input.payload === 'object' && input.payload !== null
+      ? input.payload as Record<string, unknown>
+      : { data: input.payload };
+
+  return {
+    shouldRetry: true,
+    attemptNumber: nextAttemptNumber,
+    retryAt,
+    payload: {
+      ...sourcePayload,
+      _webhookRetry: {
+        attemptNumber: nextAttemptNumber,
+        previousAttemptAt: new Date(now).toISOString(),
+      },
+    },
+  };
 }
 
 /**

--- a/src/webhooks/service.ts
+++ b/src/webhooks/service.ts
@@ -7,6 +7,7 @@ import { randomUUID } from 'node:crypto';
 import { logger } from '../lib/logger.js';
 import { CORRELATION_ID_HEADER } from '../middleware/correlationId.js';
 import { getCorrelationId } from '../tracing/middleware.js';
+import { getPool } from '../db/pool.js';
 import type {
   WebhookEvent,
   WebhookDelivery,
@@ -15,8 +16,91 @@ import type {
 } from './types.js';
 import { DEFAULT_RETRY_POLICY } from './types.js';
 import { webhookDeliveryStore } from './store.js';
-import { calculateNextRetryTime, shouldRetry } from './retry.js';
+import {
+  calculateNextRetryTime,
+  scheduleWebhookOutboxRetry,
+  shouldRetry,
+} from './retry.js';
 import { computeWebhookSignature } from './signature.js';
+
+interface OutboxRow {
+  id: string;
+  stream_id: string;
+  event_type: string;
+  payload: unknown;
+  created_at: Date | string;
+}
+
+interface DbClient {
+  query<T = unknown>(sql: string, params?: unknown[]): Promise<{ rows: T[] }>;
+  release(): void;
+}
+
+interface DbPool {
+  connect(): Promise<DbClient>;
+}
+
+export interface WebhookDispatcherOptions {
+  endpointUrl?: string;
+  secret?: string;
+  pollIntervalMs?: number;
+  batchSize?: number;
+  pool?: DbPool;
+  policy?: WebhookRetryPolicy;
+}
+
+interface ResolvedEndpoint {
+  endpointUrl: string;
+  secret: string;
+}
+
+function parsePositiveInteger(value: string | undefined, fallback: number): number {
+  if (!value) return fallback;
+  const parsed = Number.parseInt(value, 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+function isLoopbackHostname(hostname: string): boolean {
+  return hostname === 'localhost' || hostname === '127.0.0.1' || hostname === '::1';
+}
+
+function assertSafeWebhookEndpoint(endpointUrl: string): void {
+  const url = new URL(endpointUrl);
+
+  if (url.username || url.password) {
+    throw new Error('Webhook endpoint must not include credentials');
+  }
+
+  if (url.protocol !== 'https:' && url.protocol !== 'http:') {
+    throw new Error('Webhook endpoint must use http or https');
+  }
+
+  if (process.env.NODE_ENV === 'production' && url.protocol !== 'https:' && !isLoopbackHostname(url.hostname)) {
+    throw new Error('Webhook endpoint must use https in production');
+  }
+}
+
+function normalizePayload(payload: unknown): unknown {
+  if (typeof payload === 'string') {
+    try {
+      return JSON.parse(payload);
+    } catch {
+      return payload;
+    }
+  }
+
+  return payload;
+}
+
+function extractAttemptNumber(payload: unknown): number {
+  if (typeof payload !== 'object' || payload === null) return 1;
+  const retry = (payload as Record<string, unknown>)['_webhookRetry'];
+  if (typeof retry !== 'object' || retry === null) return 1;
+  const attemptNumber = (retry as Record<string, unknown>)['attemptNumber'];
+  return typeof attemptNumber === 'number' && Number.isFinite(attemptNumber) && attemptNumber > 0
+    ? Math.floor(attemptNumber)
+    : 1;
+}
 
 export class WebhookService {
   private policy: WebhookRetryPolicy;
@@ -94,6 +178,7 @@ export class WebhookService {
         delivery.endpointUrl,
         delivery.payload,
         delivery.deliveryId,
+        delivery.eventType,
         ts,
         signature,
         correlationId,
@@ -175,6 +260,7 @@ export class WebhookService {
     url: string,
     payload: string,
     deliveryId: string,
+    eventType: string,
     timestamp: string,
     signature: string,
     correlationId?: string,
@@ -188,7 +274,7 @@ export class WebhookService {
         'x-fluxora-delivery-id': deliveryId,
         'x-fluxora-timestamp': timestamp,
         'x-fluxora-signature': signature,
-        'x-fluxora-event': 'webhook.event',
+        'x-fluxora-event': eventType,
       };
 
       if (correlationId && correlationId !== 'unknown') {
@@ -252,4 +338,189 @@ export class WebhookService {
   }
 }
 
+/**
+ * Polls PostgreSQL webhook_outbox rows and delivers them to the configured
+ * consumer endpoint. Rows stay locked until their HTTP delivery transaction
+ * commits, so concurrent workers use FOR UPDATE SKIP LOCKED without sending
+ * the same row at the same time.
+ */
+export class WebhookDispatcher {
+  private readonly endpointUrl?: string;
+  private readonly secret?: string;
+  private readonly pollIntervalMs: number;
+  private readonly batchSize: number;
+  private readonly pool: DbPool;
+  private readonly policy: WebhookRetryPolicy;
+  private readonly service: WebhookService;
+  private timer: NodeJS.Timeout | null = null;
+  private stopped = true;
+  private inFlight: Promise<void> | null = null;
+
+  constructor(options: WebhookDispatcherOptions = {}) {
+    this.endpointUrl = options.endpointUrl ?? process.env.WEBHOOK_URL;
+    this.secret = options.secret ?? process.env.WEBHOOK_SECRET;
+    this.pollIntervalMs =
+      options.pollIntervalMs ?? parsePositiveInteger(process.env.WEBHOOK_POLL_INTERVAL_MS, 10_000);
+    this.batchSize = options.batchSize ?? parsePositiveInteger(process.env.WEBHOOK_BATCH_SIZE, 10);
+    this.pool = options.pool ?? (getPool() as unknown as DbPool);
+    this.policy = options.policy ?? DEFAULT_RETRY_POLICY;
+    this.service = new WebhookService(this.policy);
+  }
+
+  start(): void {
+    if (!this.stopped) return;
+
+    if (!this.endpointUrl || !this.secret) {
+      logger.warn('Webhook outbox dispatcher disabled; WEBHOOK_URL and WEBHOOK_SECRET are required');
+      return;
+    }
+
+    assertSafeWebhookEndpoint(this.endpointUrl);
+    this.stopped = false;
+    this.timer = setInterval(() => {
+      void this.pollOnce();
+    }, this.pollIntervalMs);
+    if (typeof this.timer.unref === 'function') this.timer.unref();
+
+    void this.pollOnce();
+    logger.info('Webhook outbox dispatcher started', undefined, {
+      pollIntervalMs: this.pollIntervalMs,
+      batchSize: this.batchSize,
+    });
+  }
+
+  async stop(): Promise<void> {
+    this.stopped = true;
+    if (this.timer) {
+      clearInterval(this.timer);
+      this.timer = null;
+    }
+
+    await this.inFlight;
+    logger.info('Webhook outbox dispatcher stopped');
+  }
+
+  async pollOnce(): Promise<void> {
+    if (this.inFlight) return this.inFlight;
+
+    this.inFlight = this.processBatch().finally(() => {
+      this.inFlight = null;
+    });
+
+    return this.inFlight;
+  }
+
+  private resolveEndpoint(row: OutboxRow): ResolvedEndpoint | null {
+    if (!this.endpointUrl || !this.secret) return null;
+
+    const payload = normalizePayload(row.payload);
+    const payloadObject = typeof payload === 'object' && payload !== null
+      ? payload as Record<string, unknown>
+      : {};
+    const endpointUrl =
+      typeof payloadObject['endpointUrl'] === 'string' ? payloadObject['endpointUrl'] : this.endpointUrl;
+    const secret =
+      typeof payloadObject['secret'] === 'string' ? payloadObject['secret'] : this.secret;
+
+    assertSafeWebhookEndpoint(endpointUrl);
+    return { endpointUrl, secret };
+  }
+
+  private async processBatch(): Promise<void> {
+    const endpoint = this.endpointUrl && this.secret;
+    if (!endpoint) return;
+
+    const client = await this.pool.connect();
+
+    try {
+      await client.query('BEGIN');
+      const result = await client.query<OutboxRow>(
+        `
+          SELECT id, stream_id, event_type, payload, created_at
+          FROM webhook_outbox
+          WHERE processed = false
+            AND created_at <= NOW()
+          ORDER BY created_at ASC, id ASC
+          LIMIT $1
+          FOR UPDATE SKIP LOCKED
+        `,
+        [this.batchSize],
+      );
+
+      if (result.rows.length === 0) {
+        await client.query('COMMIT');
+        return;
+      }
+
+      for (const row of result.rows) {
+        await this.deliverRow(client, row);
+      }
+
+      await client.query('COMMIT');
+    } catch (error) {
+      await client.query('ROLLBACK').catch(() => undefined);
+      logger.error('Webhook outbox dispatcher batch failed', undefined, {
+        error: error instanceof Error ? error.message : String(error),
+      });
+    } finally {
+      client.release();
+    }
+  }
+
+  private async deliverRow(client: DbClient, row: OutboxRow): Promise<void> {
+    const endpoint = this.resolveEndpoint(row);
+    if (!endpoint) {
+      logger.warn('Webhook outbox row skipped; no endpoint configured', undefined, { outboxId: row.id });
+      return;
+    }
+
+    const payload = normalizePayload(row.payload);
+    const payloadString = JSON.stringify(payload);
+    const attemptNumber = extractAttemptNumber(payload);
+    const delivery: WebhookDelivery = {
+      id: `outbox_${row.id}`,
+      deliveryId: `outbox_${row.id}`,
+      eventId: row.stream_id,
+      eventType: row.event_type as WebhookEvent['type'],
+      endpointUrl: endpoint.endpointUrl,
+      status: 'pending',
+      attempts: Array.from({ length: Math.max(0, attemptNumber - 1) }, (_, index) => ({
+        attemptNumber: index + 1,
+        timestamp: Date.now(),
+      })),
+      createdAt: new Date(row.created_at).getTime(),
+      updatedAt: Date.now(),
+      payload: payloadString,
+    };
+
+    await this.service.attemptDelivery(delivery, endpoint.secret);
+    await client.query('UPDATE webhook_outbox SET processed = true WHERE id = $1', [row.id]);
+
+    if (delivery.status === 'delivered' || delivery.status === 'permanent_failure') {
+      return;
+    }
+
+    const retry = scheduleWebhookOutboxRetry({
+      streamId: row.stream_id,
+      eventType: row.event_type,
+      payload,
+      attemptNumber,
+      policy: this.policy,
+    });
+
+    if (!retry.shouldRetry || !retry.retryAt) {
+      return;
+    }
+
+    await client.query(
+      `
+        INSERT INTO webhook_outbox (stream_id, event_type, payload, created_at, processed)
+        VALUES ($1, $2, $3::jsonb, $4, false)
+      `,
+      [row.stream_id, row.event_type, JSON.stringify(retry.payload), retry.retryAt],
+    );
+  }
+}
+
 export const webhookService = new WebhookService();
+export const webhookDispatcher = new WebhookDispatcher();

--- a/tests/webhooks/service.dispatcher.test.ts
+++ b/tests/webhooks/service.dispatcher.test.ts
@@ -1,0 +1,184 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { WebhookDispatcher } from '../../src/webhooks/service.js';
+import type { WebhookRetryPolicy } from '../../src/webhooks/types.js';
+
+interface MockClient {
+  queries: Array<{ sql: string; params: unknown[] | undefined }>;
+  rows: unknown[];
+  query: ReturnType<typeof vi.fn>;
+  release: ReturnType<typeof vi.fn>;
+}
+
+const policy: WebhookRetryPolicy = {
+  maxAttempts: 3,
+  initialBackoffMs: 1000,
+  backoffMultiplier: 1,
+  maxBackoffMs: 1000,
+  jitterPercent: 0,
+  timeoutMs: 1000,
+  retryableStatusCodes: [500],
+};
+
+function createClient(rows: unknown[]): MockClient {
+  const client: MockClient = {
+    queries: [],
+    rows,
+    query: vi.fn(async (sql: string, params?: unknown[]) => {
+      client.queries.push({ sql, params });
+      if (sql.includes('SELECT id, stream_id')) {
+        return { rows: client.rows };
+      }
+      return { rows: [] };
+    }),
+    release: vi.fn(),
+  };
+
+  return client;
+}
+
+function createDispatcher(client: MockClient): WebhookDispatcher {
+  return new WebhookDispatcher({
+    endpointUrl: 'https://consumer.example/webhooks',
+    secret: 'test-secret',
+    pollIntervalMs: 60_000,
+    batchSize: 5,
+    policy,
+    pool: {
+      connect: vi.fn(async () => client),
+    },
+  });
+}
+
+describe('WebhookDispatcher outbox polling', () => {
+  beforeEach(() => {
+    vi.spyOn(Math, 'random').mockReturnValue(0.5);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('no-ops cleanly when the outbox is empty', async () => {
+    const client = createClient([]);
+    global.fetch = vi.fn() as unknown as typeof fetch;
+
+    await createDispatcher(client).pollOnce();
+
+    expect(global.fetch).not.toHaveBeenCalled();
+    expect(client.queries.some(q => q.sql.includes('COMMIT'))).toBe(true);
+    expect(client.release).toHaveBeenCalledOnce();
+  });
+
+  it('claims rows with FOR UPDATE SKIP LOCKED and marks successful deliveries processed', async () => {
+    const client = createClient([
+      {
+        id: '42',
+        stream_id: 'stream-1',
+        event_type: 'stream.created',
+        payload: { id: 'evt-1', amount: '10' },
+        created_at: new Date(),
+      },
+    ]);
+    global.fetch = vi.fn(async () => new Response(null, { status: 204 })) as unknown as typeof fetch;
+
+    await createDispatcher(client).pollOnce();
+
+    const select = client.queries.find(q => q.sql.includes('SELECT id, stream_id'));
+    expect(select?.sql).toContain('FOR UPDATE SKIP LOCKED');
+    expect(select?.params).toEqual([5]);
+    expect(global.fetch).toHaveBeenCalledOnce();
+    expect(client.queries).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          sql: 'UPDATE webhook_outbox SET processed = true WHERE id = $1',
+          params: ['42'],
+        }),
+      ]),
+    );
+    expect(client.queries.some(q => q.sql.includes('INSERT INTO webhook_outbox'))).toBe(false);
+  });
+
+  it('marks failed attempts processed and delegates retry scheduling to a future outbox row', async () => {
+    const now = new Date('2026-05-26T12:00:00.000Z').getTime();
+    vi.spyOn(Date, 'now').mockReturnValue(now);
+    const client = createClient([
+      {
+        id: '43',
+        stream_id: 'stream-2',
+        event_type: 'stream.updated',
+        payload: { id: 'evt-2', amount: '20' },
+        created_at: new Date(now),
+      },
+    ]);
+    global.fetch = vi.fn(async () => new Response(null, { status: 500, statusText: 'Server Error' })) as unknown as typeof fetch;
+
+    await createDispatcher(client).pollOnce();
+
+    const insert = client.queries.find(q => q.sql.includes('INSERT INTO webhook_outbox'));
+    expect(client.queries).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          sql: 'UPDATE webhook_outbox SET processed = true WHERE id = $1',
+          params: ['43'],
+        }),
+      ]),
+    );
+    expect(insert?.params?.[0]).toBe('stream-2');
+    expect(insert?.params?.[1]).toBe('stream.updated');
+    expect(JSON.parse(insert?.params?.[2] as string)).toMatchObject({
+      id: 'evt-2',
+      _webhookRetry: { attemptNumber: 2 },
+    });
+    expect(insert?.params?.[3]).toEqual(new Date(now + 1000));
+  });
+
+  it('does not enqueue another row after retry attempts are exhausted', async () => {
+    const client = createClient([
+      {
+        id: '44',
+        stream_id: 'stream-3',
+        event_type: 'stream.cancelled',
+        payload: {
+          id: 'evt-3',
+          _webhookRetry: { attemptNumber: 3 },
+        },
+        created_at: new Date(),
+      },
+    ]);
+    global.fetch = vi.fn(async () => new Response(null, { status: 500, statusText: 'Server Error' })) as unknown as typeof fetch;
+
+    await createDispatcher(client).pollOnce();
+
+    expect(client.queries.some(q => q.sql.includes('INSERT INTO webhook_outbox'))).toBe(false);
+  });
+
+  it('drains an in-flight delivery when stopped during shutdown', async () => {
+    let releaseFetch: (() => void) | undefined;
+    const client = createClient([
+      {
+        id: '45',
+        stream_id: 'stream-4',
+        event_type: 'stream.created',
+        payload: { id: 'evt-4' },
+        created_at: new Date(),
+      },
+    ]);
+    global.fetch = vi.fn(
+      async () => new Promise<Response>((resolve) => {
+        releaseFetch = () => resolve(new Response(null, { status: 200 }));
+      }),
+    ) as unknown as typeof fetch;
+    const dispatcher = createDispatcher(client);
+
+    const poll = dispatcher.pollOnce();
+    const stopped = dispatcher.stop();
+
+    await Promise.resolve();
+    expect(client.release).not.toHaveBeenCalled();
+    releaseFetch?.();
+
+    await Promise.all([poll, stopped]);
+    expect(client.release).toHaveBeenCalledOnce();
+    expect(client.queries.some(q => q.sql.includes('COMMIT'))).toBe(true);
+  });
+});


### PR DESCRIPTION
 ## Description

  Implemented a live PostgreSQL-backed webhook outbox dispatcher with at-least-
  once delivery semantics.

  The dispatcher polls `webhook_outbox`, safely claims pending rows using
  `SELECT ... FOR UPDATE SKIP LOCKED`, delivers signed webhook HTTP requests,
  marks attempted rows as processed, and schedules retry rows for retryable
  failures. It is wired into service startup and graceful shutdown so in-flight
  batches drain before database connections close.

  ## Changes

  - Added `WebhookDispatcher` in `src/webhooks/service.ts`
  - Added durable retry scheduling in `src/webhooks/retry.ts`
  - Wired dispatcher startup and shutdown drain lifecycle
  - Added tests for empty outbox, successful delivery, retry scheduling, locking
  SQL, and shutdown drain
  - Added webhook dispatcher documentation
  - Added `WEBHOOK_POLL_INTERVAL_MS` and `WEBHOOK_BATCH_SIZE` env examples

  ## Testing

  - `git diff --check` passed

  ## Security Notes

  - Webhook requests are signed with the configured secret
  - Production HTTP endpoints are rejected unless they are loopback
  - URLs with embedded credentials are rejected
  - Consumers should deduplicate webhook deliveries because delivery is at-
  least-once
closes #247 