### PR TITLE
feat: add pluggable OIDC provider support to auth session endpoint

### DIFF
--- a/docs/auth.md
+++ b/docs/auth.md
@@ -1,0 +1,77 @@
+# Authentication and Pluggable OIDC Support
+
+Fluxora supports two parallel authentication paths at the session creation endpoint `POST /api/auth/session` to obtain a Fluxora JWT:
+
+1. **Shared-Secret Authentication (Fallback):** Generates a JWT using a static pre-configured secret.
+2. **Pluggable OIDC/OAuth2 Authentication:** Exchanges an ID token from an external Identity Provider (SSO) for a Fluxora JWT.
+
+---
+
+## Configuration
+
+To enable OIDC/OAuth2 authentication, configure the following environment variables:
+
+| Environment Variable | Type | Required | Description |
+| :--- | :--- | :--- | :--- |
+| `OIDC_ISSUER_URL` | URL | No | The base URL of the identity provider (e.g. `https://keycloak.example.com/realms/myrealm` or `https://auth0.com`). If set, OIDC authentication is enabled. |
+| `OIDC_AUDIENCE` | String | No | The client ID / audience expected in incoming ID tokens. Signature claims validation will enforce this check if set. |
+
+---
+
+## Flow: OIDC ID Token Exchange
+
+Enterprise dashboard clients or operators can exchange their OIDC ID Token for a Fluxora JWT.
+
+```mermaid
+sequenceDiagram
+    autonumber
+    actor Operator as Enterprise Operator
+    participant Client as Dashboard Client
+    participant IdP as Identity Provider (SSO)
+    participant Server as Fluxora Backend
+
+    Operator->>Client: Clicks SSO Log In
+    Client->>IdP: Redirects to login
+    IdP->>Operator: Asks for credentials
+    Operator->>IdP: Authenticates
+    IdP->>Client: Returns OIDC ID Token
+    Client->>Server: POST /api/auth/session { idToken }
+    Server->>Server: Decodes header, extracts kid
+    Note over Server: Retrieves & caches JWKS from OIDC_ISSUER_URL/.well-known/jwks.json
+    Server->>Server: Verifies token signature & claims (iss, aud, exp)
+    Server->>Server: Asserts token is not replayed
+    Server->>Client: Returns Fluxora JWT
+```
+
+### Request Example
+```http
+POST /api/auth/session
+Content-Type: application/json
+
+{
+  "idToken": "eyJhbGciOiJSUzI1NiIsImtpZCI6ImtleS1pZC0xIi... "
+}
+```
+
+### Response Example
+```json
+{
+  "token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...",
+  "user": {
+    "address": "GCSX22222222222222222222222222222222222222222222222222UV",
+    "role": "operator"
+  }
+}
+```
+
+---
+
+## Security & Implementation Details
+
+- **JWKS Cache Policy:** The JWKS retrieved from the provider is cached in Redis (under the key `fluxora:jwks:<issuer_url>`) and locally in memory for 24 hours to reduce latency.
+- **Key Rotation Support:** If a token contains a `kid` that is not found in the cache, Fluxora will automatically perform a force refresh once to fetch fresh keys from the provider.
+- **Token Replay Prevention:** Verified ID tokens are hashed via SHA-256 and registered in Redis (and memory) with a TTL matching the token's expiration (`exp`). If a duplicate token is presented during this period, it is rejected with an unauthorized error.
+- **Address Claims Mapping:** To map the SSO identity to a Stellar account address, Fluxora parses claims in the following order of precedence:
+  1. `stellar_address`
+  2. `address`
+  3. `sub`

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -64,6 +64,8 @@ export interface Config {
     indexerStallThresholdMs: number;
     indexerLastSuccessfulSyncAt?: string | undefined;
     deploymentChecklistVersion: string;
+    oidcIssuerUrl?: string | undefined;
+    oidcAudience?: string | undefined;
 }
 
 /**
@@ -281,6 +283,8 @@ export function loadConfig(): Config {
         indexerStallThresholdMs: parseIntEnv(process.env.INDEXER_STALL_THRESHOLD_MS, 5 * 60 * 1000, 1000),
         indexerLastSuccessfulSyncAt: process.env.INDEXER_LAST_SUCCESSFUL_SYNC_AT,
         deploymentChecklistVersion: process.env.DEPLOYMENT_CHECKLIST_VERSION ?? '2026-03-27',
+        oidcIssuerUrl: process.env.OIDC_ISSUER_URL ? validateUrl(process.env.OIDC_ISSUER_URL, 'OIDC_ISSUER_URL') : undefined,
+        oidcAudience: process.env.OIDC_AUDIENCE,
     };
 
     return config;

--- a/src/routes/auth.ts
+++ b/src/routes/auth.ts
@@ -1,15 +1,27 @@
 import { Router, Request, Response } from 'express';
 import { z } from 'zod';
 import { generateToken } from '../lib/auth.js';
-import { validationError, asyncHandler } from '../middleware/errorHandler.js';
+import { validationError, unauthorized, asyncHandler } from '../middleware/errorHandler.js';
 import { info } from '../utils/logger.js';
+import { getConfig } from '../config/env.js';
+import { verifyIdToken } from '../services/oidcProvider.js';
 
 export const authRouter = Router();
 
-// Schema for session creation
+// Schema for session creation supporting OIDC token exchange and shared-secret fallback
 const SessionRequestSchema = z.object({
-  address: z.string().min(1, 'Stellar address is required'),
+  address: z.string().optional(),
   role: z.enum(['operator', 'viewer']).optional().default('viewer'),
+  idToken: z.string().optional(),
+}).refine(data => {
+  // If idToken is not provided, address is required.
+  if (!data.idToken && (!data.address || data.address.trim() === '')) {
+    return false;
+  }
+  return true;
+}, {
+  message: 'Stellar address is required when idToken is not provided',
+  path: ['address'],
 });
 
 /**
@@ -19,7 +31,8 @@ const SessionRequestSchema = z.object({
  *     summary: Create a new session (get JWT)
  *     description: |
  *       Issues a JWT for a dashboard client. 
- *       In this iteration, any valid Stellar address can obtain a session.
+ *       If OIDC is configured and an ID token is provided, uses OIDC exchange.
+ *       Otherwise, falls back to the static shared-secret path.
  *     tags:
  *       - auth
  *     requestBody:
@@ -28,8 +41,6 @@ const SessionRequestSchema = z.object({
  *         application/json:
  *           schema:
  *             type: object
- *             required:
- *               - address
  *             properties:
  *               address:
  *                 type: string
@@ -38,6 +49,9 @@ const SessionRequestSchema = z.object({
  *                 type: string
  *                 enum: [operator, viewer]
  *                 default: viewer
+ *               idToken:
+ *                 type: string
+ *                 description: External OIDC ID token
  *     responses:
  *       200:
  *         description: Success
@@ -52,6 +66,8 @@ const SessionRequestSchema = z.object({
  *                   type: object
  *       400:
  *         description: Invalid input
+ *       401:
+ *         description: Unauthorized
  */
 authRouter.post(
   '/session',
@@ -63,14 +79,42 @@ authRouter.post(
       throw validationError('Invalid session request', result.error.format());
     }
 
-    const { address, role } = result.data;
-    const token = generateToken({ address, role: role as 'operator' | 'viewer' });
+    const { address, role, idToken } = result.data;
+    const config = getConfig();
 
-    info('Session created', { address, role, requestId });
+    let targetAddress = address;
+    let targetRole = role;
+
+    if (idToken) {
+      if (!config.oidcIssuerUrl) {
+        throw validationError('OIDC authentication is not configured on this server');
+      }
+
+      try {
+        const verified = await verifyIdToken(idToken);
+        if (!targetAddress) {
+          targetAddress = verified.address;
+        }
+        if (!req.body.role) {
+          targetRole = verified.role;
+        }
+      } catch (err) {
+        throw unauthorized(`OIDC token validation failed: ${err instanceof Error ? err.message : String(err)}`);
+      }
+    }
+
+    if (!targetAddress) {
+      throw validationError('Stellar address is required');
+    }
+
+    const token = generateToken({ address: targetAddress, role: targetRole as 'operator' | 'viewer' });
+
+    info('Session created', { address: targetAddress, role: targetRole, requestId, authMethod: idToken ? 'oidc' : 'shared-secret' });
 
     res.json({
       token,
-      user: { address, role },
+      user: { address: targetAddress, role: targetRole },
     });
   })
 );
+

--- a/src/services/oidcProvider.ts
+++ b/src/services/oidcProvider.ts
@@ -1,0 +1,345 @@
+import crypto from 'crypto';
+import jwt from 'jsonwebtoken';
+import { getConfig } from '../config/env.js';
+import { createRedisClient, type RedisClient } from '../redis/client.js';
+import { info, warn, error } from '../utils/logger.js';
+
+interface JwksKey {
+  kty: string;
+  kid: string;
+  use?: string;
+  alg?: string;
+  n: string;
+  e: string;
+  [key: string]: unknown;
+}
+
+interface JwksResponse {
+  keys: JwksKey[];
+}
+
+interface CachedJwks {
+  jwks: JwksResponse;
+  expiresAt: number;
+}
+
+// In-memory cache for JWKS
+const jwksMemoryCache = new Map<string, CachedJwks>();
+
+// In-memory cache for replay prevention
+// Stores replayKey -> expiration timestamp (ms)
+const memoryReplayCache = new Map<string, number>();
+
+let redisClient: RedisClient | null = null;
+let redisClientPromise: Promise<RedisClient | null> | null = null;
+
+/**
+ * Gets or initializes the Redis client for OIDC caching.
+ */
+export async function getOidcRedisClient(): Promise<RedisClient | null> {
+  const config = getConfig();
+  if (!config.redisEnabled) {
+    return null;
+  }
+  if (redisClient) {
+    return redisClient;
+  }
+  if (redisClientPromise) {
+    return redisClientPromise;
+  }
+
+  redisClientPromise = (async () => {
+    try {
+      const client = await createRedisClient({
+        url: config.redisUrl,
+        enabled: config.redisEnabled,
+      });
+      redisClient = client;
+      return client;
+    } catch (err) {
+      warn('Failed to initialize Redis client for OIDC provider service', {
+        error: err instanceof Error ? err.message : String(err),
+      });
+      redisClientPromise = null;
+      return null;
+    }
+  })();
+
+  return redisClientPromise;
+}
+
+/**
+ * Fetches and caches the JWKS keys.
+ */
+export async function getJwks(
+  issuerUrl: string,
+  options: { forceRefresh?: boolean } = {}
+): Promise<JwksResponse> {
+  const normalizedIssuer = issuerUrl.replace(/\/$/, '');
+  const jwksUrl = `${normalizedIssuer}/.well-known/jwks.json`;
+  const redisKey = `fluxora:jwks:${normalizedIssuer}`;
+  const now = Date.now();
+
+  // 1. Check in-memory cache
+  if (!options.forceRefresh) {
+    const memCached = jwksMemoryCache.get(normalizedIssuer);
+    if (memCached && memCached.expiresAt > now) {
+      return memCached.jwks;
+    }
+  }
+
+  // 2. Check Redis cache
+  if (!options.forceRefresh) {
+    try {
+      const redis = await getOidcRedisClient();
+      if (redis) {
+        const cached = await redis.get(redisKey);
+        if (cached) {
+          const parsed = JSON.parse(cached) as JwksResponse;
+          // Store in memory cache for faster subsequent lookups
+          jwksMemoryCache.set(normalizedIssuer, {
+            jwks: parsed,
+            // Align memory TTL with a reasonable time (1 hour from now or default)
+            expiresAt: now + 3600 * 1000,
+          });
+          return parsed;
+        }
+      }
+    } catch (err) {
+      warn('Redis JWKS read failure, falling back to HTTP fetch', {
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+
+  // 3. Fetch from HTTP endpoint
+  info(`Fetching JWKS from external provider: ${jwksUrl}`);
+  let response: globalThis.Response;
+  try {
+    response = await fetch(jwksUrl);
+  } catch (err) {
+    const msg = `JWKS fetch request failed: ${err instanceof Error ? err.message : String(err)}`;
+    error(msg);
+    throw new Error(msg);
+  }
+
+  if (!response.ok) {
+    const msg = `JWKS fetch failed with HTTP status ${response.status}`;
+    error(msg);
+    throw new Error(msg);
+  }
+
+  let jwks: JwksResponse;
+  try {
+    jwks = (await response.json()) as JwksResponse;
+  } catch (err) {
+    const msg = `JWKS response is not valid JSON: ${err instanceof Error ? err.message : String(err)}`;
+    error(msg);
+    throw new Error(msg);
+  }
+
+  if (!jwks || !Array.isArray(jwks.keys)) {
+    const msg = 'Invalid JWKS format returned from identity provider';
+    error(msg);
+    throw new Error(msg);
+  }
+
+  // TTL is 24 hours (86400 seconds)
+  const ttlSeconds = 86400;
+
+  // 4. Cache in memory
+  jwksMemoryCache.set(normalizedIssuer, {
+    jwks,
+    expiresAt: now + ttlSeconds * 1000,
+  });
+
+  // 5. Cache in Redis
+  try {
+    const redis = await getOidcRedisClient();
+    if (redis) {
+      await redis.set(redisKey, JSON.stringify(jwks), { ex: ttlSeconds });
+    }
+  } catch (err) {
+    warn('Failed to cache JWKS in Redis', {
+      error: err instanceof Error ? err.message : String(err),
+    });
+  }
+
+  return jwks;
+}
+
+/**
+ * Validates the token to prevent replay attacks.
+ */
+async function preventReplay(idToken: string, exp: number): Promise<void> {
+  const now = Math.floor(Date.now() / 1000);
+  const ttl = exp - now;
+
+  if (ttl <= 0) {
+    throw new Error('OIDC ID token is expired');
+  }
+
+  const tokenHash = crypto.createHash('sha256').update(idToken).digest('hex');
+  const replayKey = `fluxora:oidc_replay:${tokenHash}`;
+  const nowMs = Date.now();
+
+  // 1. Check in-memory replay cache
+  const inMemoryExpiry = memoryReplayCache.get(replayKey);
+  if (inMemoryExpiry && inMemoryExpiry > nowMs) {
+    throw new Error('Token replay detected: this token has already been exchanged');
+  }
+
+  // 2. Check Redis replay cache
+  try {
+    const redis = await getOidcRedisClient();
+    if (redis) {
+      const exists = await redis.exists(replayKey);
+      if (exists) {
+        throw new Error('Token replay detected: this token has already been exchanged');
+      }
+      await redis.set(replayKey, '1', { ex: ttl });
+    }
+  } catch (err) {
+    if (err instanceof Error && err.message.includes('Token replay detected')) {
+      throw err;
+    }
+    warn('Failed to check/set token replay key in Redis', {
+      error: err instanceof Error ? err.message : String(err),
+    });
+  }
+
+  // Store in memory replay cache as fallback / double check
+  memoryReplayCache.set(replayKey, nowMs + ttl * 1000);
+}
+
+/**
+ * Verifies the signature of a public key in JWK format and verifies claims.
+ */
+function verifyWithJwk(
+  idToken: string,
+  jwk: JwksKey,
+  issuerUrl: string,
+  audience?: string
+): any {
+  let pem: string;
+  try {
+    const publicKey = crypto.createPublicKey({
+      key: jwk,
+      format: 'jwk',
+    });
+    pem = publicKey.export({
+      type: 'spki',
+      format: 'pem',
+    }) as string;
+  } catch (err) {
+    throw new Error(`Failed to import JWK to PEM public key: ${err instanceof Error ? err.message : String(err)}`);
+  }
+
+  const verifyOptions: jwt.VerifyOptions = {
+    algorithms: ['RS256'],
+    issuer: issuerUrl,
+  };
+
+  if (audience) {
+    verifyOptions.audience = audience;
+  }
+
+  try {
+    return jwt.verify(idToken, pem, verifyOptions);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    throw new Error(`Token verification failed: ${msg}`);
+  }
+}
+
+/**
+ * Verifies an OIDC ID Token signature, iss, aud, exp, and prevents replay attacks.
+ */
+export async function verifyIdToken(idToken: string): Promise<{
+  address: string;
+  role: 'operator' | 'viewer';
+  sub: string;
+  email?: string;
+  claims: any;
+}> {
+  const config = getConfig();
+  const issuerUrl = config.oidcIssuerUrl;
+  const audience = config.oidcAudience;
+
+  if (!issuerUrl) {
+    throw new Error('OIDC issuer URL is not configured');
+  }
+
+  // 1. Decode token to extract kid
+  const decoded = jwt.decode(idToken, { complete: true });
+  if (!decoded || typeof decoded === 'string' || !decoded.header || !decoded.payload) {
+    throw new Error('Invalid token structure');
+  }
+
+  const kid = decoded.header.kid;
+  if (!kid) {
+    throw new Error('Missing key ID (kid) in token header');
+  }
+
+  const payload = decoded.payload as any;
+  if (!payload || typeof payload !== 'object') {
+    throw new Error('Invalid token payload');
+  }
+
+  const exp = payload.exp;
+  if (typeof exp !== 'number') {
+    throw new Error('Token does not contain an expiration claim (exp)');
+  }
+
+  // 2. Fetch JWKS and locate the key
+  let jwks = await getJwks(issuerUrl);
+  let jwk = jwks.keys.find((k) => k.kid === kid);
+
+  // If signing key not found, force-refresh the JWKS once in case of recent key rotation
+  if (!jwk) {
+    info(`Signing key not found in cache for kid: ${kid}. Force-refreshing JWKS...`);
+    jwks = await getJwks(issuerUrl, { forceRefresh: true });
+    jwk = jwks.keys.find((k) => k.kid === kid);
+    if (!jwk) {
+      throw new Error(`Signing key not found for kid: ${kid}`);
+    }
+  }
+
+  // 3. Verify token signature and claims
+  const verifiedPayload = verifyWithJwk(idToken, jwk, issuerUrl, audience);
+
+  // 4. Token replay prevention
+  await preventReplay(idToken, exp);
+
+  // 5. Extract claims
+  const sub = verifiedPayload.sub;
+  const email = verifiedPayload.email;
+  // Fall back chain for address: custom claim 'stellar_address', standard claim 'address', then 'sub'
+  const address = verifiedPayload.stellar_address || verifiedPayload.address || sub;
+  const role = verifiedPayload.role === 'operator' ? 'operator' : 'viewer';
+
+  return {
+    address,
+    role,
+    sub,
+    email,
+    claims: verifiedPayload,
+  };
+}
+
+/**
+ * Resets local in-memory caches and closes active Redis connections (for testing).
+ */
+export async function _resetOidcProviderForTest(): Promise<void> {
+  jwksMemoryCache.clear();
+  memoryReplayCache.clear();
+  if (redisClient) {
+    try {
+      await redisClient.close();
+    } catch {
+      // ignore
+    }
+    redisClient = null;
+  }
+  redisClientPromise = null;
+}

--- a/tests/services/oidcProvider.test.ts
+++ b/tests/services/oidcProvider.test.ts
@@ -1,0 +1,418 @@
+import { vi, describe, it, expect, beforeEach, afterEach, beforeAll, afterAll } from 'vitest';
+import crypto from 'crypto';
+import jwt from 'jsonwebtoken';
+import request from 'supertest';
+import { app } from '../../src/app.js';
+import { initializeConfig, resetConfig } from '../../src/config/env.js';
+import {
+  setRedisClientFactory,
+  DefaultRedisClientFactory,
+  type RedisClient,
+  type RedisClientFactory,
+} from '../../src/redis/client.js';
+import {
+  verifyIdToken,
+  getJwks,
+  _resetOidcProviderForTest,
+} from '../../src/services/oidcProvider.js';
+
+// Helper to generate RSA Key pair
+const { privateKey, publicKey } = crypto.generateKeyPairSync('rsa', {
+  modulusLength: 2048,
+});
+
+const kid1 = 'key-id-1';
+const kid2 = 'key-id-2';
+const issuer = 'https://issuer.example.com';
+const audience = 'my-audience';
+
+const jwk1 = {
+  kid: kid1,
+  kty: 'RSA',
+  alg: 'RS256',
+  use: 'sig',
+  ...publicKey.export({ format: 'jwk' }),
+};
+
+// Mock Redis client setup
+const mockClient: RedisClient = {
+  get: vi.fn(),
+  set: vi.fn(),
+  exists: vi.fn(),
+  close: vi.fn(),
+};
+
+const mockFactory: RedisClientFactory = {
+  createClient: async () => mockClient,
+};
+
+describe('OIDC Provider Service & Routes', () => {
+  let originalFetch: typeof globalThis.fetch;
+  let originalEnv: Record<string, string | undefined>;
+
+  beforeAll(() => {
+    originalFetch = globalThis.fetch;
+    originalEnv = { ...process.env };
+    setRedisClientFactory(mockFactory);
+  });
+
+  afterAll(() => {
+    globalThis.fetch = originalFetch;
+    setRedisClientFactory(new DefaultRedisClientFactory());
+    process.env = originalEnv;
+  });
+
+  beforeEach(async () => {
+    vi.restoreAllMocks();
+    // Setup env vars
+    process.env.OIDC_ISSUER_URL = issuer;
+    process.env.OIDC_AUDIENCE = audience;
+    process.env.REDIS_ENABLED = 'true';
+    process.env.JWT_SECRET = 'a-very-long-secret-key-for-testing-only-12345';
+    process.env.NODE_ENV = 'test';
+    
+    resetConfig();
+    initializeConfig();
+    await _resetOidcProviderForTest();
+
+    // Reset Redis mock implementation
+    vi.mocked(mockClient.get).mockResolvedValue(null);
+    vi.mocked(mockClient.set).mockResolvedValue(undefined);
+    vi.mocked(mockClient.exists).mockResolvedValue(false);
+  });
+
+  afterEach(async () => {
+    await _resetOidcProviderForTest();
+  });
+
+  // ── JWKS Retrieval & Cache Tests ───────────────────────────────────────────
+
+  describe('getJwks', () => {
+    it('should fetch JWKS from HTTP when not cached', async () => {
+      const mockResponse = { keys: [jwk1] };
+      globalThis.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => mockResponse,
+      } as Response);
+
+      const keys = await getJwks(issuer);
+
+      expect(globalThis.fetch).toHaveBeenCalledWith(`${issuer}/.well-known/jwks.json`);
+      expect(keys).toEqual(mockResponse);
+      expect(mockClient.set).toHaveBeenCalled();
+    });
+
+    it('should return cached JWKS from Redis if available', async () => {
+      const mockResponse = { keys: [jwk1] };
+      vi.mocked(mockClient.get).mockResolvedValue(JSON.stringify(mockResponse));
+      globalThis.fetch = vi.fn();
+
+      const keys = await getJwks(issuer);
+
+      expect(globalThis.fetch).not.toHaveBeenCalled();
+      expect(keys).toEqual(mockResponse);
+    });
+
+    it('should bypass cache and force refetch when requested', async () => {
+      const mockResponse = { keys: [jwk1] };
+      vi.mocked(mockClient.get).mockResolvedValue(JSON.stringify({ keys: [] }));
+      globalThis.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => mockResponse,
+      } as Response);
+
+      const keys = await getJwks(issuer, { forceRefresh: true });
+
+      expect(globalThis.fetch).toHaveBeenCalled();
+      expect(keys).toEqual(mockResponse);
+    });
+
+    it('should throw error when fetch fails', async () => {
+      globalThis.fetch = vi.fn().mockRejectedValue(new Error('Network error'));
+      await expect(getJwks(issuer)).rejects.toThrow('JWKS fetch request failed');
+    });
+
+    it('should throw error when response status is not ok', async () => {
+      globalThis.fetch = vi.fn().mockResolvedValue({
+        ok: false,
+        status: 404,
+      } as Response);
+      await expect(getJwks(issuer)).rejects.toThrow('JWKS fetch failed with HTTP status 404');
+    });
+
+    it('should fall back to HTTP fetch when Redis read fails', async () => {
+      vi.mocked(mockClient.get).mockRejectedValue(new Error('Redis read timeout'));
+      const mockResponse = { keys: [jwk1] };
+      globalThis.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => mockResponse,
+      } as Response);
+
+      const keys = await getJwks(issuer);
+      expect(globalThis.fetch).toHaveBeenCalled();
+      expect(keys).toEqual(mockResponse);
+    });
+  });
+
+  // ── ID Token Signature & Claims Verification Tests ─────────────────────────
+
+  describe('verifyIdToken', () => {
+    it('should verify valid RS256 token and extract claims', async () => {
+      const token = jwt.sign(
+        {
+          iss: issuer,
+          aud: audience,
+          sub: 'user123',
+          email: 'user@example.com',
+          stellar_address: 'GCSX22222222222222222222222222222222222222222222222222UV',
+          role: 'operator',
+        },
+        privateKey,
+        { algorithm: 'RS256', keyid: kid1, expiresIn: '10m' }
+      );
+
+      globalThis.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({ keys: [jwk1] }),
+      } as Response);
+
+      const result = await verifyIdToken(token);
+      expect(result.address).toBe('GCSX22222222222222222222222222222222222222222222222222UV');
+      expect(result.role).toBe('operator');
+      expect(result.sub).toBe('user123');
+      expect(result.email).toBe('user@example.com');
+    });
+
+    it('should fall back to sub claim when address/stellar_address are missing', async () => {
+      const token = jwt.sign(
+        {
+          iss: issuer,
+          aud: audience,
+          sub: 'GB345...',
+          role: 'viewer',
+        },
+        privateKey,
+        { algorithm: 'RS256', keyid: kid1, expiresIn: '10m' }
+      );
+
+      globalThis.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({ keys: [jwk1] }),
+      } as Response);
+
+      const result = await verifyIdToken(token);
+      expect(result.address).toBe('GB345...');
+      expect(result.role).toBe('viewer');
+    });
+
+    it('should throw if issuer does not match config', async () => {
+      const token = jwt.sign(
+        {
+          iss: 'https://bad-issuer.com',
+          aud: audience,
+          sub: 'user123',
+        },
+        privateKey,
+        { algorithm: 'RS256', keyid: kid1, expiresIn: '1h' }
+      );
+
+      globalThis.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({ keys: [jwk1] }),
+      } as Response);
+
+      await expect(verifyIdToken(token)).rejects.toThrow('jwt issuer invalid');
+    });
+
+    it('should throw if audience does not match config', async () => {
+      const token = jwt.sign(
+        {
+          iss: issuer,
+          aud: 'wrong-audience',
+          sub: 'user123',
+        },
+        privateKey,
+        { algorithm: 'RS256', keyid: kid1, expiresIn: '1h' }
+      );
+
+      globalThis.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({ keys: [jwk1] }),
+      } as Response);
+
+      await expect(verifyIdToken(token)).rejects.toThrow('jwt audience invalid');
+    });
+
+    it('should throw if token is expired', async () => {
+      const token = jwt.sign(
+        {
+          iss: issuer,
+          aud: audience,
+          sub: 'user123',
+          exp: Math.floor(Date.now() / 1000) - 1000,
+        },
+        privateKey,
+        { algorithm: 'RS256', keyid: kid1 }
+      );
+
+      globalThis.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({ keys: [jwk1] }),
+      } as Response);
+
+      await expect(verifyIdToken(token)).rejects.toThrow('jwt expired');
+    });
+
+    it('should force-refresh JWKS if kid is missing initially', async () => {
+      const token = jwt.sign(
+        {
+          iss: issuer,
+          aud: audience,
+          sub: 'user123',
+        },
+        privateKey,
+        { algorithm: 'RS256', keyid: kid2, expiresIn: '1h' }
+      );
+
+      const jwk2 = {
+        kid: kid2,
+        kty: 'RSA',
+        alg: 'RS256',
+        use: 'sig',
+        ...publicKey.export({ format: 'jwk' }),
+      };
+
+      // Mock first call returning key-id-1, second call returning key-id-2
+      globalThis.fetch = vi.fn()
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({ keys: [jwk1] }),
+        } as Response)
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({ keys: [jwk1, jwk2] }),
+        } as Response);
+
+      const result = await verifyIdToken(token);
+      expect(result.sub).toBe('user123');
+      expect(globalThis.fetch).toHaveBeenCalledTimes(2);
+    });
+
+    it('should prevent token replay', async () => {
+      const token = jwt.sign(
+        {
+          iss: issuer,
+          aud: audience,
+          sub: 'user123',
+        },
+        privateKey,
+        { algorithm: 'RS256', keyid: kid1, expiresIn: '5m' }
+      );
+
+      globalThis.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({ keys: [jwk1] }),
+      } as Response);
+
+      // First validation: should pass
+      await expect(verifyIdToken(token)).resolves.toBeDefined();
+
+      // Mock Redis client exists check for second validation
+      vi.mocked(mockClient.exists).mockResolvedValue(true);
+
+      // Second validation: should throw replay error
+      await expect(verifyIdToken(token)).rejects.toThrow('Token replay detected');
+    });
+  });
+
+  // ── Route Endpoint Integration Tests ──────────────────────────────────────
+
+  describe('POST /api/auth/session', () => {
+    it('should fall back to shared-secret path if idToken is absent', async () => {
+      const address = 'GCSX22222222222222222222222222222222222222222222222222UV';
+      const res = await request(app)
+        .post('/api/auth/session')
+        .send({ address, role: 'operator' });
+
+      expect(res.status).toBe(200);
+      expect(res.body.token).toBeDefined();
+      expect(res.body.user.address).toBe(address);
+    });
+
+    it('should return 400 if both address and idToken are absent', async () => {
+      const res = await request(app)
+        .post('/api/auth/session')
+        .send({ role: 'operator' });
+
+      expect(res.status).toBe(400);
+      expect(res.body.error.code).toBe('VALIDATION_ERROR');
+    });
+
+    it('should return 400 if OIDC is not configured on server but client sends idToken', async () => {
+      // Disable OIDC
+      delete process.env.OIDC_ISSUER_URL;
+      resetConfig();
+      initializeConfig();
+
+      const res = await request(app)
+        .post('/api/auth/session')
+        .send({ idToken: 'some-token' });
+
+      expect(res.status).toBe(400);
+      expect(res.body.error.message).toContain('OIDC authentication is not configured');
+    });
+
+    it('should authenticate and issue session JWT when valid idToken is provided', async () => {
+      const idToken = jwt.sign(
+        {
+          iss: issuer,
+          aud: audience,
+          sub: 'user123',
+          stellar_address: 'GCSX22222222222222222222222222222222222222222222222222UV',
+          role: 'operator',
+        },
+        privateKey,
+        { algorithm: 'RS256', keyid: kid1, expiresIn: '5m' }
+      );
+
+      globalThis.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({ keys: [jwk1] }),
+      } as Response);
+
+      const res = await request(app)
+        .post('/api/auth/session')
+        .send({ idToken });
+
+      expect(res.status).toBe(200);
+      expect(res.body.token).toBeDefined();
+      expect(res.body.user.address).toBe('GCSX22222222222222222222222222222222222222222222222222UV');
+      expect(res.body.user.role).toBe('operator');
+    });
+
+    it('should return 401 when idToken validation fails', async () => {
+      const idToken = jwt.sign(
+        {
+          iss: issuer,
+          aud: 'wrong-audience',
+          sub: 'user123',
+        },
+        privateKey,
+        { algorithm: 'RS256', keyid: kid1, expiresIn: '1h' }
+      );
+
+      globalThis.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({ keys: [jwk1] }),
+      } as Response);
+
+      const res = await request(app)
+        .post('/api/auth/session')
+        .send({ idToken });
+
+      expect(res.status).toBe(401);
+      expect(res.body.error.code).toBe('UNAUTHORIZED');
+      expect(res.body.error.message).toContain('OIDC token validation failed');
+    });
+  });
+});


### PR DESCRIPTION
Added OIDC token exchange support to `POST /api/auth/session` alongside the existing shared-secret fallback path. This allows external Identity Providers (SSO) to authenticate users and issue Fluxora JWTs.
### Why it was done
To allow enterprise operators to use external Identity Providers (e.g. Keycloak, Auth0) for authentication within Fluxora, ensuring seamless integration with existing SSO infrastructures.
### How it was verified
1. Implemented unit and integration tests inside `tests/services/oidcProvider.test.ts` covering JWKS fetching, caching, signature/claims verification, route endpoint integration, and replay prevention.
2. Verified all tests passed successfully using `pnpm test`.
Closes #226