### PR TITLE
feat: add Sunset header middleware and formal API deprecation policy

### DIFF
--- a/docs/api/deprecation-policy.md
+++ b/docs/api/deprecation-policy.md
@@ -1,0 +1,37 @@
+# API Deprecation Policy
+
+Fluxora uses response headers and published documentation to give API consumers a predictable route retirement process.
+
+## Timeline
+
+1. Announce the deprecation in release notes, the changelog, and this policy.
+2. Add the route to `src/config/deprecations.ts` with an ISO-8601 UTC sunset date and migration link.
+3. Serve the deprecated route for at least 90 days, or one major release cycle, whichever is longer.
+4. Keep the route behavior-compatible during the deprecation window except for urgent security fixes.
+5. Remove the route only after the sunset date has passed and the migration guide is available.
+
+## Response Headers
+
+Deprecated routes include these headers on every matching response:
+
+```http
+Deprecation: true
+Sunset: Wed, 30 Sep 2026 00:00:00 GMT
+Link: </docs/api/deprecation-policy.md#current-deprecations>; rel="deprecation"
+```
+
+`Sunset` is formatted as an HTTP date as required by RFC 8594. `Deprecation` is a machine-readable signal that the route is scheduled for removal. `Link` points to migration details when a route-specific guide exists.
+
+## Consumer Guide
+
+Clients should treat `Deprecation: true` as an action-required signal. Store or surface the `Sunset` date, follow the `Link` migration guide, and move traffic before the sunset date. Deprecated routes remain served during the window, including after the sunset date if removal has not shipped yet, but callers should not depend on that grace period.
+
+## Security Notes
+
+Deprecation metadata is configured in source control and validated before middleware registration. Header values containing carriage returns or line feeds are rejected to prevent response-splitting attacks. The middleware logs only method, path, configured route, sunset date, and correlation ID when a route is past sunset.
+
+## Current Deprecations
+
+| Route | Sunset date | Replacement |
+| --- | --- | --- |
+| `/api/rate-limits/config` | `2026-09-30T00:00:00.000Z` | Use deployment-managed rate-limit configuration and `GET /api/rate-limits` for caller status. |

--- a/src/app.ts
+++ b/src/app.ts
@@ -22,6 +22,8 @@ import { bodySizeLimitMiddleware, BODY_LIMIT_BYTES } from './middleware/requestP
 import { httpMetrics } from './middleware/httpMetrics.js';
 import { isShuttingDown } from './shutdown.js';
 import { createRateLimiter } from './middleware/rateLimiter.js';
+import { createDeprecationMiddleware } from './middleware/deprecation.js';
+import { routeDeprecations } from './config/deprecations.js';
 import { createRateLimitsRouter } from './routes/rateLimits.js';
 import { getRateLimitConfig } from './config/rateLimits.js';
 import { successResponse, errorResponse } from './utils/response.js';
@@ -66,6 +68,7 @@ export function createApp(options: AppOptions = {}): Express {
   app.use(corsAllowlistMiddleware);
   app.use(requestLoggerMiddleware);
   app.use(httpMetrics);
+  app.use(createDeprecationMiddleware(routeDeprecations));
   app.use(rateLimiter);
 
   app.use((_req: Request, res: Response, next: NextFunction) => {

--- a/src/config/deprecations.ts
+++ b/src/config/deprecations.ts
@@ -1,0 +1,15 @@
+import type { DeprecatedRoute } from '../middleware/deprecation.js';
+
+/**
+ * Machine-readable route retirement registry.
+ *
+ * Keep dates in ISO-8601 UTC form. The middleware converts them to HTTP-date
+ * values for the Sunset response header required by RFC 8594.
+ */
+export const routeDeprecations: readonly DeprecatedRoute[] = [
+  {
+    route: '/api/rate-limits/config',
+    sunsetDate: '2026-09-30T00:00:00.000Z',
+    link: '/docs/api/deprecation-policy.md#current-deprecations',
+  },
+];

--- a/src/middleware/deprecation.ts
+++ b/src/middleware/deprecation.ts
@@ -1,0 +1,138 @@
+import type { NextFunction, Request, RequestHandler, Response } from 'express';
+import { logger } from '../logging/logger.js';
+
+export interface DeprecatedRoute {
+  /** Absolute route path or route prefix to mark as deprecated. */
+  route: string;
+  /** ISO-8601 date/time for the planned removal. */
+  sunsetDate: string;
+  /** Optional migration or policy URL exposed through the Link header. */
+  link?: string;
+}
+
+interface NormalizedDeprecatedRoute extends DeprecatedRoute {
+  sunset: Date;
+}
+
+const HEADER_VALUE_UNSAFE = /[\r\n]/;
+
+function assertSafeHeaderValue(name: string, value: string): void {
+  if (HEADER_VALUE_UNSAFE.test(value)) {
+    throw new Error(`${name} must not contain CR or LF characters`);
+  }
+}
+
+function normalizeRoute(route: string): string {
+  if (!route.startsWith('/')) {
+    throw new Error('Deprecated route must start with /');
+  }
+
+  if (HEADER_VALUE_UNSAFE.test(route)) {
+    throw new Error('Deprecated route must not contain CR or LF characters');
+  }
+
+  if (route.length > 1 && route.endsWith('/')) {
+    return route.slice(0, -1);
+  }
+
+  return route;
+}
+
+function normalizeEntry(route: string, sunsetDate: string, link?: string): NormalizedDeprecatedRoute {
+  assertSafeHeaderValue('Sunset date', sunsetDate);
+
+  const sunset = new Date(sunsetDate);
+  if (Number.isNaN(sunset.getTime())) {
+    throw new Error(`Invalid sunset date for deprecated route ${route}`);
+  }
+
+  if (link) {
+    assertSafeHeaderValue('Link URL', link);
+  }
+
+  return {
+    route: normalizeRoute(route),
+    sunsetDate,
+    sunset,
+    link,
+  };
+}
+
+function routeMatches(req: Request, route: string): boolean {
+  const path = req.path.length > 1 && req.path.endsWith('/') ? req.path.slice(0, -1) : req.path;
+  return path === route || path.startsWith(`${route}/`);
+}
+
+function formatLink(link: string): string {
+  return `<${link}>; rel="deprecation"`;
+}
+
+function appendLinkHeader(res: Response, link: string): void {
+  const existing = res.getHeader('Link');
+  const next = formatLink(link);
+
+  if (Array.isArray(existing)) {
+    res.setHeader('Link', [...existing, next]);
+    return;
+  }
+
+  if (typeof existing === 'string' && existing.length > 0) {
+    res.setHeader('Link', `${existing}, ${next}`);
+    return;
+  }
+
+  res.setHeader('Link', next);
+}
+
+function applyDeprecationHeaders(req: Request, res: Response, entries: NormalizedDeprecatedRoute[]): void {
+  if (entries.length === 0) return;
+
+  const earliestSunset = entries.reduce((earliest, entry) =>
+    entry.sunset.getTime() < earliest.sunset.getTime() ? entry : earliest,
+  );
+
+  res.setHeader('Deprecation', 'true');
+  res.setHeader('Sunset', earliestSunset.sunset.toUTCString());
+
+  for (const entry of entries) {
+    if (entry.link) {
+      appendLinkHeader(res, entry.link);
+    }
+
+    if (entry.sunset.getTime() <= Date.now()) {
+      logger.warn('deprecated route is past its sunset date', {
+        method: req.method,
+        path: req.path,
+        route: entry.route,
+        sunsetDate: entry.sunsetDate,
+        correlationId: req.correlationId,
+      });
+    }
+  }
+}
+
+/**
+ * Marks a route or route prefix as deprecated and emits RFC 8594 Sunset,
+ * Deprecation, and optional migration Link headers without changing behavior.
+ */
+export function deprecate(route: string, sunsetDate: string, link?: string): RequestHandler {
+  const entry = normalizeEntry(route, sunsetDate, link);
+
+  return (req: Request, res: Response, next: NextFunction): void => {
+    if (routeMatches(req, entry.route)) {
+      applyDeprecationHeaders(req, res, [entry]);
+    }
+
+    next();
+  };
+}
+
+export function createDeprecationMiddleware(entries: readonly DeprecatedRoute[]): RequestHandler {
+  const normalized = entries.map((entry) => normalizeEntry(entry.route, entry.sunsetDate, entry.link));
+
+  return (req: Request, res: Response, next: NextFunction): void => {
+    const matches = normalized.filter((entry) => routeMatches(req, entry.route));
+    applyDeprecationHeaders(req, res, matches);
+    next();
+  };
+}

--- a/tests/unit/middleware/deprecation.test.ts
+++ b/tests/unit/middleware/deprecation.test.ts
@@ -1,0 +1,152 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+import type { Request, Response, NextFunction } from 'express';
+import { createDeprecationMiddleware, deprecate } from '../../../src/middleware/deprecation.js';
+import { logger } from '../../../src/logging/logger.js';
+
+function mockRequest(path: string, method = 'GET'): Request {
+  return {
+    path,
+    method,
+    correlationId: 'test-correlation-id',
+  } as Request;
+}
+
+function mockResponse(): Response & {
+  headers: Map<string, string | string[] | number>;
+  setHeader: ReturnType<typeof vi.fn>;
+  getHeader: ReturnType<typeof vi.fn>;
+} {
+  const headers = new Map<string, string | string[] | number>();
+  const res = {
+    headers,
+    setHeader: vi.fn((name: string, value: string | string[] | number) => {
+      headers.set(name, value);
+      return res;
+    }),
+    getHeader: vi.fn((name: string) => headers.get(name)),
+  } as unknown as Response & {
+    headers: Map<string, string | string[] | number>;
+    setHeader: ReturnType<typeof vi.fn>;
+    getHeader: ReturnType<typeof vi.fn>;
+  };
+
+  return res;
+}
+
+function mockNext(): NextFunction {
+  return vi.fn();
+}
+
+describe('deprecation middleware', () => {
+  beforeEach(() => {
+    vi.spyOn(logger, 'warn').mockImplementation(() => undefined);
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-01-01T00:00:00.000Z'));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it('attaches Deprecation, Sunset, and Link headers for a deprecated route', () => {
+    const middleware = deprecate(
+      '/api/legacy',
+      '2026-06-30T00:00:00.000Z',
+      'https://docs.fluxora.example/migrate',
+    );
+    const req = mockRequest('/api/legacy');
+    const res = mockResponse();
+    const next = mockNext();
+
+    middleware(req, res, next);
+
+    expect(res.headers.get('Deprecation')).toBe('true');
+    expect(res.headers.get('Sunset')).toBe('Tue, 30 Jun 2026 00:00:00 GMT');
+    expect(res.headers.get('Link')).toBe('<https://docs.fluxora.example/migrate>; rel="deprecation"');
+    expect(next).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not attach headers to unrelated routes', () => {
+    const middleware = deprecate('/api/legacy', '2026-06-30T00:00:00.000Z');
+    const req = mockRequest('/api/streams');
+    const res = mockResponse();
+    const next = mockNext();
+
+    middleware(req, res, next);
+
+    expect(res.setHeader).not.toHaveBeenCalled();
+    expect(next).toHaveBeenCalledTimes(1);
+  });
+
+  it('serves past-sunset routes and logs a warning', () => {
+    const middleware = deprecate('/api/legacy', '2025-12-31T00:00:00.000Z');
+    const req = mockRequest('/api/legacy');
+    const res = mockResponse();
+    const next = mockNext();
+
+    middleware(req, res, next);
+
+    expect(res.headers.get('Deprecation')).toBe('true');
+    expect(res.headers.get('Sunset')).toBe('Wed, 31 Dec 2025 00:00:00 GMT');
+    expect(logger.warn).toHaveBeenCalledWith(
+      'deprecated route is past its sunset date',
+      expect.objectContaining({
+        method: 'GET',
+        path: '/api/legacy',
+        route: '/api/legacy',
+        sunsetDate: '2025-12-31T00:00:00.000Z',
+      }),
+    );
+    expect(next).toHaveBeenCalledTimes(1);
+  });
+
+  it('works when no Link URL is provided', () => {
+    const middleware = deprecate('/api/legacy', '2026-06-30T00:00:00.000Z');
+    const req = mockRequest('/api/legacy');
+    const res = mockResponse();
+    const next = mockNext();
+
+    middleware(req, res, next);
+
+    expect(res.headers.get('Deprecation')).toBe('true');
+    expect(res.headers.get('Sunset')).toBe('Tue, 30 Jun 2026 00:00:00 GMT');
+    expect(res.headers.has('Link')).toBe(false);
+  });
+
+  it('handles multiple deprecated route matches on one request', () => {
+    const middleware = createDeprecationMiddleware([
+      {
+        route: '/api',
+        sunsetDate: '2026-12-31T00:00:00.000Z',
+        link: 'https://docs.fluxora.example/api',
+      },
+      {
+        route: '/api/legacy',
+        sunsetDate: '2026-06-30T00:00:00.000Z',
+        link: 'https://docs.fluxora.example/legacy',
+      },
+    ]);
+    const req = mockRequest('/api/legacy/transfers');
+    const res = mockResponse();
+    const next = mockNext();
+
+    middleware(req, res, next);
+
+    expect(res.headers.get('Deprecation')).toBe('true');
+    expect(res.headers.get('Sunset')).toBe('Tue, 30 Jun 2026 00:00:00 GMT');
+    expect(res.headers.get('Link')).toBe(
+      '<https://docs.fluxora.example/api>; rel="deprecation", <https://docs.fluxora.example/legacy>; rel="deprecation"',
+    );
+    expect(next).toHaveBeenCalledTimes(1);
+  });
+
+  it('rejects unsafe header values during middleware creation', () => {
+    expect(() => deprecate('/api/legacy', '2026-06-30T00:00:00.000Z\r\nX-Bad: yes')).toThrow(
+      'Sunset date must not contain CR or LF characters',
+    );
+    expect(() => deprecate('/api/legacy', '2026-06-30T00:00:00.000Z', '/docs\r\nX-Bad: yes')).toThrow(
+      'Link URL must not contain CR or LF characters',
+    );
+  });
+});


### PR DESCRIPTION
Closes #294 
Summary

Adds middleware-driven API route deprecation support using Deprecation, Sunset, and optional Link headers, backed by a typed route deprecation registry.

Changes

Added src/middleware/deprecation.ts with deprecate() and registry-based middleware helpers.
Added src/config/deprecations.ts for deprecated route metadata.
Wired deprecation middleware into the Express app.
Documented the API deprecation lifecycle in docs/api/deprecation-policy.md.
Added focused unit tests for headers, past sunset dates, missing links, multiple matches, and header injection safety.
Validation

npm exec vitest -- run tests/unit/middleware/deprecation.test.ts passed.
npm run build was attempted but is blocked by an existing syntax error in tests/webhooks/retry.rateLimit.test.ts.