### PR TITLE
feat: add admin websocket force-disconnect by stream_id

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -1,5 +1,7 @@
 # Fluxora API — Reference
 
+Admin-specific operational endpoints are documented in [docs/api/admin-endpoints.md](docs/api/admin-endpoints.md).
+
 ## Idempotency
 
 ### Overview

--- a/docs/api/admin-endpoints.md
+++ b/docs/api/admin-endpoints.md
@@ -1,0 +1,52 @@
+# Admin API Endpoints
+
+All endpoints under `/api/admin` require an `Authorization: Bearer <ADMIN_API_KEY>` header unless noted otherwise. Requests without valid admin credentials are rejected by `requireAdminAuth`.
+
+## WebSocket disconnect
+
+### `POST /api/admin/ws/disconnect`
+
+Forcibly closes every WebSocket subscription currently attached to the given `stream_id`.
+
+Request body:
+
+```json
+{
+  "stream_id": "stream-123"
+}
+```
+
+Behavior:
+
+- Every active socket subscribed to the stream is closed with code `4000`.
+- The close reason is `admin-forced-disconnect`.
+- An audit row is written to `audit_logs` with the action `ADMIN_WS_DISCONNECT`.
+- If the stream has no active subscribers, the endpoint still succeeds and returns `disconnectedCount: 0`.
+
+Response:
+
+```json
+{
+  "message": "WebSocket subscribers disconnected.",
+  "stream_id": "stream-123",
+  "disconnectedCount": 2
+}
+```
+
+Security notes:
+
+- The endpoint is admin-only and fails closed when `ADMIN_API_KEY` is unset.
+- Input is validated server-side; non-string or empty `stream_id` values return `400`.
+- Audit persistence is attempted after the disconnect so operators get a durable record of the action.
+
+## Related admin endpoints
+
+- `GET /api/admin/status`
+- `GET /api/admin/pause`
+- `PUT /api/admin/pause`
+- `GET /api/admin/reindex`
+- `POST /api/admin/reindex`
+- `GET /api/admin/api-keys`
+- `POST /api/admin/api-keys`
+- `POST /api/admin/api-keys/:id/rotate`
+- `DELETE /api/admin/api-keys/:id`

--- a/src/lib/auditLog.ts
+++ b/src/lib/auditLog.ts
@@ -5,13 +5,16 @@
  * occurs (stream create, stream cancel). Entries are append-only; nothing
  * in this module mutates or removes existing records.
  *
- * Two write paths:
+ * Three write paths:
  *  1. `recordAuditEvent`          – in-memory only; never throws; used by
  *                                   non-transactional callers (admin routes, etc.)
  *  2. `buildAuditEntry` +
  *     `writeAuditEntryToDb`       – used inside DB transactions so the audit
  *                                   row is committed or rolled back atomically
  *                                   with the primary stream operation.
+ *  3. `recordAuditEventToDb`       – non-transactional helper that writes to
+ *                                   the shared Postgres audit table and then
+ *                                   mirrors the entry into the in-memory log.
  *
  * Trust boundaries
  * - Internal workers call `recordAuditEvent` or the transactional helpers.
@@ -25,8 +28,18 @@
  */
 
 import { logger } from './logger.js';
+import { getPool, query } from '../db/pool.js';
 
-export type AuditAction = 'STREAM_CREATED' | 'STREAM_CANCELLED' | 'STREAM_STATUS_UPDATED' | 'DLQ_LISTED' | 'DLQ_REPLAYED' | 'DLQ_PURGED' | 'PAUSE_FLAGS_UPDATED' | 'REINDEX_TRIGGERED';
+export type AuditAction =
+  | 'STREAM_CREATED'
+  | 'STREAM_CANCELLED'
+  | 'STREAM_STATUS_UPDATED'
+  | 'DLQ_LISTED'
+  | 'DLQ_REPLAYED'
+  | 'DLQ_PURGED'
+  | 'PAUSE_FLAGS_UPDATED'
+  | 'REINDEX_TRIGGERED'
+  | 'ADMIN_WS_DISCONNECT';
 
 /**
  * Minimal prepare/run shape used by {@link writeAuditEntryToDb}.
@@ -60,7 +73,18 @@ const AUDIT_LOG_KEY = '__FLUXORA_AUDIT_LOG__';
 if (!(globalThis as Record<string, unknown>)[AUDIT_LOG_KEY]) {
   (globalThis as Record<string, unknown>)[AUDIT_LOG_KEY] = [];
 }
-const auditLog: AuditEntry[] = (globalThis as Record<string, unknown>)[AUDIT_LOG_KEY] as AuditEntry[];
+const auditLog: AuditEntry[] = (globalThis as Record<string, unknown>)[
+  AUDIT_LOG_KEY
+] as AuditEntry[];
+
+function appendAuditEntry(entry: AuditEntry): void {
+  auditLog.push(entry);
+  logger.info('Audit event recorded', entry.correlationId, {
+    action: entry.action,
+    resourceType: entry.resourceType,
+    resourceId: entry.resourceId,
+  });
+}
 
 // ── In-memory path (non-transactional) ───────────────────────────────────────
 
@@ -73,7 +97,7 @@ export function recordAuditEvent(
   resourceType: string,
   resourceId: string,
   correlationId?: string,
-  meta?: Record<string, unknown>,
+  meta?: Record<string, unknown>
 ): void {
   try {
     const entry: AuditEntry = {
@@ -85,8 +109,7 @@ export function recordAuditEvent(
       ...(correlationId !== undefined ? { correlationId } : {}),
       ...(meta !== undefined ? { meta } : {}),
     };
-    auditLog.push(entry);
-    logger.info('Audit event recorded', correlationId, { action, resourceType, resourceId });
+    appendAuditEntry(entry);
   } catch (err) {
     // Audit must never block the primary operation.
     logger.error('Failed to record audit event', undefined, {
@@ -109,7 +132,7 @@ export function buildAuditEntry(
   resourceType: string,
   resourceId: string,
   correlationId?: string,
-  meta?: Record<string, unknown>,
+  meta?: Record<string, unknown>
 ): AuditEntry {
   return {
     seq: ++seq,
@@ -133,7 +156,7 @@ export function writeAuditEntryToDb(db: AuditDbConnection, entry: AuditEntry): v
   db.prepare(
     `INSERT INTO audit_logs
        (seq, timestamp, action, resource_type, resource_id, correlation_id, meta)
-     VALUES (?, ?, ?, ?, ?, ?, ?)`,
+     VALUES (?, ?, ?, ?, ?, ?, ?)`
   ).run(
     entry.seq,
     entry.timestamp,
@@ -141,16 +164,45 @@ export function writeAuditEntryToDb(db: AuditDbConnection, entry: AuditEntry): v
     entry.resourceType,
     entry.resourceId,
     entry.correlationId ?? null,
-    entry.meta !== undefined ? JSON.stringify(entry.meta) : null,
+    entry.meta !== undefined ? JSON.stringify(entry.meta) : null
   );
 
   // Mirror into in-memory log so GET /api/audit reflects transactional writes.
-  auditLog.push(entry);
-  logger.info('Audit entry written to DB', entry.correlationId, {
-    action: entry.action,
-    resourceType: entry.resourceType,
-    resourceId: entry.resourceId,
-  });
+  appendAuditEntry(entry);
+}
+
+/**
+ * Build and persist an audit entry using the shared Postgres pool.
+ * Intended for non-transactional admin actions that still need durable audit
+ * logging in the `audit_logs` table.
+ */
+export async function recordAuditEventToDb(
+  action: AuditAction,
+  resourceType: string,
+  resourceId: string,
+  correlationId?: string,
+  meta?: Record<string, unknown>
+): Promise<AuditEntry> {
+  const entry = buildAuditEntry(action, resourceType, resourceId, correlationId, meta);
+
+  await query(
+    getPool(),
+    `INSERT INTO audit_logs
+       (seq, timestamp, action, resource_type, resource_id, correlation_id, meta)
+     VALUES ($1, $2, $3, $4, $5, $6, $7)`,
+    [
+      entry.seq,
+      entry.timestamp,
+      entry.action,
+      entry.resourceType,
+      entry.resourceId,
+      entry.correlationId ?? null,
+      entry.meta !== undefined ? JSON.stringify(entry.meta) : null,
+    ]
+  );
+
+  appendAuditEntry(entry);
+  return entry;
 }
 
 // ── Queries ───────────────────────────────────────────────────────────────────

--- a/src/metrics/dbMetrics.ts
+++ b/src/metrics/dbMetrics.ts
@@ -1,4 +1,4 @@
-import { Counter, Gauge } from 'prom-client';
+import { Counter, Gauge, Histogram } from 'prom-client';
 import { registry } from '../metrics.js';
 
 /**
@@ -6,7 +6,9 @@ import { registry } from '../metrics.js';
  * Labels: repository (e.g. "streamRepository"), operation (e.g. "upsertStream")
  */
 export const dbQueryDurationSeconds =
-  (registry.getSingleMetric('fluxora_db_query_duration_seconds') as Histogram<'repository' | 'operation'>) ||
+  (registry.getSingleMetric('fluxora_db_query_duration_seconds') as Histogram<
+    'repository' | 'operation'
+  >) ||
   new Histogram({
     name: 'fluxora_db_query_duration_seconds',
     help: 'Duration of PostgreSQL queries in seconds, partitioned by repository and operation',

--- a/src/routes/admin.ts
+++ b/src/routes/admin.ts
@@ -7,13 +7,9 @@ import {
   triggerReindex,
   AdminStatePersistenceError,
 } from '../state/adminState.js';
-import {
-  createApiKey,
-  rotateApiKey,
-  revokeApiKey,
-  listApiKeys,
-} from '../lib/apiKey.js';
-import { recordAuditEvent } from '../lib/auditLog.js';
+import { createApiKey, rotateApiKey, revokeApiKey, listApiKeys } from '../lib/apiKey.js';
+import { recordAuditEvent, recordAuditEventToDb } from '../lib/auditLog.js';
+import { getStreamHub } from '../ws/hub.js';
 
 export const adminRouter = Router();
 
@@ -92,18 +88,12 @@ adminRouter.put('/pause', (req, res) => {
     throw err;
   }
 
-  recordAuditEvent(
-    'PAUSE_FLAGS_UPDATED',
-    'pauseFlags',
-    'system',
-    req.correlationId,
-    {
-      previous,
-      updated,
-      ...(streamCreation !== undefined ? { streamCreation } : {}),
-      ...(ingestion !== undefined ? { ingestion } : {}),
-    },
-  );
+  recordAuditEvent('PAUSE_FLAGS_UPDATED', 'pauseFlags', 'system', req.correlationId, {
+    previous,
+    updated,
+    ...(streamCreation !== undefined ? { streamCreation } : {}),
+    ...(ingestion !== undefined ? { ingestion } : {}),
+  });
 
   res.json({ message: 'Pause flags updated.', pauseFlags: updated });
 });
@@ -132,17 +122,63 @@ adminRouter.post('/reindex', async (_req, res) => {
 
   const state = await triggerReindex();
 
-  recordAuditEvent(
-    'REINDEX_TRIGGERED',
-    'reindex',
-    'system',
-    _req.correlationId,
-    { status: state.status, startedAt: state.startedAt },
-  );
+  recordAuditEvent('REINDEX_TRIGGERED', 'reindex', 'system', _req.correlationId, {
+    status: state.status,
+    startedAt: state.startedAt,
+  });
 
   res.status(202).json({
     message: 'Reindex started.',
     reindex: state,
+  });
+});
+
+/**
+ * POST /api/admin/ws/disconnect
+ * Forcibly closes every active WebSocket subscription for a given stream_id.
+ */
+adminRouter.post('/ws/disconnect', async (req, res) => {
+  const { stream_id: streamIdValue } = req.body ?? {};
+
+  if (typeof streamIdValue !== 'string') {
+    res.status(400).json({ error: 'stream_id (string) is required.' });
+    return;
+  }
+
+  const streamId = streamIdValue.trim();
+  if (streamId.length === 0) {
+    res.status(400).json({ error: 'stream_id (string) is required.' });
+    return;
+  }
+
+  const hub = getStreamHub();
+  if (!hub) {
+    res.status(503).json({
+      error: 'WebSocket hub is not initialized. Try again after the service starts.',
+    });
+    return;
+  }
+
+  const disconnectedCount = hub.disconnectByStreamId(streamId);
+
+  try {
+    await recordAuditEventToDb('ADMIN_WS_DISCONNECT', 'stream', streamId, req.correlationId, {
+      disconnectedCount,
+      closeCode: 4000,
+      closeReason: 'admin-forced-disconnect',
+    });
+  } catch (err) {
+    res.status(503).json({
+      error: 'Unable to persist audit log entry. Try again later.',
+      disconnectedCount,
+    });
+    return;
+  }
+
+  res.json({
+    message: 'WebSocket subscribers disconnected.',
+    stream_id: streamId,
+    disconnectedCount,
   });
 });
 

--- a/src/ws/hub.ts
+++ b/src/ws/hub.ts
@@ -160,13 +160,9 @@ export class StreamHub extends EventEmitter {
       this.ownsDedup = true;
     }
 
-    this.wsAuthRequired =
-      options?.wsAuthRequired ??
-      (process.env.WS_AUTH_REQUIRED === 'true');
+    this.wsAuthRequired = options?.wsAuthRequired ?? process.env.WS_AUTH_REQUIRED === 'true';
 
-    this.jwtSecret =
-      options?.jwtSecret ??
-      process.env.JWT_SECRET;
+    this.jwtSecret = options?.jwtSecret ?? process.env.JWT_SECRET;
 
     this.eventStore = options?.eventStore;
 
@@ -182,9 +178,9 @@ export class StreamHub extends EventEmitter {
         if (!result.ok) {
           socket.write(
             'HTTP/1.1 401 Unauthorized\r\n' +
-            'Content-Type: text/plain\r\n' +
-            'Connection: close\r\n\r\n' +
-            `Unauthorized: ${result.code}\r\n`,
+              'Content-Type: text/plain\r\n' +
+              'Connection: close\r\n\r\n' +
+              `Unauthorized: ${result.code}\r\n`
           );
           socket.destroy();
           return;
@@ -368,7 +364,7 @@ export class StreamHub extends EventEmitter {
 
   private authorizeSubscriptionFilter(
     ws: WebSocket,
-    filter: SubscriptionFilter,
+    filter: SubscriptionFilter
   ): { ok: true; filter: SubscriptionFilter } | { ok: false; code: string; message: string } {
     const state = this.clients.get(ws);
     if (!state) {
@@ -386,7 +382,8 @@ export class StreamHub extends EventEmitter {
         return {
           ok: false,
           code: 'UNAUTHORIZED',
-          message: 'recipient_address subscriptions require an authenticated Stellar public key subject',
+          message:
+            'recipient_address subscriptions require an authenticated Stellar public key subject',
         };
       }
 
@@ -451,6 +448,34 @@ export class StreamHub extends EventEmitter {
     }
   }
 
+  /**
+   * Force-close every socket currently subscribed to a stream ID.
+   * Returns the number of sockets targeted before the disconnect completes.
+   */
+  disconnectByStreamId(streamId: string): number {
+    const subscribers = this.streamSubscriptions.get(streamId);
+    if (!subscribers || subscribers.size === 0) {
+      return 0;
+    }
+
+    const targets = Array.from(subscribers);
+    this.streamSubscriptions.delete(streamId);
+
+    for (const ws of targets) {
+      try {
+        ws.close(4000, 'admin-forced-disconnect');
+      } catch {
+        try {
+          ws.terminate();
+        } catch {
+          // no-op
+        }
+      }
+    }
+
+    return targets.length;
+  }
+
   // ── Broadcast ──────────────────────────────────────────────────────────────
 
   async broadcast(event: StreamUpdateEvent): Promise<void> {
@@ -463,7 +488,13 @@ export class StreamHub extends EventEmitter {
     if (subscribers.size === 0) return;
 
     const correlationId = getCorrelationId();
-    const message = JSON.stringify({ type: 'stream_update', streamId, eventId, payload, correlationId });
+    const message = JSON.stringify({
+      type: 'stream_update',
+      streamId,
+      eventId,
+      payload,
+      correlationId,
+    });
     const targets = Array.from(subscribers);
 
     if (targets.length <= FANOUT_YIELD_BATCH) {
@@ -500,9 +531,14 @@ export class StreamHub extends EventEmitter {
     return targets;
   }
 
-  private deliverBatch(batch: WebSocket[], message: string, streamId: string, eventId: string): number {
+  private deliverBatch(
+    batch: WebSocket[],
+    message: string,
+    streamId: string,
+    eventId: string
+  ): number {
     let sent = 0;
-    
+
     for (const ws of batch) {
       if (ws.readyState !== WebSocket.OPEN) continue;
 
@@ -512,7 +548,11 @@ export class StreamHub extends EventEmitter {
         this.metrics.terminatedConnections++;
         this.metrics.droppedMessages++;
         this.emitBackpressure(ws, 'terminate', buffered, this.terminateBytes, streamId, eventId);
-        try { ws.terminate(); } catch { /* ignore */ }
+        try {
+          ws.terminate();
+        } catch {
+          /* ignore */
+        }
         this.onDisconnect(ws);
         continue;
       }
@@ -547,9 +587,14 @@ export class StreamHub extends EventEmitter {
         'ws.correlation_id': correlationId,
       },
     });
-    tracer.recordEvent(span, 'ws.broadcast', { streamId, eventId, recipients: sent, correlationId });
+    tracer.recordEvent(span, 'ws.broadcast', {
+      streamId,
+      eventId,
+      recipients: sent,
+      correlationId,
+    });
     tracer.endSpan(span, 'ok');
-    
+
     return sent;
   }
 
@@ -559,7 +604,7 @@ export class StreamHub extends EventEmitter {
     bufferedAmount: number,
     thresholdBytes: number,
     streamId: string,
-    eventId: string,
+    eventId: string
   ): void {
     const state = this.clients.get(ws);
     if (!state) return;
@@ -636,9 +681,10 @@ export class StreamHub extends EventEmitter {
       return undefined;
     }
 
-    const candidate = (payload as Record<string, unknown>)['recipient_address']
-      ?? (payload as Record<string, unknown>)['recipientAddress']
-      ?? (payload as Record<string, unknown>)['recipient'];
+    const candidate =
+      (payload as Record<string, unknown>)['recipient_address'] ??
+      (payload as Record<string, unknown>)['recipientAddress'] ??
+      (payload as Record<string, unknown>)['recipient'];
 
     if (typeof candidate !== 'string') return undefined;
 
@@ -660,7 +706,8 @@ export class StreamHub extends EventEmitter {
 
   setBackpressureThresholds(opts: { dropBytes?: number; terminateBytes?: number }): void {
     if (typeof opts.dropBytes === 'number' && opts.dropBytes >= 0) this.dropBytes = opts.dropBytes;
-    if (typeof opts.terminateBytes === 'number' && opts.terminateBytes >= 0) this.terminateBytes = opts.terminateBytes;
+    if (typeof opts.terminateBytes === 'number' && opts.terminateBytes >= 0)
+      this.terminateBytes = opts.terminateBytes;
   }
 
   /**

--- a/tests/integration/routes/admin-ws-disconnect.test.ts
+++ b/tests/integration/routes/admin-ws-disconnect.test.ts
@@ -1,0 +1,178 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import express from 'express';
+import request from 'supertest';
+
+const mocks = vi.hoisted(() => ({
+  getStreamHub: vi.fn(),
+  getPool: vi.fn(() => ({})),
+  query: vi.fn().mockResolvedValue({ rowCount: 1 }),
+}));
+
+vi.mock('../../../src/ws/hub.js', () => ({
+  getStreamHub: (...args: unknown[]) => mocks.getStreamHub(...args),
+}));
+
+vi.mock('../../../src/db/pool.js', () => ({
+  getPool: (...args: unknown[]) => mocks.getPool(...args),
+  query: (...args: unknown[]) => mocks.query(...args),
+  PoolExhaustedError: class PoolExhaustedError extends Error {
+    constructor() {
+      super('pool exhausted');
+      this.name = 'PoolExhaustedError';
+    }
+  },
+  DuplicateEntryError: class DuplicateEntryError extends Error {
+    constructor(detail?: string) {
+      super(detail ?? 'duplicate');
+      this.name = 'DuplicateEntryError';
+    }
+  },
+}));
+
+import { adminRouter } from '../../../src/routes/admin.js';
+import { correlationIdMiddleware } from '../../../src/middleware/correlationId.js';
+import { errorHandler } from '../../../src/middleware/errorHandler.js';
+import { _resetAuditLog } from '../../../src/lib/auditLog.js';
+
+const ADMIN_KEY = 'test-admin-key-for-ws-disconnect-routes';
+
+function authed(req: request.Test): request.Test {
+  return req.set('Authorization', `Bearer ${ADMIN_KEY}`);
+}
+
+function createTestApp(): express.Express {
+  const app = express();
+  app.use(express.json());
+  app.use(correlationIdMiddleware);
+  app.use('/api/admin', adminRouter);
+  app.use(errorHandler);
+  return app;
+}
+
+function createHub(initialCount = 1): { disconnectByStreamId: ReturnType<typeof vi.fn> } {
+  const activeStreams = new Map<string, number>([['stream-1', initialCount]]);
+
+  return {
+    disconnectByStreamId: vi.fn((streamId: string) => {
+      const current = activeStreams.get(streamId) ?? 0;
+      if (current === 0) {
+        return 0;
+      }
+
+      activeStreams.delete(streamId);
+      return current;
+    }),
+  };
+}
+
+describe('admin websocket disconnect route', () => {
+  let originalKey: string | undefined;
+  let app: express.Express;
+
+  beforeEach(() => {
+    originalKey = process.env.ADMIN_API_KEY;
+    process.env.ADMIN_API_KEY = ADMIN_KEY;
+    app = createTestApp();
+    mocks.getStreamHub.mockReset();
+    mocks.getPool.mockClear();
+    mocks.query.mockClear();
+    _resetAuditLog();
+  });
+
+  afterEach(() => {
+    if (originalKey !== undefined) {
+      process.env.ADMIN_API_KEY = originalKey;
+    } else {
+      delete process.env.ADMIN_API_KEY;
+    }
+  });
+
+  it('rejects unauthenticated requests with 401', async () => {
+    const res = await request(app).post('/api/admin/ws/disconnect').send({ stream_id: 'stream-1' });
+    expect(res.status).toBe(401);
+  });
+
+  it('rejects bad credentials with 403', async () => {
+    const res = await request(app)
+      .post('/api/admin/ws/disconnect')
+      .set('Authorization', 'Bearer wrong-key')
+      .send({ stream_id: 'stream-1' });
+
+    expect(res.status).toBe(403);
+  });
+
+  it('rejects missing stream_id with 400', async () => {
+    mocks.getStreamHub.mockReturnValue(createHub());
+
+    const res = await authed(request(app).post('/api/admin/ws/disconnect').send({}));
+    expect(res.status).toBe(400);
+    expect(mocks.query).not.toHaveBeenCalled();
+  });
+
+  it('disconnects active subscribers and writes an audit log row', async () => {
+    const hub = createHub(2);
+    mocks.getStreamHub.mockReturnValue(hub);
+
+    const res = await authed(
+      request(app).post('/api/admin/ws/disconnect').send({ stream_id: 'stream-1' })
+    );
+
+    expect(res.status).toBe(200);
+    expect(res.body.stream_id).toBe('stream-1');
+    expect(res.body.disconnectedCount).toBe(2);
+    expect(hub.disconnectByStreamId).toHaveBeenCalledWith('stream-1');
+    expect(mocks.query).toHaveBeenCalledTimes(1);
+    expect(mocks.query.mock.calls[0]?.[1]).toContain('INSERT INTO audit_logs');
+    expect(mocks.query.mock.calls[0]?.[2]).toEqual(
+      expect.arrayContaining([
+        expect.any(Number),
+        expect.any(String),
+        'ADMIN_WS_DISCONNECT',
+        'stream',
+        'stream-1',
+        expect.stringMatching(/^[0-9a-f-]{36}$/),
+        expect.stringContaining('disconnectedCount'),
+      ])
+    );
+  });
+
+  it('returns 200 with zero disconnected sockets when no subscribers remain', async () => {
+    const hub = createHub(0);
+    mocks.getStreamHub.mockReturnValue(hub);
+
+    const res = await authed(
+      request(app).post('/api/admin/ws/disconnect').send({ stream_id: 'stream-1' })
+    );
+
+    expect(res.status).toBe(200);
+    expect(res.body.disconnectedCount).toBe(0);
+    expect(hub.disconnectByStreamId).toHaveBeenCalledWith('stream-1');
+    expect(mocks.query).toHaveBeenCalledTimes(1);
+  });
+
+  it('handles concurrent disconnect requests safely', async () => {
+    const hub = createHub(1);
+    mocks.getStreamHub.mockReturnValue(hub);
+
+    const [first, second] = await Promise.all([
+      authed(request(app).post('/api/admin/ws/disconnect').send({ stream_id: 'stream-1' })),
+      authed(request(app).post('/api/admin/ws/disconnect').send({ stream_id: 'stream-1' })),
+    ]);
+
+    expect([first.status, second.status].sort()).toEqual([200, 200]);
+    expect([first.body.disconnectedCount, second.body.disconnectedCount].sort()).toEqual([0, 1]);
+    expect(hub.disconnectByStreamId).toHaveBeenCalledTimes(2);
+    expect(mocks.query).toHaveBeenCalledTimes(2);
+  });
+
+  it('returns 503 when the websocket hub has not been initialized', async () => {
+    mocks.getStreamHub.mockReturnValue(null);
+
+    const res = await authed(
+      request(app).post('/api/admin/ws/disconnect').send({ stream_id: 'stream-1' })
+    );
+
+    expect(res.status).toBe(503);
+    expect(mocks.query).not.toHaveBeenCalled();
+  });
+});

--- a/tests/ws/hub.adminDisconnect.test.ts
+++ b/tests/ws/hub.adminDisconnect.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import http from 'http';
+import { WebSocket } from 'ws';
+import { StreamHub } from '../../src/ws/hub.js';
+
+function setup(): Promise<{ server: http.Server; hub: StreamHub; port: number }> {
+  const server = http.createServer();
+  const hub = new StreamHub(server);
+
+  return new Promise((resolve) => {
+    server.listen(0, '127.0.0.1', () => {
+      const address = server.address() as { port: number };
+      resolve({ server, hub, port: address.port });
+    });
+  });
+}
+
+function teardown(server: http.Server, hub: StreamHub): Promise<void> {
+  return new Promise((resolve) => {
+    hub.close(() => server.close(() => resolve()));
+  });
+}
+
+function connect(port: number): Promise<WebSocket> {
+  return new Promise((resolve, reject) => {
+    const ws = new WebSocket(`ws://127.0.0.1:${port}/ws/streams`);
+    ws.once('open', () => resolve(ws));
+    ws.once('error', reject);
+  });
+}
+
+function subscribe(ws: WebSocket, streamId: string): Promise<void> {
+  return new Promise((resolve) => {
+    ws.send(JSON.stringify({ type: 'subscribe', streamId }));
+    setTimeout(resolve, 30);
+  });
+}
+
+function waitForClose(ws: WebSocket): Promise<{ code: number; reason: string }> {
+  return new Promise((resolve) => {
+    ws.once('close', (code, reason) => {
+      resolve({ code, reason: reason.toString('utf8') });
+    });
+  });
+}
+
+describe('StreamHub admin disconnect', () => {
+  let server: http.Server;
+  let hub: StreamHub;
+  let port: number;
+
+  beforeEach(async () => {
+    ({ server, hub, port } = await setup());
+  });
+
+  afterEach(async () => {
+    await teardown(server, hub);
+  });
+
+  it('force-closes sockets subscribed to a stream with the admin close code and reason', async () => {
+    const streamA = await connect(port);
+    const streamB = await connect(port);
+    const bystander = await connect(port);
+
+    await Promise.all([
+      subscribe(streamA, 'stream-a'),
+      subscribe(streamB, 'stream-a'),
+      subscribe(bystander, 'stream-b'),
+    ]);
+
+    const closeA = waitForClose(streamA);
+    const closeB = waitForClose(streamB);
+    const bystanderClose = new Promise((resolve) => {
+      let settled = false;
+      bystander.once('close', () => {
+        settled = true;
+        resolve(true);
+      });
+      setTimeout(() => {
+        if (!settled) resolve(false);
+      }, 50);
+    });
+
+    expect(hub.disconnectByStreamId('stream-a')).toBe(2);
+
+    await expect(closeA).resolves.toEqual({ code: 4000, reason: 'admin-forced-disconnect' });
+    await expect(closeB).resolves.toEqual({ code: 4000, reason: 'admin-forced-disconnect' });
+    await expect(bystanderClose).resolves.toBe(false);
+
+    bystander.close();
+  });
+
+  it('returns zero when no sockets are subscribed to the stream', () => {
+    expect(hub.disconnectByStreamId('missing-stream')).toBe(0);
+  });
+});


### PR DESCRIPTION
closes #283 

This pull request introduces a new admin API endpoint for forcibly disconnecting all WebSocket subscribers to a specific stream, along with robust audit logging for this operation. The changes also refactor audit log handling to support durable logging for admin actions, and update documentation to reflect the new functionality. Minor code formatting improvements and type additions are included as well.

**New admin WebSocket disconnect endpoint and auditing:**

* Adds `POST /api/admin/ws/disconnect`, an admin-only endpoint that force-closes all WebSocket subscriptions for a given `stream_id`, returning the number of disconnected clients. The endpoint validates input, handles errors gracefully, and persists an audit log entry for every invocation. (Fe24dbc1L122R122, [docs/api/admin-endpoints.mdR1-R52](diffhunk://#diff-37b3fb69378d7107c229110a83efea11ce56cadb2ca89cd48cc81f1f024590caR1-R52), Fb207596L448R448)

* Introduces the `ADMIN_WS_DISCONNECT` audit action type and a new `recordAuditEventToDb` function to ensure admin-triggered disconnects are durably logged in the database and mirrored in the in-memory audit log. [[1]](diffhunk://#diff-eb6cc2f3f0f64d300435157cc40326fc37dd80186a313500f634b8384d932ebaR31-R42) [[2]](diffhunk://#diff-eb6cc2f3f0f64d300435157cc40326fc37dd80186a313500f634b8384d932ebaL136-R205)

**Audit log improvements:**

* Refactors audit log code to add a third write path (`recordAuditEventToDb`) for non-transactional, durable audit entries, and centralizes in-memory log appending via a new helper. Updates all relevant code paths to use the new helper for consistency. [[1]](diffhunk://#diff-eb6cc2f3f0f64d300435157cc40326fc37dd80186a313500f634b8384d932ebaL8-R17) [[2]](diffhunk://#diff-eb6cc2f3f0f64d300435157cc40326fc37dd80186a313500f634b8384d932ebaL63-R87) [[3]](diffhunk://#diff-eb6cc2f3f0f64d300435157cc40326fc37dd80186a313500f634b8384d932ebaL88-R112)

**Documentation updates:**

* Adds a new `docs/api/admin-endpoints.md` file documenting the new disconnect endpoint and related admin APIs, and links to it from the main API reference. [[1]](diffhunk://#diff-9eddf4dc51bf6a0125ca7fb094468ad284112270385c41cebce4f8f0a29620abR3-R4) [[2]](diffhunk://#diff-37b3fb69378d7107c229110a83efea11ce56cadb2ca89cd48cc81f1f024590caR1-R52)

**WebSocket hub enhancements:**

* Implements the `disconnectByStreamId` method in `StreamHub`, which force-closes all sockets subscribed to a given stream with a specific close code and reason, and returns the count of disconnected sockets. (Fb207596L448R448)

**Minor improvements and formatting:**

* Cleans up code formatting, type signatures, and function parameter handling in various files for readability and consistency. [[1]](diffhunk://#diff-3b0664b5134d0c452fb1e28763afcbd4a48778271b62e910c7bc90f6087378b7L163-R165) Fb207596L364R364, [[2]](diffhunk://#diff-3b0664b5134d0c452fb1e28763afcbd4a48778271b62e910c7bc90f6087378b7L503-R539) [[3]](diffhunk://#diff-3b0664b5134d0c452fb1e28763afcbd4a48778271b62e910c7bc90f6087378b7L639-R687)

These changes together provide operators with a safe, auditable way to forcibly disconnect clients from a stream, and lay the groundwork for further admin operational controls.