### PR TITLE
feat: publish OpenAPI 3.1 spec with examples for all routes (#217)

### DIFF
--- a/docs/openapi/README.md
+++ b/docs/openapi/README.md
@@ -1,0 +1,37 @@
+# OpenAPI 3.1 Specification
+
+## Endpoints
+
+| URL | Description |
+|-----|-------------|
+| `GET /openapi.json` | Machine-readable OpenAPI 3.1 document |
+| `GET /docs/` | Swagger UI (interactive browser) |
+
+## How the spec is generated
+
+The spec is built from Zod schemas at startup using [`@asteasolutions/zod-to-openapi`](https://github.com/asteasolutions/zod-to-openapi) (v8, Zod 4 compatible).
+
+- **Registry**: `src/openapi/spec.ts` — registers all schemas, security schemes, and route definitions.
+- **Route**: `src/routes/docs.ts` — serves `/openapi.json` and mounts Swagger UI at `/docs/`. The spec is built once and cached for the process lifetime.
+- **App mount**: `src/app.ts` — `docsRouter` is registered before the 404 handler.
+
+## Security schemes
+
+| Scheme | Type | Used by |
+|--------|------|---------|
+| `bearerAuth` | HTTP Bearer (JWT) | Stream write, audit, admin routes |
+| `indexerWorkerToken` | API key (`x-indexer-worker-token` header) | Internal indexer endpoints |
+
+## Adding a new route
+
+1. Register any new Zod schemas with `registry.register(...)` in `src/openapi/spec.ts`.
+2. Call `registry.registerPath(...)` with the route config.
+3. Run `pnpm test -- tests/routes/docs.test.ts` to verify the spec builds and the new path appears.
+
+## Running locally
+
+```bash
+pnpm dev
+# spec:  curl http://localhost:3000/openapi.json | jq .info
+# docs:  open http://localhost:3000/docs/
+```

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
+    "@asteasolutions/zod-to-openapi": "8.5.0",
     "@opentelemetry/api": "^1.9.0",
     "@opentelemetry/exporter-trace-otlp-http": "^0.57.2",
     "@opentelemetry/instrumentation-express": "^0.46.0",
@@ -34,6 +35,7 @@
     "node-pg-migrate": "^7.6.0",
     "pg": "^8.11.3",
     "prom-client": "^15.0.0",
+    "swagger-ui-express": "5.0.1",
     "ws": "^8.14.2",
     "zod": "^4.3.6"
   },
@@ -42,6 +44,7 @@
     "@types/jsonwebtoken": "^9.0.10",
     "@types/node": "^20.19.39",
     "@types/supertest": "^6.0.2",
+    "@types/swagger-ui-express": "4.1.8",
     "@types/ws": "^8.18.1",
     "@typescript-eslint/eslint-plugin": "^8.59.0",
     "@typescript-eslint/parser": "^8.59.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@asteasolutions/zod-to-openapi':
+        specifier: 8.5.0
+        version: 8.5.0(zod@4.3.6)
       '@opentelemetry/api':
         specifier: ^1.9.0
         version: 1.9.1
@@ -59,6 +62,9 @@ importers:
       prom-client:
         specifier: ^15.0.0
         version: 15.1.3
+      swagger-ui-express:
+        specifier: 5.0.1
+        version: 5.0.1(express@4.22.1)
       ws:
         specifier: ^8.14.2
         version: 8.20.0
@@ -78,6 +84,9 @@ importers:
       '@types/supertest':
         specifier: ^6.0.2
         version: 6.0.3
+      '@types/swagger-ui-express':
+        specifier: 4.1.8
+        version: 4.1.8
       '@types/ws':
         specifier: ^8.18.1
         version: 8.18.1
@@ -110,9 +119,14 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.5
-        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@20.19.39)(vite@8.0.10(@types/node@20.19.39)(esbuild@0.27.7)(tsx@4.21.0))
+        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@20.19.39)(vite@8.0.10(@types/node@20.19.39)(esbuild@0.27.7)(tsx@4.21.0)(yaml@2.9.0))
 
 packages:
+
+  '@asteasolutions/zod-to-openapi@8.5.0':
+    resolution: {integrity: sha512-SABbKiObg5dLRiTFnqiW1WWwGcg1BJfmHtT2asIBnBHg6Smy/Ms2KHc650+JI4Hw7lSkdiNebEGXpwoxfben8Q==}
+    peerDependencies:
+      zod: ^4.0.0
 
   '@babel/code-frame@7.29.0':
     resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
@@ -973,6 +987,9 @@ packages:
   '@rolldown/pluginutils@1.0.0-rc.17':
     resolution: {integrity: sha512-n8iosDOt6Ig1UhJ2AYqoIhHWh/isz0xpicHTzpKBeotdVsTEcxsSA/i3EVM7gQAj0rU27OLAxCjzlj15IWY7bg==}
 
+  '@scarf/scarf@1.4.0':
+    resolution: {integrity: sha512-xxeapPiUXdZAE3che6f3xogoJPeZgig6omHEy1rIY5WVsB3H2BHNnZH+gHG6x91SCWyQCzWGsuL2Hh3ClO5/qQ==}
+
   '@sinclair/typebox@0.27.10':
     resolution: {integrity: sha512-MTBk/3jGLNB2tVxv6uLlFh1iu64iYOQ2PbdOSK3NW8JZsmlaOh2q6sdtKowBhfw8QFLmYNzTW4/oK4uATIi6ZA==}
 
@@ -1092,6 +1109,9 @@ packages:
 
   '@types/supertest@6.0.3':
     resolution: {integrity: sha512-8WzXq62EXFhJ7QsH3Ocb/iKQ/Ty9ZVWnVzoTKc9tyyFRRF3a74Tk2+TLFgaFFw364Ere+npzHKEJ6ga2LzIL7w==}
+
+  '@types/swagger-ui-express@4.1.8':
+    resolution: {integrity: sha512-AhZV8/EIreHFmBV5wAs0gzJUNq9JbbSXgJLQubCC0jtIo6prnI9MIRRxnU4MZX9RB9yXxF1V4R7jtLl/Wcj31g==}
 
   '@types/ws@8.18.1':
     resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
@@ -2337,6 +2357,9 @@ packages:
     resolution: {integrity: sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==}
     engines: {node: '>=6'}
 
+  openapi3-ts@4.5.0:
+    resolution: {integrity: sha512-jaL+HgTq2Gj5jRcfdutgRGLosCy/hT8sQf6VOy+P+g36cZOjI1iukdPnijC+4CmeRzg/jEllJUboEic2FhxhtQ==}
+
   optionator@0.9.4:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
     engines: {node: '>= 0.8.0'}
@@ -2717,6 +2740,15 @@ packages:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
 
+  swagger-ui-dist@5.32.6:
+    resolution: {integrity: sha512-75ttZNaYCLoFPnozPZcTUU6mS3wKT8l7WLjU5zJSHFeJa23i5vtnze6IiCl4jDMPeQTXVXIgovq4M11NNfQvSA==}
+
+  swagger-ui-express@5.0.1:
+    resolution: {integrity: sha512-SrNU3RiBGTLLmFU8GIJdOdanJTl4TOmT27tt3bWWHppqYmAZ6IDuEuBvMU6nZq0zLEe6b/1rACXCgLZqO6ZfrA==}
+    engines: {node: '>= v0.10.32'}
+    peerDependencies:
+      express: '>=4.0.0 || >=5.0.0-beta'
+
   tdigest@0.1.2:
     resolution: {integrity: sha512-+G0LLgjjo9BZX2MfdvPfH+MKLCrxlXSYec5DaPYP1fe6Iyhf0/fSmJ0bFiZ1F8BT6cGXl2LpltQptzjXKWEkKA==}
 
@@ -2948,6 +2980,11 @@ packages:
   yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
 
+  yaml@2.9.0:
+    resolution: {integrity: sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==}
+    engines: {node: '>= 14.6'}
+    hasBin: true
+
   yargs-parser@21.1.1:
     resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}
     engines: {node: '>=12'}
@@ -2964,6 +3001,11 @@ packages:
     resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
 
 snapshots:
+
+  '@asteasolutions/zod-to-openapi@8.5.0(zod@4.3.6)':
+    dependencies:
+      openapi3-ts: 4.5.0
+      zod: 4.3.6
 
   '@babel/code-frame@7.29.0':
     dependencies:
@@ -3914,6 +3956,8 @@ snapshots:
 
   '@rolldown/pluginutils@1.0.0-rc.17': {}
 
+  '@scarf/scarf@1.4.0': {}
+
   '@sinclair/typebox@0.27.10': {}
 
   '@sinonjs/commons@3.0.1':
@@ -4066,6 +4110,11 @@ snapshots:
       '@types/methods': 1.1.4
       '@types/superagent': 8.1.9
 
+  '@types/swagger-ui-express@4.1.8':
+    dependencies:
+      '@types/express': 4.17.25
+      '@types/serve-static': 1.15.10
+
   '@types/ws@8.18.1':
     dependencies:
       '@types/node': 20.19.39
@@ -4176,13 +4225,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.5(vite@8.0.10(@types/node@20.19.39)(esbuild@0.27.7)(tsx@4.21.0))':
+  '@vitest/mocker@4.1.5(vite@8.0.10(@types/node@20.19.39)(esbuild@0.27.7)(tsx@4.21.0)(yaml@2.9.0))':
     dependencies:
       '@vitest/spy': 4.1.5
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 8.0.10(@types/node@20.19.39)(esbuild@0.27.7)(tsx@4.21.0)
+      vite: 8.0.10(@types/node@20.19.39)(esbuild@0.27.7)(tsx@4.21.0)(yaml@2.9.0)
 
   '@vitest/pretty-format@4.1.5':
     dependencies:
@@ -5539,6 +5588,10 @@ snapshots:
     dependencies:
       mimic-fn: 2.1.0
 
+  openapi3-ts@4.5.0:
+    dependencies:
+      yaml: 2.9.0
+
   optionator@0.9.4:
     dependencies:
       deep-is: 0.1.4
@@ -5935,6 +5988,15 @@ snapshots:
 
   supports-preserve-symlinks-flag@1.0.0: {}
 
+  swagger-ui-dist@5.32.6:
+    dependencies:
+      '@scarf/scarf': 1.4.0
+
+  swagger-ui-express@5.0.1(express@4.22.1):
+    dependencies:
+      express: 4.22.1
+      swagger-ui-dist: 5.32.6
+
   tdigest@0.1.2:
     dependencies:
       bintrees: 1.0.2
@@ -6017,7 +6079,7 @@ snapshots:
 
   vary@1.1.2: {}
 
-  vite@8.0.10(@types/node@20.19.39)(esbuild@0.27.7)(tsx@4.21.0):
+  vite@8.0.10(@types/node@20.19.39)(esbuild@0.27.7)(tsx@4.21.0)(yaml@2.9.0):
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.4
@@ -6029,11 +6091,12 @@ snapshots:
       esbuild: 0.27.7
       fsevents: 2.3.3
       tsx: 4.21.0
+      yaml: 2.9.0
 
-  vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@20.19.39)(vite@8.0.10(@types/node@20.19.39)(esbuild@0.27.7)(tsx@4.21.0)):
+  vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@20.19.39)(vite@8.0.10(@types/node@20.19.39)(esbuild@0.27.7)(tsx@4.21.0)(yaml@2.9.0)):
     dependencies:
       '@vitest/expect': 4.1.5
-      '@vitest/mocker': 4.1.5(vite@8.0.10(@types/node@20.19.39)(esbuild@0.27.7)(tsx@4.21.0))
+      '@vitest/mocker': 4.1.5(vite@8.0.10(@types/node@20.19.39)(esbuild@0.27.7)(tsx@4.21.0)(yaml@2.9.0))
       '@vitest/pretty-format': 4.1.5
       '@vitest/runner': 4.1.5
       '@vitest/snapshot': 4.1.5
@@ -6050,7 +6113,7 @@ snapshots:
       tinyexec: 1.1.1
       tinyglobby: 0.2.16
       tinyrainbow: 3.1.0
-      vite: 8.0.10(@types/node@20.19.39)(esbuild@0.27.7)(tsx@4.21.0)
+      vite: 8.0.10(@types/node@20.19.39)(esbuild@0.27.7)(tsx@4.21.0)(yaml@2.9.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@opentelemetry/api': 1.9.1
@@ -6093,6 +6156,8 @@ snapshots:
   y18n@5.0.8: {}
 
   yallist@3.1.1: {}
+
+  yaml@2.9.0: {}
 
   yargs-parser@21.1.1: {}
 

--- a/src/app.ts
+++ b/src/app.ts
@@ -25,6 +25,7 @@ import { createRateLimiter } from './middleware/rateLimiter.js';
 import { createRateLimitsRouter } from './routes/rateLimits.js';
 import { getRateLimitConfig } from './config/rateLimits.js';
 import { successResponse, errorResponse } from './utils/response.js';
+import { docsRouter } from './routes/docs.js';
 
 export interface AppOptions {
   /** When true, mounts a /__test/error and /__test/timeout route. */
@@ -82,6 +83,9 @@ export function createApp(options: AppOptions = {}): Express {
 
   // Metrics endpoint - no auth required for Prometheus scraping
   app.use('/metrics', metricsRouter);
+
+  // OpenAPI spec and Swagger UI — no auth required
+  app.use(docsRouter);
 
   app.use('/health', healthRouter);
   app.use('/api/auth', authRouter);

--- a/src/openapi/spec.ts
+++ b/src/openapi/spec.ts
@@ -1,0 +1,782 @@
+/**
+ * OpenAPI 3.1 spec builder for Fluxora Backend.
+ * Generates the spec from zod schemas using @asteasolutions/zod-to-openapi.
+ * @module openapi/spec
+ */
+import { z } from 'zod';
+import {
+  OpenAPIRegistry,
+  OpenApiGeneratorV31,
+  extendZodWithOpenApi,
+} from '@asteasolutions/zod-to-openapi';
+
+extendZodWithOpenApi(z);
+
+export const registry = new OpenAPIRegistry();
+
+// ── Shared schemas ────────────────────────────────────────────────────────────
+
+const DecimalString = registry.register(
+  'DecimalString',
+  z.string().openapi({ example: '1000000.0000000', description: 'Decimal string amount' }),
+);
+
+const StellarAddress = registry.register(
+  'StellarAddress',
+  z.string().openapi({ example: 'GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN', description: 'Stellar public key (G…)' }),
+);
+
+const StreamStatus = registry.register(
+  'StreamStatus',
+  z.enum(['scheduled', 'active', 'paused', 'completed', 'cancelled']).openapi({ example: 'active' }),
+);
+
+const StreamObject = registry.register(
+  'Stream',
+  z.object({
+    id: z.string().openapi({ example: 'stream-abc123' }),
+    sender: StellarAddress,
+    recipient: StellarAddress,
+    depositAmount: DecimalString,
+    ratePerSecond: DecimalString,
+    startTime: z.number().int().openapi({ example: 1700000000 }),
+    endTime: z.number().int().openapi({ example: 0 }),
+    status: StreamStatus,
+  }).openapi({ description: 'A treasury stream record' }),
+);
+
+const ResponseMeta = registry.register(
+  'ResponseMeta',
+  z.object({
+    timestamp: z.string().openapi({ example: '2026-01-01T00:00:00.000Z' }),
+    requestId: z.string().optional().openapi({ example: 'req_abc123' }),
+    idempotencyReplayed: z.boolean().optional(),
+  }),
+);
+
+const ErrorEnvelope = registry.register(
+  'ErrorEnvelope',
+  z.object({
+    success: z.literal(false),
+    error: z.object({
+      code: z.string().openapi({ example: 'VALIDATION_ERROR' }),
+      message: z.string().openapi({ example: 'Validation failed' }),
+      details: z.unknown().optional(),
+      requestId: z.string().optional(),
+    }),
+  }),
+);
+
+// ── Security schemes ──────────────────────────────────────────────────────────
+
+registry.registerComponent('securitySchemes', 'bearerAuth', {
+  type: 'http',
+  scheme: 'bearer',
+  bearerFormat: 'JWT',
+  description: 'JWT issued by POST /api/auth/session',
+});
+
+registry.registerComponent('securitySchemes', 'indexerWorkerToken', {
+  type: 'apiKey',
+  in: 'header',
+  name: 'x-indexer-worker-token',
+  description: 'Static shared secret for internal indexer worker endpoints',
+});
+
+// ── Reusable response helpers ─────────────────────────────────────────────────
+
+function successSchema<T extends z.ZodTypeAny>(dataSchema: T) {
+  return z.object({ success: z.literal(true), data: dataSchema, meta: ResponseMeta });
+}
+
+const errorResponses = {
+  '400': { description: 'Validation error', content: { 'application/json': { schema: ErrorEnvelope } } },
+  '401': { description: 'Unauthorized', content: { 'application/json': { schema: ErrorEnvelope } } },
+  '403': { description: 'Forbidden', content: { 'application/json': { schema: ErrorEnvelope } } },
+  '404': { description: 'Not found', content: { 'application/json': { schema: ErrorEnvelope } } },
+  '409': { description: 'Conflict', content: { 'application/json': { schema: ErrorEnvelope } } },
+  '422': { description: 'Unprocessable entity', content: { 'application/json': { schema: ErrorEnvelope } } },
+  '429': { description: 'Too many requests', content: { 'application/json': { schema: ErrorEnvelope } } },
+  '500': { description: 'Internal server error', content: { 'application/json': { schema: ErrorEnvelope } } },
+  '503': { description: 'Service unavailable', content: { 'application/json': { schema: ErrorEnvelope } } },
+} as const;
+
+// ── GET / ─────────────────────────────────────────────────────────────────────
+
+registry.registerPath({
+  method: 'get', path: '/',
+  summary: 'API info',
+  tags: ['meta'],
+  responses: {
+    '200': {
+      description: 'API metadata',
+      content: { 'application/json': { schema: successSchema(z.object({ name: z.string(), version: z.string(), docs: z.string() })) } },
+    },
+  },
+});
+
+// ── Health ────────────────────────────────────────────────────────────────────
+
+registry.registerPath({
+  method: 'get', path: '/health',
+  summary: 'Liveness probe',
+  tags: ['health'],
+  responses: {
+    '200': {
+      description: 'Service status',
+      content: {
+        'application/json': {
+          schema: z.object({
+            status: z.enum(['ok', 'degraded', 'shutting_down']),
+            service: z.string(),
+            network: z.string(),
+            timestamp: z.string(),
+          }),
+          example: { status: 'ok', service: 'fluxora-backend', network: 'testnet', timestamp: '2026-01-01T00:00:00.000Z' },
+        },
+      },
+    },
+    '503': errorResponses['503'],
+  },
+});
+
+registry.registerPath({
+  method: 'get', path: '/health/ready',
+  summary: 'Readiness probe',
+  tags: ['health'],
+  responses: {
+    '200': {
+      description: 'All dependencies healthy or degraded',
+      content: { 'application/json': { schema: z.object({ status: z.enum(['healthy', 'degraded']), version: z.string(), dependencies: z.record(z.string(), z.string()) }) } },
+    },
+    '503': { description: 'One or more dependencies unhealthy', content: { 'application/json': { schema: ErrorEnvelope } } },
+  },
+});
+
+registry.registerPath({
+  method: 'get', path: '/health/live',
+  summary: 'Detailed health report',
+  tags: ['health'],
+  responses: {
+    '200': {
+      description: 'Full health report',
+      content: { 'application/json': { schema: successSchema(z.object({ report: z.record(z.string(), z.unknown()) })) } },
+    },
+    '500': errorResponses['500'],
+  },
+});
+
+// ── Streams ───────────────────────────────────────────────────────────────────
+
+registry.registerPath({
+  method: 'get', path: '/api/streams',
+  summary: 'List streams',
+  tags: ['streams'],
+  request: {
+    query: z.object({
+      limit: z.string().optional().openapi({ example: '20', description: 'Page size (1–100)' }),
+      cursor: z.string().optional().openapi({ description: 'Opaque pagination cursor' }),
+      status: z.string().optional().openapi({ example: 'active' }),
+      sender: z.string().optional(),
+      recipient: z.string().optional(),
+      include_total: z.enum(['true', 'false']).optional(),
+    }),
+  },
+  responses: {
+    '200': {
+      description: 'Paginated stream list',
+      content: {
+        'application/json': {
+          schema: successSchema(z.object({
+            streams: z.array(StreamObject),
+            has_more: z.boolean(),
+            next_cursor: z.string().nullable(),
+            total: z.number().int().optional(),
+          })),
+          example: { success: true, data: { streams: [], has_more: false, next_cursor: null }, meta: { timestamp: '2026-01-01T00:00:00.000Z' } },
+        },
+      },
+    },
+    '400': errorResponses['400'],
+    '503': errorResponses['503'],
+  },
+});
+
+registry.registerPath({
+  method: 'get', path: '/api/streams/{id}',
+  summary: 'Get stream by ID',
+  tags: ['streams'],
+  request: { params: z.object({ id: z.string().openapi({ example: 'stream-abc123' }) }) },
+  responses: {
+    '200': {
+      description: 'Stream record',
+      content: { 'application/json': { schema: successSchema(z.object({ stream: StreamObject })) } },
+    },
+    '404': errorResponses['404'],
+    '503': errorResponses['503'],
+  },
+});
+
+registry.registerPath({
+  method: 'post', path: '/api/streams',
+  summary: 'Create stream',
+  tags: ['streams'],
+  security: [{ bearerAuth: [] }],
+  request: {
+    headers: z.object({ 'Idempotency-Key': z.string().openapi({ description: 'Unique key (1–128 chars) to prevent duplicate creation', example: 'my-key-001' }) }),
+    body: {
+      required: true,
+      content: {
+        'application/json': {
+          schema: z.object({
+            sender: StellarAddress,
+            recipient: StellarAddress,
+            depositAmount: DecimalString,
+            ratePerSecond: DecimalString,
+            startTime: z.number().int().optional().openapi({ example: 1700000000 }),
+            endTime: z.number().int().optional().openapi({ example: 0 }),
+          }),
+          example: {
+            sender: 'GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN',
+            recipient: 'GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGZCP2J7F1NRQKQOHP3OGN',
+            depositAmount: '1000000.0000000',
+            ratePerSecond: '0.0000116',
+            startTime: 1700000000,
+          },
+        },
+      },
+    },
+  },
+  responses: {
+    '201': {
+      description: 'Stream created',
+      content: { 'application/json': { schema: successSchema(StreamObject) } },
+    },
+    '400': errorResponses['400'],
+    '401': errorResponses['401'],
+    '409': errorResponses['409'],
+    '503': errorResponses['503'],
+  },
+});
+
+registry.registerPath({
+  method: 'delete', path: '/api/streams/{id}',
+  summary: 'Cancel stream',
+  tags: ['streams'],
+  security: [{ bearerAuth: [] }],
+  request: { params: z.object({ id: z.string().openapi({ example: 'stream-abc123' }) }) },
+  responses: {
+    '200': {
+      description: 'Stream cancelled',
+      content: { 'application/json': { schema: successSchema(z.object({ message: z.string(), id: z.string() })) } },
+    },
+    '401': errorResponses['401'],
+    '404': errorResponses['404'],
+    '409': errorResponses['409'],
+    '503': errorResponses['503'],
+  },
+});
+
+registry.registerPath({
+  method: 'patch', path: '/api/streams/{id}/status',
+  summary: 'Transition stream status',
+  tags: ['streams'],
+  request: {
+    params: z.object({ id: z.string().openapi({ example: 'stream-abc123' }) }),
+    body: {
+      required: true,
+      content: {
+        'application/json': {
+          schema: z.object({ status: StreamStatus }),
+          example: { status: 'paused' },
+        },
+      },
+    },
+  },
+  responses: {
+    '200': { description: 'Updated stream', content: { 'application/json': { schema: successSchema(StreamObject) } } },
+    '400': errorResponses['400'],
+    '404': errorResponses['404'],
+    '409': errorResponses['409'],
+    '503': errorResponses['503'],
+  },
+});
+
+// ── Auth ──────────────────────────────────────────────────────────────────────
+
+registry.registerPath({
+  method: 'post', path: '/api/auth/session',
+  summary: 'Create session (get JWT)',
+  tags: ['auth'],
+  request: {
+    body: {
+      required: true,
+      content: {
+        'application/json': {
+          schema: z.object({
+            address: z.string().optional().openapi({ example: 'GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN' }),
+            role: z.enum(['operator', 'viewer']).optional().openapi({ example: 'viewer' }),
+            idToken: z.string().optional().openapi({ description: 'External OIDC ID token' }),
+          }),
+        },
+      },
+    },
+  },
+  responses: {
+    '200': {
+      description: 'JWT issued',
+      content: {
+        'application/json': {
+          schema: z.object({ token: z.string(), user: z.object({ address: z.string(), role: z.string() }) }),
+          example: { token: 'eyJ...', user: { address: 'GAAZI4...', role: 'viewer' } },
+        },
+      },
+    },
+    '400': errorResponses['400'],
+    '401': errorResponses['401'],
+  },
+});
+
+// ── Audit ─────────────────────────────────────────────────────────────────────
+
+registry.registerPath({
+  method: 'get', path: '/api/audit',
+  summary: 'List audit log entries',
+  tags: ['audit'],
+  security: [{ bearerAuth: [] }],
+  responses: {
+    '200': {
+      description: 'Audit entries',
+      content: {
+        'application/json': {
+          schema: successSchema(z.object({
+            entries: z.array(z.record(z.string(), z.unknown())),
+            total: z.number().int(),
+          })),
+        },
+      },
+    },
+    '401': errorResponses['401'],
+    '403': errorResponses['403'],
+  },
+});
+
+// ── Privacy ───────────────────────────────────────────────────────────────────
+
+registry.registerPath({
+  method: 'get', path: '/api/privacy/policy',
+  summary: 'PII policy document',
+  tags: ['privacy'],
+  responses: {
+    '200': { description: 'Full PII policy', content: { 'application/json': { schema: z.record(z.string(), z.unknown()) } } },
+  },
+});
+
+registry.registerPath({
+  method: 'get', path: '/api/privacy/retention',
+  summary: 'Data retention schedule',
+  tags: ['privacy'],
+  responses: {
+    '200': { description: 'Retention schedule', content: { 'application/json': { schema: z.record(z.string(), z.unknown()) } } },
+  },
+});
+
+// ── Admin ─────────────────────────────────────────────────────────────────────
+
+registry.registerPath({
+  method: 'get', path: '/api/admin/status/read-only',
+  summary: 'Read pause flags (no auth)',
+  tags: ['admin'],
+  responses: {
+    '200': { description: 'Pause flags', content: { 'application/json': { schema: z.object({ pauseFlags: z.record(z.string(), z.boolean()) }) } } },
+  },
+});
+
+registry.registerPath({
+  method: 'get', path: '/api/admin/status',
+  summary: 'Admin status (pause flags + reindex state)',
+  tags: ['admin'],
+  security: [{ bearerAuth: [] }],
+  responses: {
+    '200': { description: 'Admin status', content: { 'application/json': { schema: z.object({ pauseFlags: z.record(z.string(), z.boolean()), reindex: z.record(z.string(), z.unknown()) }) } } },
+    '401': errorResponses['401'],
+  },
+});
+
+registry.registerPath({
+  method: 'get', path: '/api/admin/pause',
+  summary: 'Get pause flags',
+  tags: ['admin'],
+  security: [{ bearerAuth: [] }],
+  responses: {
+    '200': { description: 'Pause flags', content: { 'application/json': { schema: z.record(z.string(), z.boolean()) } } },
+    '401': errorResponses['401'],
+  },
+});
+
+registry.registerPath({
+  method: 'put', path: '/api/admin/pause',
+  summary: 'Update pause flags',
+  tags: ['admin'],
+  security: [{ bearerAuth: [] }],
+  request: {
+    body: {
+      required: true,
+      content: {
+        'application/json': {
+          schema: z.object({
+            streamCreation: z.boolean().optional(),
+            ingestion: z.boolean().optional(),
+          }),
+          example: { streamCreation: true, ingestion: false },
+        },
+      },
+    },
+  },
+  responses: {
+    '200': { description: 'Updated pause flags', content: { 'application/json': { schema: z.object({ message: z.string(), pauseFlags: z.record(z.string(), z.boolean()) }) } } },
+    '400': errorResponses['400'],
+    '401': errorResponses['401'],
+    '503': errorResponses['503'],
+  },
+});
+
+registry.registerPath({
+  method: 'get', path: '/api/admin/reindex',
+  summary: 'Get reindex state',
+  tags: ['admin'],
+  security: [{ bearerAuth: [] }],
+  responses: {
+    '200': { description: 'Reindex state', content: { 'application/json': { schema: z.record(z.string(), z.unknown()) } } },
+    '401': errorResponses['401'],
+  },
+});
+
+registry.registerPath({
+  method: 'post', path: '/api/admin/reindex',
+  summary: 'Trigger reindex',
+  tags: ['admin'],
+  security: [{ bearerAuth: [] }],
+  responses: {
+    '202': { description: 'Reindex started', content: { 'application/json': { schema: z.object({ message: z.string(), reindex: z.record(z.string(), z.unknown()) }) } } },
+    '401': errorResponses['401'],
+    '409': errorResponses['409'],
+  },
+});
+
+registry.registerPath({
+  method: 'get', path: '/api/admin/api-keys',
+  summary: 'List API keys (hashes only)',
+  tags: ['admin'],
+  security: [{ bearerAuth: [] }],
+  responses: {
+    '200': { description: 'API key list', content: { 'application/json': { schema: z.object({ apiKeys: z.array(z.record(z.string(), z.unknown())) }) } } },
+    '401': errorResponses['401'],
+  },
+});
+
+registry.registerPath({
+  method: 'post', path: '/api/admin/api-keys',
+  summary: 'Create API key',
+  tags: ['admin'],
+  security: [{ bearerAuth: [] }],
+  request: {
+    body: { required: true, content: { 'application/json': { schema: z.object({ name: z.string().openapi({ example: 'my-service' }) }) } } },
+  },
+  responses: {
+    '201': { description: 'API key created (raw key returned once)', content: { 'application/json': { schema: z.record(z.string(), z.unknown()) } } },
+    '400': errorResponses['400'],
+    '401': errorResponses['401'],
+  },
+});
+
+registry.registerPath({
+  method: 'post', path: '/api/admin/api-keys/{id}/rotate',
+  summary: 'Rotate API key',
+  tags: ['admin'],
+  security: [{ bearerAuth: [] }],
+  request: { params: z.object({ id: z.string() }) },
+  responses: {
+    '200': { description: 'New raw key returned once', content: { 'application/json': { schema: z.record(z.string(), z.unknown()) } } },
+    '401': errorResponses['401'],
+    '404': errorResponses['404'],
+  },
+});
+
+registry.registerPath({
+  method: 'delete', path: '/api/admin/api-keys/{id}',
+  summary: 'Revoke API key',
+  tags: ['admin'],
+  security: [{ bearerAuth: [] }],
+  request: { params: z.object({ id: z.string() }) },
+  responses: {
+    '204': { description: 'Key revoked' },
+    '401': errorResponses['401'],
+    '404': errorResponses['404'],
+  },
+});
+
+// ── DLQ ───────────────────────────────────────────────────────────────────────
+
+registry.registerPath({
+  method: 'get', path: '/admin/dlq',
+  summary: 'List dead-letter queue entries',
+  tags: ['admin'],
+  security: [{ bearerAuth: [] }],
+  request: {
+    query: z.object({
+      limit: z.string().optional().openapi({ example: '50' }),
+      offset: z.string().optional().openapi({ example: '0' }),
+      topic: z.string().optional(),
+    }),
+  },
+  responses: {
+    '200': { description: 'DLQ entries', content: { 'application/json': { schema: z.record(z.string(), z.unknown()) } } },
+    '400': errorResponses['400'],
+    '401': errorResponses['401'],
+    '403': errorResponses['403'],
+  },
+});
+
+registry.registerPath({
+  method: 'get', path: '/admin/dlq/{id}',
+  summary: 'Get DLQ entry',
+  tags: ['admin'],
+  security: [{ bearerAuth: [] }],
+  request: { params: z.object({ id: z.string() }) },
+  responses: {
+    '200': { description: 'DLQ entry', content: { 'application/json': { schema: z.record(z.string(), z.unknown()) } } },
+    '401': errorResponses['401'],
+    '403': errorResponses['403'],
+    '404': errorResponses['404'],
+  },
+});
+
+registry.registerPath({
+  method: 'delete', path: '/admin/dlq/{id}',
+  summary: 'Delete DLQ entry',
+  tags: ['admin'],
+  security: [{ bearerAuth: [] }],
+  request: { params: z.object({ id: z.string() }) },
+  responses: {
+    '200': { description: 'Entry deleted', content: { 'application/json': { schema: z.record(z.string(), z.unknown()) } } },
+    '401': errorResponses['401'],
+    '403': errorResponses['403'],
+    '404': errorResponses['404'],
+  },
+});
+
+registry.registerPath({
+  method: 'post', path: '/admin/dlq/{id}/retry',
+  summary: 'Retry DLQ entry',
+  tags: ['admin'],
+  security: [{ bearerAuth: [] }],
+  request: { params: z.object({ id: z.string() }) },
+  responses: {
+    '200': { description: 'Retry queued', content: { 'application/json': { schema: z.record(z.string(), z.unknown()) } } },
+    '401': errorResponses['401'],
+    '403': errorResponses['403'],
+    '404': errorResponses['404'],
+  },
+});
+
+// ── Rate limits ───────────────────────────────────────────────────────────────
+
+registry.registerPath({
+  method: 'get', path: '/api/rate-limits',
+  summary: "Caller's current rate-limit status",
+  tags: ['rate-limits'],
+  responses: {
+    '200': { description: 'Rate-limit status', content: { 'application/json': { schema: z.record(z.string(), z.unknown()) } } },
+  },
+});
+
+registry.registerPath({
+  method: 'get', path: '/api/rate-limits/config',
+  summary: 'Active rate-limit config (admin)',
+  tags: ['rate-limits'],
+  security: [{ bearerAuth: [] }],
+  responses: {
+    '200': { description: 'Rate-limit config', content: { 'application/json': { schema: z.record(z.string(), z.unknown()) } } },
+    '401': errorResponses['401'],
+  },
+});
+
+registry.registerPath({
+  method: 'put', path: '/api/rate-limits/config',
+  summary: 'Update rate-limit config (admin)',
+  tags: ['rate-limits'],
+  security: [{ bearerAuth: [] }],
+  request: {
+    body: {
+      required: true,
+      content: {
+        'application/json': {
+          schema: z.object({
+            ip: z.object({ windowMs: z.number().optional(), max: z.number().optional(), enabled: z.boolean().optional() }).optional(),
+            apiKey: z.object({ windowMs: z.number().optional(), max: z.number().optional(), enabled: z.boolean().optional() }).optional(),
+            admin: z.object({ windowMs: z.number().optional(), max: z.number().optional(), enabled: z.boolean().optional() }).optional(),
+          }),
+          example: { ip: { max: 200 } },
+        },
+      },
+    },
+  },
+  responses: {
+    '200': { description: 'Updated config', content: { 'application/json': { schema: z.record(z.string(), z.unknown()) } } },
+    '400': errorResponses['400'],
+    '401': errorResponses['401'],
+    '409': errorResponses['409'],
+  },
+});
+
+// ── Internal indexer ──────────────────────────────────────────────────────────
+
+registry.registerPath({
+  method: 'post', path: '/internal/indexer/contract-events',
+  summary: 'Ingest contract event batch',
+  tags: ['indexer'],
+  security: [{ indexerWorkerToken: [] }],
+  request: {
+    body: {
+      required: true,
+      content: {
+        'application/json': {
+          schema: z.object({ events: z.array(z.record(z.string(), z.unknown())).max(100) }),
+          example: { events: [{ eventId: 'evt-001', ledger: 1000, contractId: 'C...', topic: 'stream.created', payload: {} }] },
+        },
+      },
+    },
+  },
+  responses: {
+    '200': { description: 'Batch persisted', content: { 'application/json': { schema: successSchema(z.object({ outcome: z.string(), insertedCount: z.number(), duplicateCount: z.number(), insertedEventIds: z.array(z.string()), duplicateEventIds: z.array(z.string()) })) } } },
+    '401': errorResponses['401'],
+    '409': errorResponses['409'],
+    '413': { description: 'Payload too large', content: { 'application/json': { schema: ErrorEnvelope } } },
+    '429': errorResponses['429'],
+    '503': errorResponses['503'],
+  },
+});
+
+registry.registerPath({
+  method: 'get', path: '/internal/indexer/events',
+  summary: 'List stored contract events',
+  tags: ['indexer'],
+  security: [{ indexerWorkerToken: [] }],
+  request: {
+    query: z.object({
+      fromLedger: z.string().optional(),
+      toledger: z.string().optional(),
+      contractId: z.string().optional(),
+      topic: z.string().optional(),
+      limit: z.string().optional().openapi({ example: '100' }),
+      offset: z.string().optional().openapi({ example: '0' }),
+    }),
+  },
+  responses: {
+    '200': { description: 'Event list', content: { 'application/json': { schema: successSchema(z.record(z.string(), z.unknown())) } } },
+    '401': errorResponses['401'],
+  },
+});
+
+registry.registerPath({
+  method: 'get', path: '/internal/indexer/events/replay',
+  summary: 'Cursor-based event replay',
+  tags: ['indexer'],
+  security: [{ indexerWorkerToken: [] }],
+  request: {
+    query: z.object({
+      afterEventId: z.string().optional().openapi({ description: 'Exclusive cursor; omit to start from beginning' }),
+      fromLedger: z.string().optional(),
+      toledger: z.string().optional(),
+      contractId: z.string().optional(),
+      topic: z.string().optional(),
+      limit: z.string().optional().openapi({ example: '100' }),
+    }),
+  },
+  responses: {
+    '200': { description: 'Cursor-paginated event page', content: { 'application/json': { schema: successSchema(z.record(z.string(), z.unknown())) } } },
+    '401': errorResponses['401'],
+  },
+});
+
+// ── Webhooks ──────────────────────────────────────────────────────────────────
+
+registry.registerPath({
+  method: 'post', path: '/internal/webhooks/receive',
+  summary: 'Receive and verify an inbound Fluxora webhook',
+  tags: ['webhooks'],
+  request: {
+    headers: z.object({
+      'x-fluxora-delivery-id': z.string().openapi({ description: 'Stable delivery ID for deduplication' }),
+      'x-fluxora-timestamp': z.string().openapi({ description: 'Unix timestamp in seconds' }),
+      'x-fluxora-signature': z.string().openapi({ description: 'HMAC-SHA256 hex signature' }),
+      'x-fluxora-event': z.string().optional().openapi({ example: 'stream.created' }),
+    }),
+    body: { required: true, content: { 'application/json': { schema: z.record(z.string(), z.unknown()) } } },
+  },
+  responses: {
+    '200': { description: 'Webhook verified and accepted', content: { 'application/json': { schema: z.object({ ok: z.literal(true), deliveryId: z.string(), eventType: z.string().nullable(), event: z.unknown() }) } } },
+    '400': errorResponses['400'],
+    '401': errorResponses['401'],
+    '413': { description: 'Payload too large', content: { 'application/json': { schema: ErrorEnvelope } } },
+  },
+});
+
+registry.registerPath({
+  method: 'post', path: '/internal/webhooks/queue',
+  summary: 'Queue a webhook delivery',
+  tags: ['webhooks'],
+  request: { body: { required: true, content: { 'application/json': { schema: z.record(z.string(), z.unknown()) } } } },
+  responses: {
+    '200': { description: 'Queued', content: { 'application/json': { schema: z.record(z.string(), z.unknown()) } } },
+    '400': errorResponses['400'],
+  },
+});
+
+// ── Metrics ───────────────────────────────────────────────────────────────────
+
+registry.registerPath({
+  method: 'get', path: '/metrics',
+  summary: 'Prometheus metrics',
+  tags: ['observability'],
+  responses: {
+    '200': { description: 'Prometheus text format', content: { 'text/plain': { schema: z.string() } } },
+  },
+});
+
+// ── Generator ─────────────────────────────────────────────────────────────────
+
+/**
+ * Build and return the complete OpenAPI 3.1 document.
+ * Called once at startup; the result is cached by the docs route.
+ */
+export function buildOpenApiSpec(): Record<string, unknown> {
+  const generator = new OpenApiGeneratorV31(registry.definitions);
+  return generator.generateDocument({
+    openapi: '3.1.0',
+    info: {
+      title: 'Fluxora Backend API',
+      version: '0.1.0',
+      description:
+        'REST API for the Fluxora treasury streaming protocol on Stellar. ' +
+        'Covers stream CRUD, health, admin, indexer ingestion, webhook delivery, and observability.',
+      contact: { name: 'Fluxora Engineering', url: 'https://github.com/Fluxora-Org/Fluxora-Backend' },
+      license: { name: 'MIT' },
+    },
+    servers: [{ url: 'http://localhost:3000', description: 'Local development' }],
+    tags: [
+      { name: 'meta', description: 'API metadata' },
+      { name: 'health', description: 'Liveness and readiness probes' },
+      { name: 'streams', description: 'Treasury stream CRUD' },
+      { name: 'auth', description: 'Session / JWT issuance' },
+      { name: 'audit', description: 'Audit log' },
+      { name: 'privacy', description: 'PII policy and retention' },
+      { name: 'admin', description: 'Admin operations (pause, reindex, API keys, DLQ)' },
+      { name: 'rate-limits', description: 'Rate-limit status and config' },
+      { name: 'indexer', description: 'Internal indexer worker endpoints' },
+      { name: 'webhooks', description: 'Webhook receive and queue' },
+      { name: 'observability', description: 'Metrics' },
+    ],
+  }) as unknown as Record<string, unknown>;
+}

--- a/src/routes/docs.ts
+++ b/src/routes/docs.ts
@@ -1,0 +1,49 @@
+/**
+ * Docs routes — serves the OpenAPI 3.1 spec and Swagger UI.
+ *
+ * GET /openapi.json  — machine-readable spec (JSON)
+ * GET /docs          — Swagger UI (HTML)
+ *
+ * The spec is built once on first request and cached for the process lifetime.
+ * No authentication is required; the spec itself contains no secrets.
+ *
+ * @module routes/docs
+ */
+import { Router } from 'express';
+import type { Request, Response } from 'express';
+import swaggerUi from 'swagger-ui-express';
+import { buildOpenApiSpec } from '../openapi/spec.js';
+
+export const docsRouter = Router();
+
+// Build once, cache for process lifetime.
+let cachedSpec: Record<string, unknown> | null = null;
+
+function getSpec(): Record<string, unknown> {
+  if (!cachedSpec) {
+    cachedSpec = buildOpenApiSpec();
+  }
+  return cachedSpec;
+}
+
+/** GET /openapi.json — raw OpenAPI 3.1 document */
+docsRouter.get('/openapi.json', (_req: Request, res: Response) => {
+  res.setHeader('Content-Type', 'application/json');
+  res.setHeader('Cache-Control', 'public, max-age=300');
+  res.json(getSpec());
+});
+
+/** GET /docs — Swagger UI */
+docsRouter.use(
+  '/docs',
+  swaggerUi.serve,
+  swaggerUi.setup(undefined, {
+    swaggerOptions: { url: '/openapi.json' },
+    customSiteTitle: 'Fluxora API Docs',
+  }),
+);
+
+/** Expose cache-busting helper for tests */
+export function resetSpecCache(): void {
+  cachedSpec = null;
+}

--- a/src/webhooks/retry.ts
+++ b/src/webhooks/retry.ts
@@ -96,13 +96,6 @@ export function applyJitter(delayMs: number, policy: EnhancedRetryPolicy): numbe
   }
 }
 
-exports.shouldRetry = shouldRetry;
-exports.isRetryableStatusCode = isRetryableStatusCode;
-exports.calculateNextRetryTime = calculateNextRetryTime;
-exports.scheduleWebhookOutboxRetry = scheduleWebhookOutboxRetry;
-exports.generateRetrySchedule = generateRetrySchedule;
-exports.formatRetryPolicy = formatRetryPolicy;
-exports.validateRetryPolicy = validateRetryPolicy;
 
 
 /**

--- a/tests/routes/docs.test.ts
+++ b/tests/routes/docs.test.ts
@@ -1,0 +1,183 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import request from 'supertest';
+import { app } from '../../src/app.js';
+import { resetSpecCache } from '../../src/routes/docs.js';
+
+beforeEach(() => {
+  resetSpecCache();
+});
+
+describe('GET /openapi.json', () => {
+  it('returns 200 with JSON content-type', async () => {
+    const res = await request(app).get('/openapi.json');
+    expect(res.status).toBe(200);
+    expect(res.headers['content-type']).toMatch(/application\/json/);
+  });
+
+  it('returns a valid OpenAPI 3.1 document', async () => {
+    const res = await request(app).get('/openapi.json');
+    expect(res.body.openapi).toBe('3.1.0');
+    expect(res.body.info.title).toBe('Fluxora Backend API');
+    expect(res.body.info.version).toBe('0.1.0');
+  });
+
+  it('includes paths object', async () => {
+    const res = await request(app).get('/openapi.json');
+    expect(res.body.paths).toBeDefined();
+    expect(typeof res.body.paths).toBe('object');
+  });
+
+  it('includes security schemes', async () => {
+    const res = await request(app).get('/openapi.json');
+    const schemes = res.body.components?.securitySchemes;
+    expect(schemes).toBeDefined();
+    expect(schemes.bearerAuth).toBeDefined();
+    expect(schemes.bearerAuth.type).toBe('http');
+    expect(schemes.bearerAuth.scheme).toBe('bearer');
+    expect(schemes.indexerWorkerToken).toBeDefined();
+    expect(schemes.indexerWorkerToken.type).toBe('apiKey');
+  });
+
+  it('covers all stream routes', async () => {
+    const res = await request(app).get('/openapi.json');
+    const paths = res.body.paths as Record<string, unknown>;
+    expect(paths['/api/streams']).toBeDefined();
+    expect(paths['/api/streams/{id}']).toBeDefined();
+  });
+
+  it('covers health routes', async () => {
+    const res = await request(app).get('/openapi.json');
+    const paths = res.body.paths as Record<string, unknown>;
+    expect(paths['/health']).toBeDefined();
+    expect(paths['/health/ready']).toBeDefined();
+    expect(paths['/health/live']).toBeDefined();
+  });
+
+  it('covers auth route', async () => {
+    const res = await request(app).get('/openapi.json');
+    expect(res.body.paths['/api/auth/session']).toBeDefined();
+  });
+
+  it('covers admin routes', async () => {
+    const res = await request(app).get('/openapi.json');
+    const paths = res.body.paths as Record<string, unknown>;
+    expect(paths['/api/admin/status']).toBeDefined();
+    expect(paths['/api/admin/pause']).toBeDefined();
+    expect(paths['/api/admin/reindex']).toBeDefined();
+    expect(paths['/api/admin/api-keys']).toBeDefined();
+  });
+
+  it('covers DLQ routes', async () => {
+    const res = await request(app).get('/openapi.json');
+    const paths = res.body.paths as Record<string, unknown>;
+    expect(paths['/admin/dlq']).toBeDefined();
+    expect(paths['/admin/dlq/{id}']).toBeDefined();
+  });
+
+  it('covers indexer routes', async () => {
+    const res = await request(app).get('/openapi.json');
+    const paths = res.body.paths as Record<string, unknown>;
+    expect(paths['/internal/indexer/contract-events']).toBeDefined();
+    expect(paths['/internal/indexer/events']).toBeDefined();
+    expect(paths['/internal/indexer/events/replay']).toBeDefined();
+  });
+
+  it('covers webhook routes', async () => {
+    const res = await request(app).get('/openapi.json');
+    const paths = res.body.paths as Record<string, unknown>;
+    expect(paths['/internal/webhooks/receive']).toBeDefined();
+    expect(paths['/internal/webhooks/queue']).toBeDefined();
+  });
+
+  it('covers rate-limit routes', async () => {
+    const res = await request(app).get('/openapi.json');
+    const paths = res.body.paths as Record<string, unknown>;
+    expect(paths['/api/rate-limits']).toBeDefined();
+    expect(paths['/api/rate-limits/config']).toBeDefined();
+  });
+
+  it('covers metrics route', async () => {
+    const res = await request(app).get('/openapi.json');
+    expect(res.body.paths['/metrics']).toBeDefined();
+  });
+
+  it('covers privacy routes', async () => {
+    const res = await request(app).get('/openapi.json');
+    const paths = res.body.paths as Record<string, unknown>;
+    expect(paths['/api/privacy/policy']).toBeDefined();
+    expect(paths['/api/privacy/retention']).toBeDefined();
+  });
+
+  it('POST /api/streams requires bearerAuth security', async () => {
+    const res = await request(app).get('/openapi.json');
+    const postStreams = (res.body.paths['/api/streams'] as Record<string, unknown>)?.post as Record<string, unknown>;
+    expect(postStreams?.security).toBeDefined();
+    const sec = postStreams.security as Array<Record<string, unknown>>;
+    expect(sec.some((s) => 'bearerAuth' in s)).toBe(true);
+  });
+
+  it('POST /internal/indexer/contract-events requires indexerWorkerToken', async () => {
+    const res = await request(app).get('/openapi.json');
+    const route = (res.body.paths['/internal/indexer/contract-events'] as Record<string, unknown>)?.post as Record<string, unknown>;
+    const sec = route?.security as Array<Record<string, unknown>>;
+    expect(sec?.some((s) => 'indexerWorkerToken' in s)).toBe(true);
+  });
+
+  it('includes error response schemas (400, 401, 404, 500)', async () => {
+    const res = await request(app).get('/openapi.json');
+    const postStreams = (res.body.paths['/api/streams'] as Record<string, unknown>)?.post as Record<string, unknown>;
+    const responses = postStreams?.responses as Record<string, unknown>;
+    expect(responses?.['400']).toBeDefined();
+    expect(responses?.['401']).toBeDefined();
+  });
+
+  it('includes example payloads for POST /api/streams', async () => {
+    const res = await request(app).get('/openapi.json');
+    const postStreams = (res.body.paths['/api/streams'] as Record<string, unknown>)?.post as Record<string, unknown>;
+    const body = postStreams?.requestBody as Record<string, unknown>;
+    const content = (body?.content as Record<string, unknown>)?.['application/json'] as Record<string, unknown>;
+    expect(content?.example).toBeDefined();
+  });
+
+  it('includes tags array', async () => {
+    const res = await request(app).get('/openapi.json');
+    expect(Array.isArray(res.body.tags)).toBe(true);
+    const tagNames = (res.body.tags as Array<{ name: string }>).map((t) => t.name);
+    expect(tagNames).toContain('streams');
+    expect(tagNames).toContain('health');
+    expect(tagNames).toContain('admin');
+    expect(tagNames).toContain('indexer');
+  });
+
+  it('sets cache-control header', async () => {
+    const res = await request(app).get('/openapi.json');
+    expect(res.headers['cache-control']).toMatch(/max-age/);
+  });
+
+  it('returns the same spec on repeated calls (cached)', async () => {
+    const res1 = await request(app).get('/openapi.json');
+    const res2 = await request(app).get('/openapi.json');
+    expect(res1.body.info.version).toBe(res2.body.info.version);
+    expect(Object.keys(res1.body.paths as object).length).toBe(
+      Object.keys(res2.body.paths as object).length,
+    );
+  });
+});
+
+describe('GET /docs', () => {
+  it('redirects /docs to /docs/', async () => {
+    const res = await request(app).get('/docs');
+    expect([301, 302, 308]).toContain(res.status);
+  });
+
+  it('returns 200 with HTML content at /docs/', async () => {
+    const res = await request(app).get('/docs/');
+    expect(res.status).toBe(200);
+    expect(res.headers['content-type']).toMatch(/html/);
+  });
+
+  it('HTML references the openapi.json URL', async () => {
+    const res = await request(app).get('/docs/');
+    expect(res.text).toMatch(/swagger|openapi/i);
+  });
+});


### PR DESCRIPTION
- Add src/openapi/spec.ts: builds OpenAPI 3.1 document from Zod schemas using @asteasolutions/zod-to-openapi. Covers all 30+ routes across streams, health, auth, admin, DLQ, indexer, webhooks, rate-limits, and metrics. Includes bearerAuth (JWT) and indexerWorkerToken security schemes, error response schemas (400/401/403/404/409/413/422/429/500/503), and request/response examples.

- Add src/routes/docs.ts: serves GET /openapi.json (cached, JSON) and mounts Swagger UI at GET /docs/ via swagger-ui-express.

- Register docsRouter in src/app.ts before the 404 handler.

- Add tests/routes/docs.test.ts: 24 tests covering spec validity, route coverage, security scheme presence, error schemas, caching, and Swagger UI availability.

- Add docs/openapi/README.md: documents endpoints, generation workflow, security schemes, and how to add new routes.

- Fix pre-existing stray CJS exports.* lines in src/webhooks/retry.ts that were crashing all app-level tests in ESM mode.

Dependencies added: @asteasolutions/zod-to-openapi@8.5.0, swagger-ui-express@5.0.1, @types/swagger-ui-express@4.1.8

close #217 