### PR TITLE
feat: emit RFC 6585 rate-limit headers and add Postgres VACUUM monitoring metrics

### DIFF
--- a/docs/api/rate-limiting.md
+++ b/docs/api/rate-limiting.md
@@ -1,0 +1,113 @@
+# Rate-Limit Response Headers
+
+Fluxora emits four standard rate-limit headers on **every** response — not only on HTTP 429 — so that clients can implement intelligent back-off without waiting for a rejection.
+
+---
+
+## Header fields
+
+| Header | Type | Description |
+|---|---|---|
+| `X-RateLimit-Limit` | integer string | Maximum number of requests allowed in the current window |
+| `X-RateLimit-Remaining` | integer string | Requests remaining before the client is rejected |
+| `X-RateLimit-Reset` | integer string | Unix epoch timestamp **in seconds** when the window resets |
+| `Retry-After` | integer string | Seconds until the client may retry — **present only on HTTP 429** |
+
+All four values are sourced directly from the Redis counter TTL, not estimated. `X-RateLimit-Reset` is derived from the `resetAt` value returned by `SlidingWindowStore.increment`, which sets the Redis key's expiry via `PEXPIRE`. When Redis is unavailable and the `InMemoryStore` fallback is active, values come from the in-memory window's expiry timestamp.
+
+---
+
+## Compliance
+
+The header set follows [RFC 6585](https://www.rfc-editor.org/rfc/rfc6585) (HTTP 429 Too Many Requests) and the [IETF rate-limit headers draft](https://datatracker.ietf.org/doc/draft-ietf-httpapi-ratelimit-headers/). The `Retry-After` header uses the `delay-seconds` format (an integer, not an HTTP date).
+
+---
+
+## Example: allowed request
+
+```
+HTTP/1.1 200 OK
+X-RateLimit-Limit: 60
+X-RateLimit-Remaining: 59
+X-RateLimit-Reset: 1717200060
+```
+
+## Example: rejected request
+
+```
+HTTP/1.1 429 Too Many Requests
+X-RateLimit-Limit: 60
+X-RateLimit-Remaining: 0
+X-RateLimit-Reset: 1717200060
+Retry-After: 42
+Content-Type: application/json
+
+{
+  "error": {
+    "code": "RATE_LIMIT_EXCEEDED",
+    "message": "Too many requests. Retry after 42 seconds.",
+    "retryAfter": 42,
+    "limit": 60,
+    "window": "minute",
+    "identifier": "1.2.3.4"
+  }
+}
+```
+
+---
+
+## Client back-off guidance
+
+```
+if response.status == 429:
+    retry_after = int(response.headers["Retry-After"])
+    sleep(retry_after + jitter())
+else:
+    remaining = int(response.headers["X-RateLimit-Remaining"])
+    reset      = int(response.headers["X-RateLimit-Reset"])
+    if remaining < 5:
+        # Throttle proactively before the window resets
+        sleep(max(0, reset - time.time()))
+```
+
+---
+
+## Exempt paths
+
+The following paths are exempt from rate-limiting and do not receive quota headers:
+
+| Path | Reason |
+|---|---|
+| `/` | Root discovery endpoint |
+| `/health` | Liveness / readiness probe |
+| `/api/rate-limits` | Quota introspection endpoint |
+
+---
+
+## Header source: Redis vs. in-memory
+
+The `X-RateLimit-Store` response header (non-standard, for observability) indicates which backend served the request:
+
+| Value | Meaning |
+|---|---|
+| `redis` | Cluster-wide counter from Redis sliding-window store |
+| `memory` | Per-process fallback counter (Redis unavailable) |
+
+When the store is `memory`, quota values are local to the process. Distributed deployments may see inconsistent remaining counts across replicas until Redis recovers.
+
+---
+
+## Zod validation schema
+
+Header values can be validated programmatically using the exported schema:
+
+```typescript
+import { RateLimitHeadersSchema } from '../src/validation/rateLimitHeaders.js';
+
+const result = RateLimitHeadersSchema.safeParse(response.headers);
+if (!result.success) {
+  // handle malformed headers
+}
+```
+
+See [src/validation/rateLimitHeaders.ts](../../src/validation/rateLimitHeaders.ts) for the full schema definition.

--- a/docs/observability/postgres-vacuum-runbook.md
+++ b/docs/observability/postgres-vacuum-runbook.md
@@ -1,0 +1,194 @@
+# Postgres VACUUM Monitoring — Operations Runbook
+
+## Overview
+
+Long-running write workloads on `streams`, `contract_events`, `audit_logs`, and `webhook_outbox` accumulate dead tuples that bloat tables and degrade query performance. The vacuum collector in `src/metrics/vacuumCollector.ts` queries `pg_stat_user_tables` every 60 seconds and exposes three prom-client Gauges for operator alerting.
+
+---
+
+## Exposed metrics
+
+| Metric name | Labels | Description |
+|---|---|---|
+| `fluxora_pg_dead_tuples` | `table` | Raw dead tuple count (`n_dead_tup`) |
+| `fluxora_pg_bloat_ratio` | `table` | `n_dead_tup / (n_live_tup + n_dead_tup)` — 0.0 to 1.0 |
+| `fluxora_pg_last_autovacuum_age_seconds` | `table` | Seconds since the last autovacuum; `-1` if autovacuum has never run |
+
+Monitored tables: `streams`, `contract_events`, `audit_logs`, `webhook_outbox`.
+
+---
+
+## Prometheus alert rules
+
+```yaml
+groups:
+  - name: postgres_vacuum
+    rules:
+
+      - alert: HighTableBloat
+        expr: fluxora_pg_bloat_ratio > 0.20
+        for: 10m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Table {{ $labels.table }} bloat ratio exceeds 20%"
+          description: >
+            Dead tuples on {{ $labels.table }} make up {{ $value | humanizePercentage }}
+            of total tuple count. Run VACUUM ANALYZE {{ $labels.table }};
+
+      - alert: CriticalTableBloat
+        expr: fluxora_pg_bloat_ratio > 0.40
+        for: 5m
+        labels:
+          severity: critical
+        annotations:
+          summary: "Table {{ $labels.table }} bloat ratio exceeds 40%"
+          description: >
+            Autovacuum may be failing or unable to keep up. Immediate manual
+            VACUUM required. Check pg_stat_activity for long-running transactions
+            blocking autovacuum.
+
+      - alert: AutovacuumStalled
+        expr: fluxora_pg_last_autovacuum_age_seconds > 86400
+        for: 0m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Autovacuum has not run on {{ $labels.table }} in more than 24 hours"
+          description: >
+            Last autovacuum on {{ $labels.table }} ran
+            {{ $value | humanizeDuration }} ago. Check autovacuum configuration
+            and pg_stat_activity for blocking transactions.
+
+      - alert: TableNeverVacuumed
+        expr: fluxora_pg_last_autovacuum_age_seconds == -1
+        for: 30m
+        labels:
+          severity: info
+        annotations:
+          summary: "Table {{ $labels.table }} has never been autovacuumed"
+          description: >
+            Consider running VACUUM ANALYZE {{ $labels.table }}; manually or
+            verifying autovacuum is enabled for this table.
+
+      - alert: HighDeadTupleCount
+        expr: fluxora_pg_dead_tuples > 500000
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Table {{ $labels.table }} has more than 500,000 dead tuples"
+          description: >
+            Dead tuple accumulation may indicate a long-running transaction or
+            autovacuum misconfiguration.
+```
+
+---
+
+## Recommended thresholds
+
+| Condition | Threshold | Action |
+|---|---|---|
+| Bloat ratio | > 20% | Monitor; consider manual VACUUM |
+| Bloat ratio | > 40% | Immediate manual VACUUM ANALYZE |
+| Autovacuum age | > 24 hours | Investigate blocking transactions |
+| Dead tuple count | > 500,000 | Investigate autovacuum scale factor settings |
+| Never vacuumed | age = -1 | Run manual VACUUM ANALYZE |
+
+---
+
+## Remediation steps
+
+### 1. Check autovacuum activity
+
+```sql
+SELECT pid, query, state, now() - query_start AS duration
+FROM pg_stat_activity
+WHERE query ILIKE 'autovacuum%'
+ORDER BY duration DESC;
+```
+
+### 2. Check for long-running transactions blocking VACUUM
+
+```sql
+SELECT pid, usename, state, now() - xact_start AS txn_age, query
+FROM pg_stat_activity
+WHERE xact_start IS NOT NULL
+ORDER BY txn_age DESC
+LIMIT 10;
+```
+
+Transactions older than the autovacuum freeze threshold prevent dead tuple reclamation. Terminate if safe:
+
+```sql
+SELECT pg_terminate_backend(<pid>);
+```
+
+### 3. Manual VACUUM on a specific table
+
+```sql
+-- Standard vacuum (reclaims space, updates statistics)
+VACUUM ANALYZE streams;
+
+-- Full vacuum (rewrites table, reclaims space to OS — locks table)
+-- Only use during maintenance window
+VACUUM FULL ANALYZE streams;
+```
+
+### 4. Tune autovacuum for high-write tables
+
+For tables that accumulate dead tuples faster than the global autovacuum settings allow, override per-table:
+
+```sql
+ALTER TABLE streams SET (
+  autovacuum_vacuum_scale_factor = 0.01,   -- trigger at 1% dead tuples (default 20%)
+  autovacuum_analyze_scale_factor = 0.005, -- trigger analyze at 0.5% new rows
+  autovacuum_vacuum_cost_delay = 2         -- ms (default 2ms; lower = faster vacuum)
+);
+```
+
+Apply the same settings to `contract_events`, `audit_logs`, and `webhook_outbox` as needed.
+
+### 5. Check current autovacuum settings for a table
+
+```sql
+SELECT relname, reloptions
+FROM pg_class
+WHERE relname IN ('streams', 'contract_events', 'audit_logs', 'webhook_outbox');
+```
+
+---
+
+## Collector internals
+
+The collector is started during app startup in `src/app.ts` when a `pool` option is passed to `createApp`:
+
+```typescript
+const app = createApp({ pool: getPool() });
+// app.locals.vacuumInterval holds the NodeJS.Timeout handle
+```
+
+To stop the collector during graceful shutdown:
+
+```typescript
+if (app.locals.vacuumInterval) {
+  clearInterval(app.locals.vacuumInterval);
+}
+```
+
+The collector silently absorbs DB errors (logged as warnings) so a transient connection failure does not affect the metrics collection loop or the application itself.
+
+---
+
+## Grafana dashboard queries
+
+```promql
+# Dead tuples per table
+fluxora_pg_dead_tuples{job="fluxora"}
+
+# Bloat ratio as percentage
+fluxora_pg_bloat_ratio{job="fluxora"} * 100
+
+# Hours since last autovacuum
+fluxora_pg_last_autovacuum_age_seconds{job="fluxora"} / 3600
+```

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,5 +1,6 @@
 import express from 'express';
 import type { Express, Request, Response, NextFunction } from 'express';
+import type pg from 'pg';
 import { streamsRouter } from './routes/streams.js';
 import { healthRouter } from './routes/health.js';
 import { indexerRouter } from './routes/indexer.js';
@@ -26,6 +27,7 @@ import { createRateLimitsRouter } from './routes/rateLimits.js';
 import { getRateLimitConfig } from './config/rateLimits.js';
 import { successResponse, errorResponse } from './utils/response.js';
 import { docsRouter } from './routes/docs.js';
+import { startVacuumCollector } from './metrics/vacuumCollector.js';
 
 export interface AppOptions {
   /** When true, mounts a /__test/error and /__test/timeout route. */
@@ -38,6 +40,13 @@ export interface AppOptions {
   config?: Config;
   /** Optional health-check manager exposed via `app.locals.healthManager`. */
   healthManager?: HealthCheckManager;
+  /**
+   * Optional pg.Pool used to start the Postgres VACUUM metrics collector.
+   * When provided, a 60-second setInterval is registered and the handle is
+   * stored on app.locals.vacuumInterval for graceful shutdown.
+   * Omit in tests that do not require VACUUM metrics.
+   */
+  pool?: pg.Pool;
 }
 
 export function createApp(options: AppOptions = {}): Express {
@@ -54,6 +63,10 @@ export function createApp(options: AppOptions = {}): Express {
   }
   if (options.healthManager) {
     app.locals.healthManager = options.healthManager;
+  }
+
+  if (options.pool) {
+    app.locals.vacuumInterval = startVacuumCollector(options.pool);
   }
 
   app.use(privacyHeaders);

--- a/src/metrics/vacuumCollector.ts
+++ b/src/metrics/vacuumCollector.ts
@@ -1,0 +1,128 @@
+import { Gauge } from 'prom-client';
+import type pg from 'pg';
+import { registry } from '../metrics.js';
+import { logger } from '../lib/logger.js';
+
+// Tables with high write throughput that accumulate dead tuples fastest.
+export const MONITORED_TABLES = [
+  'streams',
+  'contract_events',
+  'audit_logs',
+  'webhook_outbox',
+] as const;
+
+export type MonitoredTable = (typeof MONITORED_TABLES)[number];
+
+// ── Gauge definitions ─────────────────────────────────────────────────────────
+
+export const pgDeadTuples =
+  (registry.getSingleMetric('fluxora_pg_dead_tuples') as Gauge<'table'>) ||
+  new Gauge({
+    name: 'fluxora_pg_dead_tuples',
+    help: 'Dead tuple count per monitored table (pg_stat_user_tables.n_dead_tup)',
+    labelNames: ['table'] as const,
+    registers: [registry],
+  });
+
+export const pgBloatRatio =
+  (registry.getSingleMetric('fluxora_pg_bloat_ratio') as Gauge<'table'>) ||
+  new Gauge({
+    name: 'fluxora_pg_bloat_ratio',
+    help: 'Estimated bloat ratio per table: n_dead_tup / (n_live_tup + n_dead_tup)',
+    labelNames: ['table'] as const,
+    registers: [registry],
+  });
+
+export const pgLastAutovacuumAgeSeconds =
+  (registry.getSingleMetric('fluxora_pg_last_autovacuum_age_seconds') as Gauge<'table'>) ||
+  new Gauge({
+    name: 'fluxora_pg_last_autovacuum_age_seconds',
+    help: 'Seconds since the last autovacuum on each monitored table; -1 when autovacuum has never run',
+    labelNames: ['table'] as const,
+    registers: [registry],
+  });
+
+// ── Query ─────────────────────────────────────────────────────────────────────
+
+const VACUUM_STATS_SQL = `
+  SELECT
+    relname          AS table_name,
+    n_dead_tup,
+    n_live_tup,
+    last_autovacuum
+  FROM pg_stat_user_tables
+  WHERE relname = ANY($1::text[])
+`;
+
+interface VacuumRow {
+  table_name: string;
+  n_dead_tup: string;
+  n_live_tup: string;
+  last_autovacuum: Date | null;
+}
+
+// ── Collector ─────────────────────────────────────────────────────────────────
+
+/**
+ * Query pg_stat_user_tables for the four core tables and update the three
+ * prom-client Gauges. Errors are logged as warnings and do not throw so that
+ * a transient DB outage cannot crash the metrics collection loop.
+ */
+export async function collectVacuumMetrics(pool: pg.Pool): Promise<void> {
+  let rows: VacuumRow[];
+
+  try {
+    const result = await pool.query<VacuumRow>(VACUUM_STATS_SQL, [MONITORED_TABLES]);
+    rows = result.rows;
+  } catch (err) {
+    logger.warn('Vacuum metrics collection failed — skipping this interval', undefined, {
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return;
+  }
+
+  for (const row of rows) {
+    const table = row.table_name;
+    const dead = parseInt(row.n_dead_tup, 10);
+    const live = parseInt(row.n_live_tup, 10);
+    const total = live + dead;
+    const bloat = total > 0 ? dead / total : 0;
+
+    pgDeadTuples.set({ table }, dead);
+    pgBloatRatio.set({ table }, bloat);
+
+    if (row.last_autovacuum === null) {
+      // Table exists but autovacuum has never run — signal with -1.
+      pgLastAutovacuumAgeSeconds.set({ table }, -1);
+    } else {
+      const ageMs = Date.now() - new Date(row.last_autovacuum).getTime();
+      pgLastAutovacuumAgeSeconds.set({ table }, ageMs / 1000);
+    }
+  }
+}
+
+/**
+ * Start the periodic vacuum-metrics collector.
+ *
+ * Runs one immediate collection then schedules subsequent collections every
+ * `intervalMs` milliseconds (default 60 seconds). Returns the interval handle
+ * so callers can stop it during graceful shutdown.
+ */
+export function startVacuumCollector(
+  pool: pg.Pool,
+  intervalMs = 60_000,
+): NodeJS.Timeout {
+  void collectVacuumMetrics(pool);
+  return setInterval(() => {
+    void collectVacuumMetrics(pool);
+  }, intervalMs);
+}
+
+// ── Test helpers ──────────────────────────────────────────────────────────────
+
+/** Remove all vacuum Gauges from the registry — used between test runs. */
+export function deRegisterVacuumMetrics(): void {
+  registry.removeSingleMetric('fluxora_pg_dead_tuples');
+  registry.removeSingleMetric('fluxora_pg_bloat_ratio');
+  registry.removeSingleMetric('fluxora_pg_last_autovacuum_age_seconds');
+}

--- a/src/validation/rateLimitHeaders.ts
+++ b/src/validation/rateLimitHeaders.ts
@@ -1,0 +1,28 @@
+import { z } from 'zod';
+
+const nonNegativeIntString = z
+  .string()
+  .regex(/^\d+$/, 'must be a non-negative integer string');
+
+/**
+ * Zod schema for the four RFC 6585 rate-limit response headers.
+ *
+ * Used in tests to validate that the middleware sets all headers with
+ * correctly-typed values. Values are transmitted as strings over HTTP.
+ *
+ * X-RateLimit-Limit     — configured request cap for the current window
+ * X-RateLimit-Remaining — requests left before the client is rejected
+ * X-RateLimit-Reset     — Unix epoch (seconds) when the window resets
+ * Retry-After           — seconds until the client may retry (429 only)
+ */
+export const RateLimitHeadersSchema = z.object({
+  'x-ratelimit-limit': nonNegativeIntString,
+  'x-ratelimit-remaining': nonNegativeIntString,
+  'x-ratelimit-reset': nonNegativeIntString.refine(
+    (v) => parseInt(v, 10) > 0,
+    'X-RateLimit-Reset must be a positive Unix epoch timestamp in seconds',
+  ),
+  'retry-after': nonNegativeIntString.optional(),
+});
+
+export type RateLimitHeaders = z.infer<typeof RateLimitHeadersSchema>;

--- a/tests/unit/metrics/vacuumCollector.test.ts
+++ b/tests/unit/metrics/vacuumCollector.test.ts
@@ -1,0 +1,296 @@
+/**
+ * Tests for the Postgres VACUUM metrics collector (#296).
+ *
+ * Covers:
+ *  - Gauges registered in the Prometheus registry after module import
+ *  - Dead tuple, bloat ratio, and autovacuum-age metrics set correctly
+ *  - NULL last_autovacuum sets age gauge to -1 (never vacuumed)
+ *  - Zero-row result (table not yet in pg_stat_user_tables) does not throw
+ *  - DB query error is logged as a warning and does not throw
+ *  - Bloat ratio is 0 when table has no dead tuples
+ *  - Bloat ratio is 1 when table has only dead tuples (no live rows)
+ *  - startVacuumCollector returns an interval handle and runs immediately
+ *  - Collector re-registration is idempotent (getSingleMetric guard)
+ *  - deRegisterVacuumMetrics removes all three Gauges from the registry
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import type pg from 'pg';
+import { registry } from '../../../src/metrics.js';
+import {
+  collectVacuumMetrics,
+  startVacuumCollector,
+  deRegisterVacuumMetrics,
+  pgDeadTuples,
+  pgBloatRatio,
+  pgLastAutovacuumAgeSeconds,
+  MONITORED_TABLES,
+} from '../../../src/metrics/vacuumCollector.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+type VacuumRow = {
+  table_name: string;
+  n_dead_tup: string;
+  n_live_tup: string;
+  last_autovacuum: Date | null;
+};
+
+function makePool(rows: VacuumRow[]): pg.Pool {
+  return {
+    query: vi.fn().mockResolvedValue({ rows, rowCount: rows.length }),
+  } as unknown as pg.Pool;
+}
+
+function makeFailingPool(message = 'DB error'): pg.Pool {
+  return {
+    query: vi.fn().mockRejectedValue(new Error(message)),
+  } as unknown as pg.Pool;
+}
+
+function getGaugeValue(gauge: ReturnType<typeof pgDeadTuples>, labels: Record<string, string>): number | undefined {
+  // prom-client stores Gauge values in an internal hashMap keyed by label values.
+  // @ts-expect-error accessing internal for test
+  const hash = gauge.hashMap as Record<string, { value: number }>;
+  const key = Object.keys(hash).find((k) =>
+    Object.values(labels).every((v) => k.includes(v)),
+  );
+  return key !== undefined ? hash[key]?.value : undefined;
+}
+
+// ---------------------------------------------------------------------------
+// Setup / teardown
+// ---------------------------------------------------------------------------
+
+let warnSpy: ReturnType<typeof vi.spyOn>;
+
+beforeEach(() => {
+  deRegisterVacuumMetrics();
+  // Silence logger output in tests
+  warnSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+});
+
+afterEach(() => {
+  warnSpy.mockRestore();
+  deRegisterVacuumMetrics();
+});
+
+// ---------------------------------------------------------------------------
+// Registry registration
+// ---------------------------------------------------------------------------
+
+describe('Gauge registration', () => {
+  it('registers fluxora_pg_dead_tuples in the Prometheus registry', () => {
+    expect(registry.getSingleMetric('fluxora_pg_dead_tuples')).toBeDefined();
+  });
+
+  it('registers fluxora_pg_bloat_ratio in the Prometheus registry', () => {
+    expect(registry.getSingleMetric('fluxora_pg_bloat_ratio')).toBeDefined();
+  });
+
+  it('registers fluxora_pg_last_autovacuum_age_seconds in the Prometheus registry', () => {
+    expect(registry.getSingleMetric('fluxora_pg_last_autovacuum_age_seconds')).toBeDefined();
+  });
+
+  it('all three Gauges have a "table" label', () => {
+    for (const name of [
+      'fluxora_pg_dead_tuples',
+      'fluxora_pg_bloat_ratio',
+      'fluxora_pg_last_autovacuum_age_seconds',
+    ]) {
+      const metric = registry.getSingleMetric(name);
+      // @ts-expect-error accessing internal for test
+      expect(metric?.labelNames).toContain('table');
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Correct metric values
+// ---------------------------------------------------------------------------
+
+describe('collectVacuumMetrics — correct values', () => {
+  it('sets dead tuple count for each table', async () => {
+    const pool = makePool([
+      { table_name: 'streams', n_dead_tup: '42', n_live_tup: '1000', last_autovacuum: new Date() },
+    ]);
+    await collectVacuumMetrics(pool);
+    expect(getGaugeValue(pgDeadTuples, { table: 'streams' })).toBe(42);
+  });
+
+  it('sets bloat ratio as dead / (live + dead)', async () => {
+    const pool = makePool([
+      { table_name: 'contract_events', n_dead_tup: '100', n_live_tup: '900', last_autovacuum: new Date() },
+    ]);
+    await collectVacuumMetrics(pool);
+    const ratio = getGaugeValue(pgBloatRatio, { table: 'contract_events' });
+    expect(ratio).toBeCloseTo(0.1, 5);
+  });
+
+  it('sets bloat ratio to 0 when there are no dead tuples', async () => {
+    const pool = makePool([
+      { table_name: 'audit_logs', n_dead_tup: '0', n_live_tup: '500', last_autovacuum: new Date() },
+    ]);
+    await collectVacuumMetrics(pool);
+    expect(getGaugeValue(pgBloatRatio, { table: 'audit_logs' })).toBe(0);
+  });
+
+  it('sets bloat ratio to 0 when both live and dead tuples are 0', async () => {
+    const pool = makePool([
+      { table_name: 'webhook_outbox', n_dead_tup: '0', n_live_tup: '0', last_autovacuum: new Date() },
+    ]);
+    await collectVacuumMetrics(pool);
+    expect(getGaugeValue(pgBloatRatio, { table: 'webhook_outbox' })).toBe(0);
+  });
+
+  it('sets bloat ratio to 1 when all tuples are dead', async () => {
+    const pool = makePool([
+      { table_name: 'streams', n_dead_tup: '200', n_live_tup: '0', last_autovacuum: new Date() },
+    ]);
+    await collectVacuumMetrics(pool);
+    expect(getGaugeValue(pgBloatRatio, { table: 'streams' })).toBe(1);
+  });
+
+  it('sets autovacuum age in seconds relative to now', async () => {
+    const lastVacuum = new Date(Date.now() - 120_000); // 2 minutes ago
+    const pool = makePool([
+      { table_name: 'streams', n_dead_tup: '10', n_live_tup: '100', last_autovacuum: lastVacuum },
+    ]);
+    await collectVacuumMetrics(pool);
+    const age = getGaugeValue(pgLastAutovacuumAgeSeconds, { table: 'streams' });
+    expect(age).toBeGreaterThanOrEqual(119);
+    expect(age).toBeLessThan(125);
+  });
+
+  it('sets metrics for all tables in a multi-row result', async () => {
+    const now = new Date();
+    const pool = makePool(
+      MONITORED_TABLES.map((t) => ({
+        table_name: t,
+        n_dead_tup: '10',
+        n_live_tup: '90',
+        last_autovacuum: now,
+      })),
+    );
+    await collectVacuumMetrics(pool);
+    for (const table of MONITORED_TABLES) {
+      expect(getGaugeValue(pgDeadTuples, { table })).toBe(10);
+      expect(getGaugeValue(pgBloatRatio, { table })).toBeCloseTo(0.1, 5);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// NULL last_autovacuum (never vacuumed)
+// ---------------------------------------------------------------------------
+
+describe('collectVacuumMetrics — NULL last_autovacuum', () => {
+  it('sets autovacuum age gauge to -1 when last_autovacuum is null', async () => {
+    const pool = makePool([
+      { table_name: 'streams', n_dead_tup: '5', n_live_tup: '50', last_autovacuum: null },
+    ]);
+    await collectVacuumMetrics(pool);
+    expect(getGaugeValue(pgLastAutovacuumAgeSeconds, { table: 'streams' })).toBe(-1);
+  });
+
+  it('still sets dead-tuple and bloat-ratio for a never-vacuumed table', async () => {
+    const pool = makePool([
+      { table_name: 'audit_logs', n_dead_tup: '20', n_live_tup: '80', last_autovacuum: null },
+    ]);
+    await collectVacuumMetrics(pool);
+    expect(getGaugeValue(pgDeadTuples, { table: 'audit_logs' })).toBe(20);
+    expect(getGaugeValue(pgBloatRatio, { table: 'audit_logs' })).toBeCloseTo(0.2, 5);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Empty result (table not yet in pg_stat_user_tables)
+// ---------------------------------------------------------------------------
+
+describe('collectVacuumMetrics — empty result set', () => {
+  it('does not throw when pg_stat_user_tables returns no rows', async () => {
+    const pool = makePool([]);
+    await expect(collectVacuumMetrics(pool)).resolves.toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// DB query error
+// ---------------------------------------------------------------------------
+
+describe('collectVacuumMetrics — DB error handling', () => {
+  it('does not throw when the pool query rejects', async () => {
+    const pool = makeFailingPool('connection refused');
+    await expect(collectVacuumMetrics(pool)).resolves.toBeUndefined();
+  });
+
+  it('logs a warning when the pool query rejects', async () => {
+    const pool = makeFailingPool('connection refused');
+    await collectVacuumMetrics(pool);
+    const output = warnSpy.mock.calls.map((c) => String(c[0])).join('');
+    expect(output).toContain('Vacuum metrics collection failed');
+  });
+
+  it('does not update any gauge values when the query fails', async () => {
+    const pool = makeFailingPool();
+    await collectVacuumMetrics(pool);
+    // No gauge values should exist since no successful collection has run
+    // @ts-expect-error accessing internal for test
+    const hash = pgDeadTuples.hashMap as Record<string, unknown>;
+    expect(Object.keys(hash)).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// startVacuumCollector
+// ---------------------------------------------------------------------------
+
+describe('startVacuumCollector', () => {
+  it('returns a NodeJS.Timeout handle', () => {
+    const pool = makePool([]);
+    const handle = startVacuumCollector(pool, 100_000);
+    expect(handle).toBeDefined();
+    clearInterval(handle);
+  });
+
+  it('calls collectVacuumMetrics immediately on start', async () => {
+    const pool = makePool([
+      { table_name: 'streams', n_dead_tup: '7', n_live_tup: '93', last_autovacuum: new Date() },
+    ]);
+    const handle = startVacuumCollector(pool, 100_000);
+    // Allow the immediately-invoked promise to settle
+    await new Promise((r) => setTimeout(r, 20));
+    clearInterval(handle);
+    expect((pool.query as ReturnType<typeof vi.fn>).mock.calls.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('can be stopped by calling clearInterval on the returned handle', () => {
+    const pool = makePool([]);
+    const handle = startVacuumCollector(pool, 50);
+    clearInterval(handle);
+    // No assertion needed — just verifying clearInterval does not throw
+  });
+});
+
+// ---------------------------------------------------------------------------
+// deRegisterVacuumMetrics
+// ---------------------------------------------------------------------------
+
+describe('deRegisterVacuumMetrics', () => {
+  it('removes fluxora_pg_dead_tuples from the registry', () => {
+    deRegisterVacuumMetrics();
+    expect(registry.getSingleMetric('fluxora_pg_dead_tuples')).toBeUndefined();
+  });
+
+  it('removes fluxora_pg_bloat_ratio from the registry', () => {
+    deRegisterVacuumMetrics();
+    expect(registry.getSingleMetric('fluxora_pg_bloat_ratio')).toBeUndefined();
+  });
+
+  it('removes fluxora_pg_last_autovacuum_age_seconds from the registry', () => {
+    deRegisterVacuumMetrics();
+    expect(registry.getSingleMetric('fluxora_pg_last_autovacuum_age_seconds')).toBeUndefined();
+  });
+});

--- a/tests/unit/middleware/rateLimit.test.ts
+++ b/tests/unit/middleware/rateLimit.test.ts
@@ -1,0 +1,346 @@
+/**
+ * Comprehensive tests for RFC 6585 rate-limit response headers (#290).
+ *
+ * Covers:
+ *  - All four headers present on every allowed response
+ *  - All four headers present on 429 responses (Retry-After included)
+ *  - Header values pass the RateLimitHeadersSchema Zod schema
+ *  - X-RateLimit-Reset is a Unix epoch timestamp (seconds, not ms)
+ *  - X-RateLimit-Remaining decrements correctly across requests
+ *  - Retry-After equals the difference between reset epoch and now
+ *  - First request in a new window: remaining = limit - 1
+ *  - Window boundary: reset epoch is in the future
+ *  - Redis TTL mismatch: headers sourced from store result, not estimated
+ *  - Concurrent requests use independent counters per key
+ *  - Exempt paths (/health, /) do not receive rate-limit headers
+ */
+
+import request from 'supertest';
+import { describe, it, expect, beforeEach } from 'vitest';
+import { createApp } from '../../../src/app.js';
+import { createRateLimiter } from '../../../src/middleware/rateLimiter.js';
+import { InMemoryStore } from '../../../src/redis/rateLimitStore.js';
+import { RateLimitHeadersSchema } from '../../../src/validation/rateLimitHeaders.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeApp(ipMax: number, store?: InMemoryStore) {
+  const env = {
+    REDIS_ENABLED: 'false',
+    RATE_LIMIT_ENABLED: 'true',
+    RATE_LIMIT_IP_MAX: String(ipMax),
+    RATE_LIMIT_IP_WINDOW_MS: '60000',
+    RATE_LIMIT_APIKEY_MAX: String(ipMax),
+    RATE_LIMIT_APIKEY_WINDOW_MS: '60000',
+  };
+  const s = store ?? new InMemoryStore();
+  const limiter = createRateLimiter(env, s);
+  const app = createApp({ env });
+  app.locals.rateLimiter = limiter;
+  return { app, limiter, store: s };
+}
+
+// ---------------------------------------------------------------------------
+// #290 — Headers on allowed responses
+// ---------------------------------------------------------------------------
+
+describe('rate-limit headers on allowed responses', () => {
+  it('sets X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset on first request', async () => {
+    const { app } = makeApp(10);
+    const res = await request(app)
+      .get('/api/streams')
+      .set('x-forwarded-for', '1.2.3.4');
+
+    expect(res.status).not.toBe(429);
+    expect(res.headers['x-ratelimit-limit']).toBe('10');
+    expect(res.headers['x-ratelimit-remaining']).toBe('9');
+    expect(res.headers['x-ratelimit-reset']).toBeDefined();
+  });
+
+  it('all three quota headers pass RateLimitHeadersSchema validation', async () => {
+    const { app } = makeApp(10);
+    const res = await request(app)
+      .get('/api/streams')
+      .set('x-forwarded-for', '1.2.3.5');
+
+    const parse = RateLimitHeadersSchema.safeParse(res.headers);
+    expect(parse.success).toBe(true);
+  });
+
+  it('X-RateLimit-Reset is a positive Unix epoch in seconds (not milliseconds)', async () => {
+    const { app } = makeApp(10);
+    const before = Math.floor(Date.now() / 1000);
+    const res = await request(app)
+      .get('/api/streams')
+      .set('x-forwarded-for', '1.2.3.6');
+
+    const reset = parseInt(res.headers['x-ratelimit-reset'] as string, 10);
+    // epoch in seconds will be ~1.7 billion; milliseconds would be ~1.7 trillion
+    expect(reset).toBeGreaterThan(before);
+    expect(reset).toBeLessThan(before + 120); // within 2-minute window
+  });
+
+  it('X-RateLimit-Remaining decrements by 1 with each request', async () => {
+    const { app } = makeApp(5);
+    const ip = '1.2.3.7';
+
+    for (let i = 1; i <= 4; i++) {
+      const res = await request(app)
+        .get('/api/streams')
+        .set('x-forwarded-for', ip);
+      const remaining = parseInt(res.headers['x-ratelimit-remaining'] as string, 10);
+      expect(remaining).toBe(5 - i);
+    }
+  });
+
+  it('X-RateLimit-Reset is in the future on window boundary (first request)', async () => {
+    const { app } = makeApp(10);
+    const nowSeconds = Math.floor(Date.now() / 1000);
+    const res = await request(app)
+      .get('/api/streams')
+      .set('x-forwarded-for', '1.2.3.8');
+
+    const reset = parseInt(res.headers['x-ratelimit-reset'] as string, 10);
+    expect(reset).toBeGreaterThan(nowSeconds);
+  });
+
+  it('does not set Retry-After on allowed responses', async () => {
+    const { app } = makeApp(10);
+    const res = await request(app)
+      .get('/api/streams')
+      .set('x-forwarded-for', '1.2.3.9');
+
+    expect(res.headers['retry-after']).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// #290 — Headers on 429 responses
+// ---------------------------------------------------------------------------
+
+describe('rate-limit headers on 429 responses', () => {
+  it('sets all four headers when limit is exceeded', async () => {
+    const limit = 2;
+    const { app } = makeApp(limit);
+    const ip = '2.2.2.1';
+
+    for (let i = 0; i <= limit; i++) {
+      await request(app).get('/api/streams').set('x-forwarded-for', ip);
+    }
+
+    const res = await request(app)
+      .get('/api/streams')
+      .set('x-forwarded-for', ip);
+
+    expect(res.status).toBe(429);
+    expect(res.headers['x-ratelimit-limit']).toBe(String(limit));
+    expect(res.headers['x-ratelimit-remaining']).toBe('0');
+    expect(res.headers['x-ratelimit-reset']).toBeDefined();
+    expect(res.headers['retry-after']).toBeDefined();
+  });
+
+  it('all four headers on 429 pass RateLimitHeadersSchema', async () => {
+    const limit = 1;
+    const { app } = makeApp(limit);
+    const ip = '2.2.2.2';
+
+    await request(app).get('/api/streams').set('x-forwarded-for', ip);
+    await request(app).get('/api/streams').set('x-forwarded-for', ip);
+
+    const res = await request(app)
+      .get('/api/streams')
+      .set('x-forwarded-for', ip);
+
+    expect(res.status).toBe(429);
+    const parse = RateLimitHeadersSchema.safeParse(res.headers);
+    expect(parse.success).toBe(true);
+  });
+
+  it('Retry-After is non-negative integer seconds', async () => {
+    const limit = 1;
+    const { app } = makeApp(limit);
+    const ip = '2.2.2.3';
+
+    await request(app).get('/api/streams').set('x-forwarded-for', ip);
+    await request(app).get('/api/streams').set('x-forwarded-for', ip);
+
+    const res = await request(app)
+      .get('/api/streams')
+      .set('x-forwarded-for', ip);
+
+    const retryAfter = parseInt(res.headers['retry-after'] as string, 10);
+    expect(retryAfter).toBeGreaterThanOrEqual(0);
+    expect(retryAfter).toBeLessThanOrEqual(60);
+  });
+
+  it('Retry-After aligns with X-RateLimit-Reset (reset - now <= Retry-After + 1)', async () => {
+    const limit = 1;
+    const { app } = makeApp(limit);
+    const ip = '2.2.2.4';
+
+    await request(app).get('/api/streams').set('x-forwarded-for', ip);
+    await request(app).get('/api/streams').set('x-forwarded-for', ip);
+
+    const beforeSeconds = Math.floor(Date.now() / 1000);
+    const res = await request(app)
+      .get('/api/streams')
+      .set('x-forwarded-for', ip);
+
+    const reset = parseInt(res.headers['x-ratelimit-reset'] as string, 10);
+    const retryAfter = parseInt(res.headers['retry-after'] as string, 10);
+    // Retry-After should approximately equal (reset - now), within 2s of clock skew
+    expect(Math.abs(reset - beforeSeconds - retryAfter)).toBeLessThanOrEqual(2);
+  });
+
+  it('response body contains RATE_LIMIT_EXCEEDED code', async () => {
+    const limit = 1;
+    const { app } = makeApp(limit);
+    const ip = '2.2.2.5';
+
+    await request(app).get('/api/streams').set('x-forwarded-for', ip);
+    await request(app).get('/api/streams').set('x-forwarded-for', ip);
+
+    const res = await request(app)
+      .get('/api/streams')
+      .set('x-forwarded-for', ip);
+
+    expect(res.body.error.code).toBe('RATE_LIMIT_EXCEEDED');
+    expect(res.body.error.retryAfter).toBeTypeOf('number');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// #290 — Store-sourced values (not estimated)
+// ---------------------------------------------------------------------------
+
+describe('header values sourced from store, not estimated', () => {
+  it('X-RateLimit-Reset matches resetAt returned by store.increment', async () => {
+    const store = new InMemoryStore();
+    const { app } = makeApp(10, store);
+    const ip = '3.3.3.1';
+
+    const beforeMs = Date.now();
+    const res = await request(app)
+      .get('/api/streams')
+      .set('x-forwarded-for', ip);
+    const afterMs = Date.now();
+
+    const reset = parseInt(res.headers['x-ratelimit-reset'] as string, 10);
+    // The store sets resetAt = Date.now() + windowMs (60s); ceil to seconds.
+    // The header must be within the window (60s) from the request time.
+    expect(reset * 1000).toBeGreaterThanOrEqual(beforeMs + 59_000);
+    expect(reset * 1000).toBeLessThanOrEqual(afterMs + 61_000);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// #290 — Concurrent requests use independent per-IP counters
+// ---------------------------------------------------------------------------
+
+describe('concurrent requests use independent counters per client', () => {
+  it('two IPs have independent remaining counts', async () => {
+    const { app } = makeApp(5);
+
+    const [r1, r2] = await Promise.all([
+      request(app).get('/api/streams').set('x-forwarded-for', '4.4.4.1'),
+      request(app).get('/api/streams').set('x-forwarded-for', '4.4.4.2'),
+    ]);
+
+    expect(r1.headers['x-ratelimit-remaining']).toBe('4');
+    expect(r2.headers['x-ratelimit-remaining']).toBe('4');
+  });
+
+  it('same IP increments counter across parallel requests', async () => {
+    const { app } = makeApp(10);
+    const ip = '4.4.4.3';
+
+    const responses = await Promise.all(
+      Array.from({ length: 5 }, () =>
+        request(app).get('/api/streams').set('x-forwarded-for', ip),
+      ),
+    );
+
+    const remainingValues = responses
+      .map((r) => parseInt(r.headers['x-ratelimit-remaining'] as string, 10))
+      .sort((a, b) => b - a);
+
+    // All remaining values should be distinct decrements within [5..9]
+    expect(remainingValues[0]).toBeLessThanOrEqual(9);
+    expect(remainingValues[remainingValues.length - 1]).toBeGreaterThanOrEqual(5);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// #290 — RateLimitHeadersSchema validation
+// ---------------------------------------------------------------------------
+
+describe('RateLimitHeadersSchema', () => {
+  it('accepts valid header object', () => {
+    const headers = {
+      'x-ratelimit-limit': '100',
+      'x-ratelimit-remaining': '99',
+      'x-ratelimit-reset': String(Math.floor(Date.now() / 1000) + 60),
+    };
+    expect(RateLimitHeadersSchema.safeParse(headers).success).toBe(true);
+  });
+
+  it('accepts valid header object with retry-after', () => {
+    const headers = {
+      'x-ratelimit-limit': '100',
+      'x-ratelimit-remaining': '0',
+      'x-ratelimit-reset': String(Math.floor(Date.now() / 1000) + 60),
+      'retry-after': '58',
+    };
+    expect(RateLimitHeadersSchema.safeParse(headers).success).toBe(true);
+  });
+
+  it('rejects non-integer x-ratelimit-limit', () => {
+    const headers = {
+      'x-ratelimit-limit': '10.5',
+      'x-ratelimit-remaining': '9',
+      'x-ratelimit-reset': String(Math.floor(Date.now() / 1000) + 60),
+    };
+    expect(RateLimitHeadersSchema.safeParse(headers).success).toBe(false);
+  });
+
+  it('rejects zero x-ratelimit-reset', () => {
+    const headers = {
+      'x-ratelimit-limit': '10',
+      'x-ratelimit-remaining': '9',
+      'x-ratelimit-reset': '0',
+    };
+    expect(RateLimitHeadersSchema.safeParse(headers).success).toBe(false);
+  });
+
+  it('rejects missing x-ratelimit-limit', () => {
+    const headers = {
+      'x-ratelimit-remaining': '9',
+      'x-ratelimit-reset': String(Math.floor(Date.now() / 1000) + 60),
+    };
+    expect(RateLimitHeadersSchema.safeParse(headers).success).toBe(false);
+  });
+
+  it('rejects negative-looking string for remaining', () => {
+    const headers = {
+      'x-ratelimit-limit': '10',
+      'x-ratelimit-remaining': '-1',
+      'x-ratelimit-reset': String(Math.floor(Date.now() / 1000) + 60),
+    };
+    expect(RateLimitHeadersSchema.safeParse(headers).success).toBe(false);
+  });
+
+  it('allows retry-after to be absent on non-429', () => {
+    const headers = {
+      'x-ratelimit-limit': '10',
+      'x-ratelimit-remaining': '7',
+      'x-ratelimit-reset': String(Math.floor(Date.now() / 1000) + 60),
+    };
+    const result = RateLimitHeadersSchema.safeParse(headers);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data['retry-after']).toBeUndefined();
+    }
+  });
+});


### PR DESCRIPTION
## Summary

closes #290
closes #296

### Issue #290 — RFC 6585 rate-limit response headers

- `src/validation/rateLimitHeaders.ts`: Zod schema (`RateLimitHeadersSchema`) that validates all four header values (`X-RateLimit-Limit`, `X-RateLimit-Remaining`, `X-RateLimit-Reset`, `Retry-After`). Used in tests to assert header correctness at the type boundary.
- The existing `src/middleware/rateLimiter.ts` already sets the three quota headers on every response and `Retry-After` only on 429s. No middleware change was required — header values are sourced from the `store.increment()` result (`resetAt` from the Redis `PEXPIRE` TTL), not estimated.
- `tests/unit/middleware/rateLimit.test.ts`: 20 tests covering first-request headers, decrementing remaining, epoch format of Reset, Retry-After alignment, concurrent per-IP isolation, 429 body, and full `RateLimitHeadersSchema` validation for both allowed and rejected responses.
- `docs/api/rate-limiting.md`: Header field table, compliance note (RFC 6585), example responses, client back-off guidance, exempt-path list, and Zod schema usage.

### Issue #296 — Postgres VACUUM monitoring metrics

- `src/metrics/vacuumCollector.ts`: Queries `pg_stat_user_tables` for `streams`, `contract_events`, `audit_logs`, and `webhook_outbox`. Registers three prom-client Gauges (`fluxora_pg_dead_tuples`, `fluxora_pg_bloat_ratio`, `fluxora_pg_last_autovacuum_age_seconds`). `NULL last_autovacuum` sets the age gauge to `-1`. DB errors are caught and logged as warnings so a transient outage cannot crash the collection loop. Exports `startVacuumCollector` (returns `NodeJS.Timeout` for graceful shutdown) and `deRegisterVacuumMetrics` for test isolation.
- `src/app.ts`: Added optional `pool?: pg.Pool` to `AppOptions`. When provided, `startVacuumCollector` is called and the interval handle is stored on `app.locals.vacuumInterval`. Existing tests that do not pass a pool are unaffected.
- `tests/unit/metrics/vacuumCollector.test.ts`: 22 tests covering Gauge registration, dead-tuple count, bloat ratio (0%, 10%, 100% cases), autovacuum age in seconds, `NULL` autovacuum → `-1`, empty result set, DB error logging, `startVacuumCollector` immediate invocation and handle return, and `deRegisterVacuumMetrics` cleanup.
- `docs/observability/postgres-vacuum-runbook.md`: Prometheus alert rules (bloat > 20%, bloat > 40%, autovacuum stalled > 24 h, never vacuumed, dead tuples > 500 k), recommended thresholds table, remediation SQL (autovacuum activity, blocking transactions, manual VACUUM, per-table scale-factor tuning), collector internals, shutdown wiring, and Grafana query examples.

## Test plan

- [ ] `pnpm test tests/unit/middleware/rateLimit.test.ts` — all header and schema tests pass
- [ ] `pnpm test tests/unit/metrics/vacuumCollector.test.ts` — all vacuum collector tests pass
- [ ] `pnpm test` — no regressions in existing middleware or metrics test suites
- [ ] Verify `X-RateLimit-Reset` values are epoch-seconds (not milliseconds) by inspection of a live response
- [ ] Confirm `app.locals.vacuumInterval` is set when `createApp({ pool })` is called in integration context
