### PR TITLE
Add pgcrypto encryption for sender and recipient addresses with helpe…

### DIFF
--- a/docs/security/pii-encryption.md
+++ b/docs/security/pii-encryption.md
@@ -1,0 +1,47 @@
+# PII Encryption for Streams
+
+This project now protects `sender_address` and `recipient_address` in the `streams`
+PostgreSQL table using row-level `pgcrypto` encryption.
+
+## What changed
+
+- Added a PostgreSQL migration to enable the `pgcrypto` extension.
+- Added an application-managed environment key: `PGCRYPTO_KEY`.
+- Added optional `PGCRYPTO_KEY_PREVIOUS` support for key rotation.
+- Stream writes now encrypt addresses before storing them.
+- Stream reads now decrypt addresses transparently in query results.
+- Queries on `sender_address` / `recipient_address` use keyed hash columns
+  (`sender_address_hash`, `recipient_address_hash`) for efficient filtering.
+
+## Database schema
+
+The `streams` table now includes:
+
+- `sender_address`: encrypted PGP armor text or legacy plaintext
+- `recipient_address`: encrypted PGP armor text or legacy plaintext
+- `sender_address_hash`: HMAC-SHA256 of the sender address keyed by `PGCRYPTO_KEY`
+- `recipient_address_hash`: HMAC-SHA256 of the recipient address keyed by `PGCRYPTO_KEY`
+
+A helper function `decrypt_stream_address` is installed in the database to
+support decryption of both currently encrypted rows and legacy plaintext rows.
+
+## Runtime requirements
+
+- `PGCRYPTO_KEY` must be provided when the service performs stream writes/reads.
+- The key must be at least 32 characters long.
+- `PGCRYPTO_KEY_PREVIOUS` may be provided when rotating the active key.
+
+## Security model
+
+- Addresses are encrypted with `pgp_sym_encrypt(..., 'cipher-algo=aes256,compress-algo=0,armor')`.
+- Search filters continue to work via keyed HMAC hash columns.
+- Legacy plaintext values are decrypted transparently until the row is migrated.
+- Key rotation is supported by retaining a previous key for decryption only.
+
+## Migration
+
+A new migration file was added:
+
+- `migrations/20260601_enable_pgcrypto_encrypt_addresses.ts`
+
+Run migrations before starting the service to ensure the database schema is compatible.

--- a/migrations/20260601_enable_pgcrypto_encrypt_addresses.ts
+++ b/migrations/20260601_enable_pgcrypto_encrypt_addresses.ts
@@ -1,0 +1,51 @@
+import { MigrationBuilder } from 'node-pg-migrate';
+
+export async function up(pgm: MigrationBuilder): Promise<void> {
+  pgm.createExtension('pgcrypto', { ifNotExists: true });
+
+  pgm.addColumns('streams', {
+    sender_address_hash: { type: 'text', notNull: true, default: '' },
+    recipient_address_hash: { type: 'text', notNull: true, default: '' },
+  });
+
+  pgm.createIndex('streams', 'sender_address_hash');
+  pgm.createIndex('streams', 'recipient_address_hash');
+
+  pgm.sql(`
+    CREATE OR REPLACE FUNCTION decrypt_stream_address(
+      value text,
+      current_key text,
+      previous_key text DEFAULT NULL
+    ) RETURNS text AS $$
+    DECLARE
+      decrypted text;
+    BEGIN
+      IF value IS NULL THEN
+        RETURN NULL;
+      END IF;
+
+      IF value LIKE '-----BEGIN PGP MESSAGE-----%' THEN
+        BEGIN
+          decrypted := pgp_sym_decrypt(value, current_key);
+          RETURN decrypted;
+        EXCEPTION WHEN others THEN
+          IF previous_key IS NOT NULL THEN
+            decrypted := pgp_sym_decrypt(value, previous_key);
+            RETURN decrypted;
+          END IF;
+          RAISE;
+        END;
+      END IF;
+
+      RETURN value;
+    END;
+    $$ LANGUAGE plpgsql IMMUTABLE;
+  `);
+}
+
+export async function down(pgm: MigrationBuilder): Promise<void> {
+  pgm.dropIndex('streams', 'recipient_address_hash');
+  pgm.dropIndex('streams', 'sender_address_hash');
+  pgm.dropColumns('streams', ['recipient_address_hash', 'sender_address_hash']);
+  pgm.sql('DROP FUNCTION IF EXISTS decrypt_stream_address(text, text, text)');
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,15 @@
 {
-  "name": "fluxora-backend",
-  "version": "0.1.0",
+  "name": "indexer-replay-batching",
+  "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "fluxora-backend",
-      "version": "0.1.0",
+      "name": "indexer-replay-batching",
+      "version": "1.0.0",
+      "license": "MIT",
       "dependencies": {
+        "@asteasolutions/zod-to-openapi": "8.5.0",
         "@opentelemetry/api": "^1.9.0",
         "@opentelemetry/exporter-trace-otlp-http": "^0.57.2",
         "@opentelemetry/instrumentation-express": "^0.46.0",
@@ -25,25 +27,42 @@
         "node-pg-migrate": "^7.6.0",
         "pg": "^8.11.3",
         "prom-client": "^15.0.0",
+        "swagger-ui-express": "5.0.1",
         "ws": "^8.14.2",
         "zod": "^4.3.6"
       },
       "devDependencies": {
         "@types/express": "^4.17.21",
+        "@types/jest": "^30.0.0",
         "@types/jsonwebtoken": "^9.0.10",
         "@types/node": "^20.19.39",
         "@types/supertest": "^6.0.2",
+        "@types/swagger-ui-express": "4.1.8",
         "@types/ws": "^8.18.1",
         "@typescript-eslint/eslint-plugin": "^8.59.0",
         "@typescript-eslint/parser": "^8.59.0",
         "eslint": "^10.2.1",
         "eslint-config-prettier": "^10.1.8",
         "jest": "^29.7.0",
+        "prettier": "^3.5.3",
         "supertest": "^6.3.3",
+        "ts-jest": "^29.4.11",
         "tsx": "^4.7.0",
         "typescript": "^5.9.3",
         "vitest": "^4.1.5",
         "ws": "^8.20.0"
+      }
+    },
+    "node_modules/@asteasolutions/zod-to-openapi": {
+      "version": "8.5.0",
+      "resolved": "https://registry.npmjs.org/@asteasolutions/zod-to-openapi/-/zod-to-openapi-8.5.0.tgz",
+      "integrity": "sha512-SABbKiObg5dLRiTFnqiW1WWwGcg1BJfmHtT2asIBnBHg6Smy/Ms2KHc650+JI4Hw7lSkdiNebEGXpwoxfben8Q==",
+      "license": "MIT",
+      "dependencies": {
+        "openapi3-ts": "^4.1.2"
+      },
+      "peerDependencies": {
+        "zod": "^4.0.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -1426,6 +1445,16 @@
         }
       }
     },
+    "node_modules/@jest/diff-sequences": {
+      "version": "30.4.0",
+      "resolved": "https://registry.npmjs.org/@jest/diff-sequences/-/diff-sequences-30.4.0.tgz",
+      "integrity": "sha512-zOpzlfUs45l6u7jm39qr87JCHUDsaeCtvL+kQe/Vn9jSnRB4/5IPXISm0h9I1vZW/o00Kn4UTJ2MOlhnUGwv3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
     "node_modules/@jest/environment": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-29.7.0.tgz",
@@ -1487,6 +1516,16 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
+    "node_modules/@jest/get-type": {
+      "version": "30.1.0",
+      "resolved": "https://registry.npmjs.org/@jest/get-type/-/get-type-30.1.0.tgz",
+      "integrity": "sha512-eMbZE2hUnx1WV0pmURZY9XoXPkUYjpc55mb0CrhtdWLtzMQPFvu/rZkTLZFTsdaVQa+Tr4eWAteqcUzoawq/uA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
     "node_modules/@jest/globals": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-29.7.0.tgz",
@@ -1501,6 +1540,30 @@
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/pattern": {
+      "version": "30.4.0",
+      "resolved": "https://registry.npmjs.org/@jest/pattern/-/pattern-30.4.0.tgz",
+      "integrity": "sha512-RAWn3+f9u8BsHijKJ71uHcFp6vmyEt6VvoWXkl6hKF3qVIuWNmudVjg12DlBPGup/frIl5UcUlH5HfEuvHpEXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "jest-regex-util": "30.4.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/pattern/node_modules/jest-regex-util": {
+      "version": "30.4.0",
+      "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-30.4.0.tgz",
+      "integrity": "sha512-mWlvLviKIgIQ8VCuM1xRdD0TWp3zlzionlmDBjuXVBs+VkmXq6FgW9T4Emr7oGz/Rk6feDCGyiugolcQEyp3mg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
     "node_modules/@jest/reporters": {
@@ -2894,6 +2957,13 @@
       "integrity": "sha512-n8iosDOt6Ig1UhJ2AYqoIhHWh/isz0xpicHTzpKBeotdVsTEcxsSA/i3EVM7gQAj0rU27OLAxCjzlj15IWY7bg==",
       "dev": true
     },
+    "node_modules/@scarf/scarf": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@scarf/scarf/-/scarf-1.4.0.tgz",
+      "integrity": "sha512-xxeapPiUXdZAE3che6f3xogoJPeZgig6omHEy1rIY5WVsB3H2BHNnZH+gHG6x91SCWyQCzWGsuL2Hh3ClO5/qQ==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0"
+    },
     "node_modules/@sinclair/typebox": {
       "version": "0.27.10",
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.10.tgz",
@@ -3109,6 +3179,232 @@
         "@types/istanbul-lib-report": "*"
       }
     },
+    "node_modules/@types/jest": {
+      "version": "30.0.0",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-30.0.0.tgz",
+      "integrity": "sha512-XTYugzhuwqWjws0CVz8QpM36+T+Dz5mTEBKhNs/esGLnCIlGdRy+Dq78NRjd7ls7r8BC8ZRMOrKlkO1hU0JOwA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "expect": "^30.0.0",
+        "pretty-format": "^30.0.0"
+      }
+    },
+    "node_modules/@types/jest/node_modules/@jest/expect-utils": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-30.4.1.tgz",
+      "integrity": "sha512-ZBn5CglH8fBsQsvs4VWNzD4aWfUYks+IdOOQU3MEK71ol/BcVm+P+rtb1KpiFBpSWSCE27uOahyyf1vfqOVbcQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/get-type": "30.1.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@types/jest/node_modules/@jest/schemas": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-30.4.1.tgz",
+      "integrity": "sha512-i6b4qw5qnP8c5FEeBJg/uZQ4ddrkN6Ca8qISJh0pr7a5hfn3h3v5x60BEbOC7OYAGZNMs1LfFLwnW2CuK8F57Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sinclair/typebox": "^0.34.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@types/jest/node_modules/@jest/types": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-30.4.1.tgz",
+      "integrity": "sha512-f1x/vJXIfjOlEmejYpbkbgw1gOqpPECwMvMEtBqe47j7H2Hg8h8w3o3ikhSXq3MI15kg+oQ0exWO0uCtTNJLoQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/pattern": "30.4.0",
+        "@jest/schemas": "30.4.1",
+        "@types/istanbul-lib-coverage": "^2.0.6",
+        "@types/istanbul-reports": "^3.0.4",
+        "@types/node": "*",
+        "@types/yargs": "^17.0.33",
+        "chalk": "^4.1.2"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@types/jest/node_modules/@sinclair/typebox": {
+      "version": "0.34.49",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.49.tgz",
+      "integrity": "sha512-brySQQs7Jtn0joV8Xh9ZV/hZb9Ozb0pmazDIASBkYKCjXrXU3mpcFahmK/z4YDhGkQvP9mWJbVyahdtU5wQA+A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/jest/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@types/jest/node_modules/ci-info": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.4.0.tgz",
+      "integrity": "sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/sibiraj-s"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@types/jest/node_modules/expect": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/expect/-/expect-30.4.1.tgz",
+      "integrity": "sha512-PMARsyh/JtqC20HoGqlFcIlQAyqUtW4PlI1rup1uhYJtKuwAjbvWi3GQMAn+STdHum/dk8xrKfUM1+5SAwpolA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/expect-utils": "30.4.1",
+        "@jest/get-type": "30.1.0",
+        "jest-matcher-utils": "30.4.1",
+        "jest-message-util": "30.4.1",
+        "jest-mock": "30.4.1",
+        "jest-util": "30.4.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@types/jest/node_modules/jest-diff": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-30.4.1.tgz",
+      "integrity": "sha512-CRpFK0RtLriVDGcPPAnR6HMVI8bSR2jnUIgralhauzYQZIb4RH9AtEInTuQr65LmmGggGcRT6HIASxwqsVsmlA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/diff-sequences": "30.4.0",
+        "@jest/get-type": "30.1.0",
+        "chalk": "^4.1.2",
+        "pretty-format": "30.4.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@types/jest/node_modules/jest-matcher-utils": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-30.4.1.tgz",
+      "integrity": "sha512-zvYfX5CaeEkFrrLS9suWe9rvJrm9J1Iv3ua8kIBv9GEPzcnsfBf0bob37la7s67fs0nlBC3EuvkOLnXQKxtx4A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/get-type": "30.1.0",
+        "chalk": "^4.1.2",
+        "jest-diff": "30.4.1",
+        "pretty-format": "30.4.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@types/jest/node_modules/jest-message-util": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-30.4.1.tgz",
+      "integrity": "sha512-kwCKIvq0MCW1HzLoGola9Te6JUdzgV0loyKJ3Qghrkz9i5/RRIHsL95BMQc2HBBhlBKC4j22K9p11TGHH8RBpQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.27.1",
+        "@jest/types": "30.4.1",
+        "@types/stack-utils": "^2.0.3",
+        "chalk": "^4.1.2",
+        "graceful-fs": "^4.2.11",
+        "jest-util": "30.4.1",
+        "picomatch": "^4.0.3",
+        "pretty-format": "30.4.1",
+        "slash": "^3.0.0",
+        "stack-utils": "^2.0.6"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@types/jest/node_modules/jest-mock": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-30.4.1.tgz",
+      "integrity": "sha512-/i8SVb8/NSB7RfNi8gfqu8gxLV23KaL5EpAttyb9iz8qWRIqXRLflycz/32wXsYkOnaUlx8NAKnJYtpsmXUmfw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "30.4.1",
+        "@types/node": "*",
+        "jest-util": "30.4.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@types/jest/node_modules/jest-util": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.4.1.tgz",
+      "integrity": "sha512-vjQb1sACEiv13DKJMDToJpzVW0joCsIQrmbg0fi7CyOOt+g9jTuQl2A216pWRBYhOVt53XbL/2LbMKg1BECWOw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "30.4.1",
+        "@types/node": "*",
+        "chalk": "^4.1.2",
+        "ci-info": "^4.2.0",
+        "graceful-fs": "^4.2.11",
+        "picomatch": "^4.0.3"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@types/jest/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/@types/jest/node_modules/pretty-format": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.4.1.tgz",
+      "integrity": "sha512-K6KiKMHTL4jjX4u3Kir2EW07nRfcqVTXIImx50wbjHQTcZPgg+gjVeNTIT3l3L1Rd4UefxfogquC9J37SoFyyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/schemas": "30.4.1",
+        "ansi-styles": "^5.2.0",
+        "react-is-18": "npm:react-is@^18.3.1",
+        "react-is-19": "npm:react-is@^19.2.5"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
@@ -3258,6 +3554,17 @@
       "dependencies": {
         "@types/methods": "^1.1.4",
         "@types/superagent": "^8.1.0"
+      }
+    },
+    "node_modules/@types/swagger-ui-express": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@types/swagger-ui-express/-/swagger-ui-express-4.1.8.tgz",
+      "integrity": "sha512-AhZV8/EIreHFmBV5wAs0gzJUNq9JbbSXgJLQubCC0jtIo6prnI9MIRRxnU4MZX9RB9yXxF1V4R7jtLl/Wcj31g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/express": "*",
+        "@types/serve-static": "*"
       }
     },
     "node_modules/@types/ws": {
@@ -4161,6 +4468,19 @@
       },
       "engines": {
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/bs-logger": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/bs-logger/-/bs-logger-0.2.6.tgz",
+      "integrity": "sha512-pd8DCoxmbgc7hyPKOvxtqNcjYoOsABPQdcCUjGp3d42VR2CX1ORhk2A87oqqu5R1kk+76nsxZupkmyd+MVtCog==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-json-stable-stringify": "2.x"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/bser": {
@@ -5680,6 +6000,28 @@
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/handlebars": {
+      "version": "4.7.9",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.9.tgz",
+      "integrity": "sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "minimist": "^1.2.5",
+        "neo-async": "^2.6.2",
+        "source-map": "^0.6.1",
+        "wordwrap": "^1.0.0"
+      },
+      "bin": {
+        "handlebars": "bin/handlebars"
+      },
+      "engines": {
+        "node": ">=0.4.7"
+      },
+      "optionalDependencies": {
+        "uglify-js": "^3.1.4"
+      }
     },
     "node_modules/has-flag": {
       "version": "4.0.0",
@@ -7224,6 +7566,13 @@
       "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
       "license": "MIT"
     },
+    "node_modules/lodash.memoize": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
+      "integrity": "sha512-t7j+NzmgnQzTAYXcsHYLgimltOV1MXHtlOWf6GjL9Kj8GK5FInw5JotxvbOs+IvV1/Dzo04/fCGfLVs7aXb4Ag==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/lodash.once": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
@@ -7283,6 +7632,13 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/make-error": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/makeerror": {
       "version": "1.0.12",
@@ -7407,6 +7763,16 @@
         "node": "*"
       }
     },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/minipass": {
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
@@ -7460,6 +7826,13 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/neo-async": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
+      "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/node-int64": {
       "version": "0.4.0",
@@ -7638,6 +8011,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/openapi3-ts": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/openapi3-ts/-/openapi3-ts-4.5.0.tgz",
+      "integrity": "sha512-jaL+HgTq2Gj5jRcfdutgRGLosCy/hT8sQf6VOy+P+g36cZOjI1iukdPnijC+4CmeRzg/jEllJUboEic2FhxhtQ==",
+      "license": "MIT",
+      "dependencies": {
+        "yaml": "^2.8.0"
       }
     },
     "node_modules/optionator": {
@@ -8016,6 +8398,22 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/prettier": {
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.3.tgz",
+      "integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
     "node_modules/pretty-format": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
@@ -8177,6 +8575,22 @@
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
       "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/react-is-18": {
+      "name": "react-is",
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/react-is-19": {
+      "name": "react-is",
+      "version": "19.2.6",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.6.tgz",
+      "integrity": "sha512-XjBR15BhXuylgWGuslhDKqlSayuqvqBX91BP8pauG8kd1zY8kotkNWbXksTCNRarse4kuGbe2kIY05ARtwNIvw==",
       "dev": true,
       "license": "MIT"
     },
@@ -8828,6 +9242,30 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/swagger-ui-dist": {
+      "version": "5.32.6",
+      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-5.32.6.tgz",
+      "integrity": "sha512-75ttZNaYCLoFPnozPZcTUU6mS3wKT8l7WLjU5zJSHFeJa23i5vtnze6IiCl4jDMPeQTXVXIgovq4M11NNfQvSA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@scarf/scarf": "=1.4.0"
+      }
+    },
+    "node_modules/swagger-ui-express": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/swagger-ui-express/-/swagger-ui-express-5.0.1.tgz",
+      "integrity": "sha512-SrNU3RiBGTLLmFU8GIJdOdanJTl4TOmT27tt3bWWHppqYmAZ6IDuEuBvMU6nZq0zLEe6b/1rACXCgLZqO6ZfrA==",
+      "license": "MIT",
+      "dependencies": {
+        "swagger-ui-dist": ">=5.0.0"
+      },
+      "engines": {
+        "node": ">= v0.10.32"
+      },
+      "peerDependencies": {
+        "express": ">=4.0.0 || >=5.0.0-beta"
+      }
+    },
     "node_modules/tdigest": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/tdigest/-/tdigest-0.1.2.tgz",
@@ -8962,6 +9400,85 @@
         "typescript": ">=4.8.4"
       }
     },
+    "node_modules/ts-jest": {
+      "version": "29.4.11",
+      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.4.11.tgz",
+      "integrity": "sha512-IrFl7l9AuB/qrNw5quqvAv/hmKMb8dhWOH4jQOGo0Oq8tCeo1O86/iTFG1FaRimgUkF13l4PcepO8ATFT6Ns4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bs-logger": "^0.2.6",
+        "fast-json-stable-stringify": "^2.1.0",
+        "handlebars": "^4.7.9",
+        "json5": "^2.2.3",
+        "lodash.memoize": "^4.1.2",
+        "make-error": "^1.3.6",
+        "semver": "^7.8.0",
+        "type-fest": "^4.41.0",
+        "yargs-parser": "^21.1.1"
+      },
+      "bin": {
+        "ts-jest": "cli.js"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || ^18.0.0 || >=20.0.0"
+      },
+      "peerDependencies": {
+        "@babel/core": ">=7.0.0-beta.0 <8",
+        "@jest/transform": "^29.0.0 || ^30.0.0",
+        "@jest/types": "^29.0.0 || ^30.0.0",
+        "babel-jest": "^29.0.0 || ^30.0.0",
+        "jest": "^29.0.0 || ^30.0.0",
+        "jest-util": "^29.0.0 || ^30.0.0",
+        "typescript": ">=4.3 <7"
+      },
+      "peerDependenciesMeta": {
+        "@babel/core": {
+          "optional": true
+        },
+        "@jest/transform": {
+          "optional": true
+        },
+        "@jest/types": {
+          "optional": true
+        },
+        "babel-jest": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jest-util": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ts-jest/node_modules/semver": {
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.1.tgz",
+      "integrity": "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/ts-jest/node_modules/type-fest": {
+      "version": "4.41.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
+      "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
@@ -9050,6 +9567,20 @@
       },
       "engines": {
         "node": ">=14.17"
+      }
+    },
+    "node_modules/uglify-js": {
+      "version": "3.19.3",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.19.3.tgz",
+      "integrity": "sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "optional": true,
+      "bin": {
+        "uglifyjs": "bin/uglifyjs"
+      },
+      "engines": {
+        "node": ">=0.8.0"
       }
     },
     "node_modules/undici-types": {
@@ -9382,6 +9913,13 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/wordwrap": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+      "integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/wrap-ansi": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
@@ -9465,6 +10003,21 @@
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
     },
     "node_modules/yargs": {
       "version": "17.7.2",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,11 @@
     "docker:seed": "docker-compose exec indexer pnpm run seed",
     "docker:test": "docker-compose exec indexer pnpm test"
   },
-  "keywords": ["indexer", "blockchain", "events"],
+  "keywords": [
+    "indexer",
+    "blockchain",
+    "events"
+  ],
   "author": "",
   "license": "MIT",
   "dependencies": {
@@ -51,6 +55,7 @@
   },
   "devDependencies": {
     "@types/express": "^4.17.21",
+    "@types/jest": "^30.0.0",
     "@types/jsonwebtoken": "^9.0.10",
     "@types/node": "^20.19.39",
     "@types/supertest": "^6.0.2",
@@ -63,6 +68,7 @@
     "jest": "^29.7.0",
     "prettier": "^3.5.3",
     "supertest": "^6.3.3",
+    "ts-jest": "^29.4.11",
     "tsx": "^4.7.0",
     "typescript": "^5.9.3",
     "vitest": "^4.1.5",

--- a/src/config/env.test.ts
+++ b/src/config/env.test.ts
@@ -71,6 +71,37 @@ describe('Environment Configuration', () => {
             expect(() => loadConfig()).toThrow(ConfigError);
         });
 
+        it('should reject too-short PGCRYPTO_KEY', () => {
+            process.env.NODE_ENV = 'development';
+            process.env.PGCRYPTO_KEY = 'short';
+            process.env.DATABASE_URL = 'postgresql://localhost/fluxora';
+            process.env.JWT_SECRET = 'a'.repeat(32);
+            process.env.INDEXER_WORKER_TOKEN = 'b'.repeat(32);
+
+            expect(() => loadConfig()).toThrow(ConfigError);
+        });
+
+        it('should reject PGCRYPTO_KEY_PREVIOUS without PGCRYPTO_KEY', () => {
+            process.env.NODE_ENV = 'development';
+            process.env.PGCRYPTO_KEY_PREVIOUS = 'b'.repeat(32);
+            process.env.DATABASE_URL = 'postgresql://localhost/fluxora';
+            process.env.JWT_SECRET = 'a'.repeat(32);
+            process.env.INDEXER_WORKER_TOKEN = 'b'.repeat(32);
+
+            expect(() => loadConfig()).toThrow(ConfigError);
+        });
+
+        it('should accept valid PGCRYPTO_KEY of sufficient length', () => {
+            process.env.NODE_ENV = 'development';
+            process.env.PGCRYPTO_KEY = 'x'.repeat(32);
+            process.env.DATABASE_URL = 'postgresql://localhost/fluxora';
+            process.env.JWT_SECRET = 'a'.repeat(32);
+            process.env.INDEXER_WORKER_TOKEN = 'b'.repeat(32);
+
+            const config = loadConfig();
+            expect(config.pgcryptoKey).toBe('x'.repeat(32));
+        });
+
         it('should parse MAX_JSON_DEPTH', () => {
             process.env.NODE_ENV = 'development';
             process.env.MAX_JSON_DEPTH = '50';

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -137,6 +137,14 @@ export const EnvSchema = z.object({
   STELLAR_RPC_RETRY_DELAY: integerEnv('STELLAR_RPC_RETRY_DELAY', 0).default(1000),
 
   JWT_SECRET: z.string().min(32, 'JWT_SECRET must be at least 32 characters'),
+  PGCRYPTO_KEY: z.preprocess(
+    (value) => (value === '' ? undefined : value),
+    z.string().min(32, 'PGCRYPTO_KEY must be at least 32 characters').optional(),
+  ),
+  PGCRYPTO_KEY_PREVIOUS: z.preprocess(
+    (value) => (value === '' ? undefined : value),
+    z.string().min(32, 'PGCRYPTO_KEY_PREVIOUS must be at least 32 characters').optional(),
+  ),
   JWT_EXPIRES_IN: z.string().min(1, 'JWT_EXPIRES_IN cannot be empty').default('24h'),
   API_KEYS: z.string().optional(),
   INDEXER_WORKER_TOKEN: z.string().min(32, 'INDEXER_WORKER_TOKEN must be at least 32 characters'),
@@ -201,7 +209,17 @@ export const EnvSchema = z.object({
   AWS_REGION: optionalString('AWS_REGION'),
   AWS_DEFAULT_REGION: optionalString('AWS_DEFAULT_REGION'),
   FLUXORA_SHUTDOWN: booleanEnv().optional(),
-}).passthrough();
+})
+  .superRefine((env, ctx) => {
+    if (env.PGCRYPTO_KEY_PREVIOUS && !env.PGCRYPTO_KEY) {
+      ctx.addIssue({
+        path: ['PGCRYPTO_KEY_PREVIOUS'],
+        code: z.ZodIssueCode.custom,
+        message: 'PGCRYPTO_KEY is required when PGCRYPTO_KEY_PREVIOUS is set',
+      });
+    }
+  })
+  .passthrough();
 
 type ParsedEnv = z.infer<typeof EnvSchema>;
 
@@ -230,6 +248,8 @@ export interface Config {
   contractAddresses: ContractAddresses;
 
   jwtSecret: string;
+  pgcryptoKey?: string | undefined;
+  pgcryptoKeyPrevious?: string | undefined;
   jwtExpiresIn: string;
   apiKeys: string[];
   indexerWorkerToken: string;
@@ -357,6 +377,8 @@ function toConfig(env: ParsedEnv): Config {
     contractAddresses: resolveContractAddresses(stellarNetwork, env),
 
     jwtSecret: env.JWT_SECRET,
+    pgcryptoKey: env.PGCRYPTO_KEY,
+    pgcryptoKeyPrevious: env.PGCRYPTO_KEY_PREVIOUS,
     jwtExpiresIn: env.JWT_EXPIRES_IN,
     apiKeys: (env.API_KEYS ?? (env.NODE_ENV === 'test' ? 'test-api-key' : ''))
       .split(',')

--- a/src/db/queries/streams.ts
+++ b/src/db/queries/streams.ts
@@ -1,0 +1,65 @@
+/**
+ * SQL query fragments and helper functions for encrypted stream PII.
+ *
+ * The `streams` table stores sender/recipient addresses encrypted with pgcrypto.
+ * Query helpers in this module keep the encryption/decryption plumbing centralized.
+ */
+
+import {
+  buildEncryptedAddressFilter,
+  pgpDecryptAddressColumn,
+  pgpEncryptAddressParam,
+} from '../../pii/pgcryptoEncryption.js';
+
+export function streamSelectColumns(
+  keyParamIndex: number,
+  previousKeyParamIndex?: number,
+): string {
+  return [
+    'id',
+    pgpDecryptAddressColumn('sender_address', keyParamIndex, previousKeyParamIndex),
+    pgpDecryptAddressColumn('recipient_address', keyParamIndex, previousKeyParamIndex),
+    'amount',
+    'streamed_amount',
+    'remaining_amount',
+    'rate_per_second',
+    'start_time',
+    'end_time',
+    'status',
+    'contract_id',
+    'transaction_hash',
+    'event_index',
+    'created_at',
+    'updated_at',
+  ].join(', ');
+}
+
+export function encryptAddressValue(addressParamIndex: number, keyParamIndex: number): string {
+  return pgpEncryptAddressParam(addressParamIndex, keyParamIndex);
+}
+
+export function senderAddressFilterCondition(
+  filterValueParamIndex: number,
+  senderHashParamIndex: number,
+  previousSenderHashParamIndex?: number,
+): string {
+  return buildEncryptedAddressFilter(
+    'sender_address',
+    filterValueParamIndex,
+    senderHashParamIndex,
+    previousSenderHashParamIndex,
+  );
+}
+
+export function recipientAddressFilterCondition(
+  filterValueParamIndex: number,
+  recipientHashParamIndex: number,
+  previousRecipientHashParamIndex?: number,
+): string {
+  return buildEncryptedAddressFilter(
+    'recipient_address',
+    filterValueParamIndex,
+    recipientHashParamIndex,
+    previousRecipientHashParamIndex,
+  );
+}

--- a/src/db/repositories/streamRepository.ts
+++ b/src/db/repositories/streamRepository.ts
@@ -41,6 +41,14 @@ import {
 } from '../types.js';
 import { info, debug } from '../../utils/logger.js';
 import { dbQueryDurationSeconds } from '../../metrics/dbMetrics.js';
+import { getConfig } from '../../config/env.js';
+import { computeAddressHashes } from '../../pii/pgcryptoEncryption.js';
+import {
+  encryptAddressValue,
+  recipientAddressFilterCondition,
+  senderAddressFilterCondition,
+  streamSelectColumns,
+} from '../queries/streams.js';
 
 const REPO = 'streamRepository';
 
@@ -77,6 +85,14 @@ function rowToRecord(row: Record<string, unknown>): StreamRecord {
   };
 }
 
+function resolvePgcryptoKeys(): { current: string; previous?: string } {
+  const config = getConfig();
+  if (!config.pgcryptoKey) {
+    throw new Error('PGCRYPTO_KEY is required to encrypt and decrypt stream PII');
+  }
+  return { current: config.pgcryptoKey, previous: config.pgcryptoKeyPrevious };
+}
+
 function isValidStatusTransition(from: StreamStatus, to: StreamStatus): boolean {
   const allowed: readonly string[] = STREAM_INVARIANTS.validTransitions[from] ?? [];
   return allowed.includes(to);
@@ -102,29 +118,53 @@ export const streamRepository = {
   async upsertStream(input: CreateStreamInput, correlationId?: string): Promise<UpsertResult> {
     return timed('upsertStream', async () => {
       const pool = getPool();
+      const keySet = resolvePgcryptoKeys();
+      const senderHashes = computeAddressHashes(input.sender_address, keySet);
+      const recipientHashes = computeAddressHashes(input.recipient_address, keySet);
+
+      const params: unknown[] = [
+        input.id,
+        input.sender_address,
+        keySet.current,
+        senderHashes.current,
+        input.recipient_address,
+        recipientHashes.current,
+        input.amount,
+        input.streamed_amount,
+        input.remaining_amount,
+        input.rate_per_second,
+        input.start_time,
+        input.end_time,
+        input.contract_id,
+        input.transaction_hash,
+        input.event_index,
+      ];
+
+      const decryptionPreviousKeyIndex = keySet.previous ? params.length + 1 : undefined;
+      if (keySet.previous) {
+        params.push(keySet.previous);
+      }
+
       const insertSql = `
         INSERT INTO streams (
-          id, sender_address, recipient_address,
+          id, sender_address, sender_address_hash,
+          recipient_address, recipient_address_hash,
           amount, streamed_amount, remaining_amount, rate_per_second,
           start_time, end_time, status,
           contract_id, transaction_hash, event_index,
           created_at, updated_at
         ) VALUES (
-          $1, $2, $3,
-          $4, $5, $6, $7,
-          $8, $9, 'active',
-          $10, $11, $12,
+          $1, ${encryptAddressValue(2, 3)}, $4,
+          ${encryptAddressValue(5, 3)}, $6,
+          $7, $8, $9, $10,
+          $11, $12, 'active',
+          $13, $14, $15,
           NOW(), NOW()
         )
         ON CONFLICT (transaction_hash, event_index) DO NOTHING
-        RETURNING *
+        RETURNING ${streamSelectColumns(3, decryptionPreviousKeyIndex)}
       `;
-      const params = [
-        input.id, input.sender_address, input.recipient_address,
-        input.amount, input.streamed_amount, input.remaining_amount, input.rate_per_second,
-        input.start_time, input.end_time,
-        input.contract_id, input.transaction_hash, input.event_index,
-      ];
+
       const result = await query<Record<string, unknown>>(pool, insertSql, params);
       if (result.rows.length > 0) {
         const stream = rowToRecord(result.rows[0]!);
@@ -161,7 +201,16 @@ export const streamRepository = {
       if (input.remaining_amount !== undefined) { setClauses.push(`remaining_amount = $${idx++}`); values.push(input.remaining_amount); }
       if (input.end_time !== undefined) { setClauses.push(`end_time = $${idx++}`); values.push(input.end_time); }
       values.push(id);
-      const sql = `UPDATE streams SET ${setClauses.join(', ')} WHERE id = $${idx} RETURNING *`;
+
+      const keySet = resolvePgcryptoKeys();
+      const keyIndex = values.length + 1;
+      const previousKeyIndex = keySet.previous ? keyIndex + 1 : undefined;
+      values.push(keySet.current);
+      if (keySet.previous) {
+        values.push(keySet.previous);
+      }
+
+      const sql = `UPDATE streams SET ${setClauses.join(', ')} WHERE id = $${idx} RETURNING ${streamSelectColumns(keyIndex, previousKeyIndex)}`;
       const result = await query<Record<string, unknown>>(pool, sql, values);
       if (result.rows.length === 0) throw new Error(`Stream not found after update: ${id}`);
       info('Stream updated', { id, input, correlationId });
@@ -173,7 +222,15 @@ export const streamRepository = {
   async getById(id: string): Promise<StreamRecord | undefined> {
     return timed('getById', async () => {
       const pool = getPool();
-      const result = await query<Record<string, unknown>>(pool, 'SELECT * FROM streams WHERE id = $1', [id]);
+      const keySet = resolvePgcryptoKeys();
+      const params: unknown[] = [id, keySet.current];
+      if (keySet.previous) params.push(keySet.previous);
+
+      const result = await query<Record<string, unknown>>(
+        pool,
+        `SELECT ${streamSelectColumns(2, keySet.previous ? 3 : undefined)} FROM streams WHERE id = $1`,
+        params,
+      );
       return result.rows[0] ? rowToRecord(result.rows[0]) : undefined;
     });
   },
@@ -182,10 +239,14 @@ export const streamRepository = {
   async getByEvent(transactionHash: string, eventIndex: number): Promise<StreamRecord | undefined> {
     return timed('getByEvent', async () => {
       const pool = getPool();
+      const keySet = resolvePgcryptoKeys();
+      const params: unknown[] = [transactionHash, eventIndex, keySet.current];
+      if (keySet.previous) params.push(keySet.previous);
+
       const result = await query<Record<string, unknown>>(
         pool,
-        'SELECT * FROM streams WHERE transaction_hash = $1 AND event_index = $2',
-        [transactionHash, eventIndex],
+        `SELECT ${streamSelectColumns(3, keySet.previous ? 4 : undefined)} FROM streams WHERE transaction_hash = $1 AND event_index = $2`,
+        params,
       );
       return result.rows[0] ? rowToRecord(result.rows[0]) : undefined;
     });
@@ -200,20 +261,46 @@ export const streamRepository = {
   ): Promise<{ streams: StreamRecord[]; hasMore: boolean; total?: number }> {
     return timed('findWithCursor', async () => {
       const pool = getPool();
+      const keySet = resolvePgcryptoKeys();
       const conditions: string[] = [];
       const params: unknown[] = [];
       let idx = 1;
+
       if (filter.status) { conditions.push(`status = $${idx++}`); params.push(filter.status); }
-      if (filter.sender_address) { conditions.push(`sender_address = $${idx++}`); params.push(filter.sender_address); }
-      if (filter.recipient_address) { conditions.push(`recipient_address = $${idx++}`); params.push(filter.recipient_address); }
+      if (filter.sender_address) {
+        const hashes = computeAddressHashes(filter.sender_address, keySet);
+        const filterIndex = idx++;
+        const currentHashIndex = idx++;
+        const previousHashIndex = keySet.previous ? idx++ : undefined;
+        conditions.push(senderAddressFilterCondition(filterIndex, currentHashIndex, previousHashIndex));
+        params.push(filter.sender_address, hashes.current);
+        if (hashes.previous) params.push(hashes.previous);
+      }
+      if (filter.recipient_address) {
+        const hashes = computeAddressHashes(filter.recipient_address, keySet);
+        const filterIndex = idx++;
+        const currentHashIndex = idx++;
+        const previousHashIndex = keySet.previous ? idx++ : undefined;
+        conditions.push(recipientAddressFilterCondition(filterIndex, currentHashIndex, previousHashIndex));
+        params.push(filter.recipient_address, hashes.current);
+        if (hashes.previous) params.push(hashes.previous);
+      }
       if (filter.contract_id) { conditions.push(`contract_id = $${idx++}`); params.push(filter.contract_id); }
+
       const whereBase = conditions.length > 0 ? `WHERE ${conditions.join(' AND ')}` : '';
       const cursorConditions = [...conditions];
       const cursorParams = [...params];
       if (afterId) { cursorConditions.push(`id > $${idx++}`); cursorParams.push(afterId); }
       const whereCursor = cursorConditions.length > 0 ? `WHERE ${cursorConditions.join(' AND ')}` : '';
-      const dataSql = `SELECT * FROM streams ${whereCursor} ORDER BY id ASC LIMIT $${idx}`;
+
+      const limitParamIndex = cursorParams.length + 1;
       cursorParams.push(limit + 1);
+      const keyIndex = cursorParams.length + 1;
+      cursorParams.push(keySet.current);
+      const previousKeyIndex = keySet.previous ? cursorParams.length + 1 : undefined;
+      if (keySet.previous) cursorParams.push(keySet.previous);
+
+      const dataSql = `SELECT ${streamSelectColumns(keyIndex, previousKeyIndex)} FROM streams ${whereCursor} ORDER BY id ASC LIMIT $${limitParamIndex}`;
       const [dataResult, countResult] = await Promise.all([
         query<Record<string, unknown>>(pool, dataSql, cursorParams),
         includeTotal
@@ -233,23 +320,48 @@ export const streamRepository = {
   async find(filter: StreamFilter, pagination: PaginationOptions): Promise<PaginatedStreams> {
     return timed('find', async () => {
       const pool = getPool();
+      const keySet = resolvePgcryptoKeys();
       const conditions: string[] = [];
       const params: unknown[] = [];
       let idx = 1;
+
       if (filter.status) { conditions.push(`status = $${idx++}`); params.push(filter.status); }
-      if (filter.sender_address) { conditions.push(`sender_address = $${idx++}`); params.push(filter.sender_address); }
-      if (filter.recipient_address) { conditions.push(`recipient_address = $${idx++}`); params.push(filter.recipient_address); }
+      if (filter.sender_address) {
+        const hashes = computeAddressHashes(filter.sender_address, keySet);
+        const filterIndex = idx++;
+        const currentHashIndex = idx++;
+        const previousHashIndex = keySet.previous ? idx++ : undefined;
+        conditions.push(senderAddressFilterCondition(filterIndex, currentHashIndex, previousHashIndex));
+        params.push(filter.sender_address, hashes.current);
+        if (hashes.previous) params.push(hashes.previous);
+      }
+      if (filter.recipient_address) {
+        const hashes = computeAddressHashes(filter.recipient_address, keySet);
+        const filterIndex = idx++;
+        const currentHashIndex = idx++;
+        const previousHashIndex = keySet.previous ? idx++ : undefined;
+        conditions.push(recipientAddressFilterCondition(filterIndex, currentHashIndex, previousHashIndex));
+        params.push(filter.recipient_address, hashes.current);
+        if (hashes.previous) params.push(hashes.previous);
+      }
       if (filter.contract_id) { conditions.push(`contract_id = $${idx++}`); params.push(filter.contract_id); }
       if (filter.start_time_from !== undefined) { conditions.push(`start_time >= $${idx++}`); params.push(filter.start_time_from); }
       if (filter.start_time_to !== undefined) { conditions.push(`start_time <= $${idx++}`); params.push(filter.start_time_to); }
       if (filter.end_time_from !== undefined) { conditions.push(`end_time >= $${idx++}`); params.push(filter.end_time_from); }
       if (filter.end_time_to !== undefined) { conditions.push(`end_time <= $${idx++}`); params.push(filter.end_time_to); }
       const where = conditions.length > 0 ? `WHERE ${conditions.join(' AND ')}` : '';
+
+      const countParams = [...params];
+      const keyIndex = params.length + 1;
+      const previousKeyIndex = keySet.previous ? keyIndex + 1 : undefined;
+      params.push(keySet.current);
+      if (keySet.previous) params.push(keySet.previous);
+
       const [countResult, dataResult] = await Promise.all([
-        query<{ count: string }>(pool, `SELECT COUNT(*) AS count FROM streams ${where}`, [...params]),
+        query<{ count: string }>(pool, `SELECT COUNT(*) AS count FROM streams ${where}`, countParams),
         query<Record<string, unknown>>(
           pool,
-          `SELECT * FROM streams ${where} ORDER BY created_at DESC LIMIT $${idx} OFFSET $${idx + 1}`,
+          `SELECT ${streamSelectColumns(keyIndex, previousKeyIndex)} FROM streams ${where} ORDER BY created_at DESC LIMIT $${params.length + 1} OFFSET $${params.length + 2}`,
           [...params, pagination.limit, pagination.offset],
         ),
       ]);

--- a/src/pii/pgcryptoEncryption.ts
+++ b/src/pii/pgcryptoEncryption.ts
@@ -1,0 +1,73 @@
+/**
+ * pgcrypto helper utilities for stream PII encryption.
+ *
+ * This module centralizes the application-side pieces of the encryption
+ * design so the repository layer can stay readable and safe.
+ */
+
+import crypto from 'crypto';
+
+export const PGCRYPTO_KEY_MIN_LENGTH = 32;
+export const PGP_SYM_ENCRYPT_OPTIONS = 'cipher-algo=aes256,compress-algo=0,armor';
+export const PGP_MESSAGE_PREFIX = '-----BEGIN PGP MESSAGE-----';
+
+export interface PgcryptoKeySet {
+  current: string;
+  previous?: string;
+}
+
+/**
+ * Compute the deterministic HMAC digest used for address filters and indexes.
+ * This preserves query efficiency while keeping the stored address ciphertext
+ * unreadable without the key.
+ */
+export function computeAddressHash(address: string, key: string): string {
+  return crypto.createHmac('sha256', key).update(address, 'utf8').digest('hex');
+}
+
+export function computeAddressHashes(address: string, keys: PgcryptoKeySet): {
+  current: string;
+  previous?: string;
+} {
+  return {
+    current: computeAddressHash(address, keys.current),
+    previous: keys.previous ? computeAddressHash(address, keys.previous) : undefined,
+  };
+}
+
+/**
+ * Build a pgcrypto encryption expression for a plaintext address parameter.
+ */
+export function pgpEncryptAddressParam(addressParamIndex: number, keyParamIndex: number): string {
+  return `pgp_sym_encrypt($${addressParamIndex}, $${keyParamIndex}, '${PGP_SYM_ENCRYPT_OPTIONS}')`;
+}
+
+/**
+ * Build a pgcrypto decryption expression for a stored address column.
+ */
+export function pgpDecryptAddressColumn(
+  columnName: string,
+  keyParamIndex: number,
+  previousKeyParamIndex?: number,
+): string {
+  const previousArg = previousKeyParamIndex !== undefined ? `$${previousKeyParamIndex}` : 'NULL';
+  return `decrypt_stream_address(${columnName}, $${keyParamIndex}, ${previousArg}) AS ${columnName}`;
+}
+
+/**
+ * Build a filter expression that uses keyed hash lookup first, and falls back
+ * to plaintext comparison for legacy rows that have not yet been backfilled.
+ */
+export function buildEncryptedAddressFilter(
+  column: 'sender_address' | 'recipient_address',
+  filterValueParamIndex: number,
+  currentHashParamIndex: number,
+  previousHashParamIndex?: number,
+): string {
+  const hashClauses = [`${column}_hash = $${currentHashParamIndex}`];
+  if (previousHashParamIndex !== undefined) {
+    hashClauses.push(`${column}_hash = $${previousHashParamIndex}`);
+  }
+  const hashCondition = hashClauses.length > 1 ? `(${hashClauses.join(' OR ')})` : hashClauses[0];
+  return `(${hashCondition} OR ${column} = $${filterValueParamIndex})`;
+}

--- a/tests/pii/pgcryptoEncryption.test.ts
+++ b/tests/pii/pgcryptoEncryption.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from 'vitest';
+import {
+  computeAddressHash,
+  computeAddressHashes,
+  pgpDecryptAddressColumn,
+  pgpEncryptAddressParam,
+  buildEncryptedAddressFilter,
+} from '../../src/pii/pgcryptoEncryption.js';
+
+describe('PGCrypto PII encryption helpers', () => {
+  const address = 'GDRXE2BQUC3AZ7D3G7BMNJ4XOSXHG6YKO4IZ3Y4S7HNW3F4AWMRI6ZIY';
+  const key = 'a'.repeat(32);
+  const previousKey = 'b'.repeat(32);
+
+  it('computes a stable hex digest for address hashing', () => {
+    const hash = computeAddressHash(address, key);
+    expect(hash).toHaveLength(64);
+    expect(hash).toMatch(/^[0-9a-f]{64}$/);
+    expect(computeAddressHash(address, key)).toBe(hash);
+  });
+
+  it('produces different hashes for different keys', () => {
+    const first = computeAddressHash(address, key);
+    const second = computeAddressHash(address, previousKey);
+    expect(first).not.toBe(second);
+  });
+
+  it('computes current and previous hash versions', () => {
+    const hashes = computeAddressHashes(address, { current: key, previous: previousKey });
+    expect(hashes.current).toHaveLength(64);
+    expect(hashes.previous).toHaveLength(64);
+    expect(hashes.current).not.toBe(hashes.previous);
+  });
+
+  it('builds pgcrypto encryption SQL with param placeholders', () => {
+    expect(pgpEncryptAddressParam(2, 5)).toContain('$2');
+    expect(pgpEncryptAddressParam(2, 5)).toContain('$5');
+    expect(pgpEncryptAddressParam(2, 5)).toContain('pgp_sym_encrypt(');
+  });
+
+  it('builds pgcrypto decryption SQL with optional previous key', () => {
+    expect(pgpDecryptAddressColumn('sender_address', 1)).toContain('decrypt_stream_address(sender_address, $1, NULL)');
+    expect(pgpDecryptAddressColumn('recipient_address', 1, 2)).toContain('decrypt_stream_address(recipient_address, $1, $2)');
+  });
+
+  it('builds a hashed address filter with plaintext fallback', () => {
+    const expr = buildEncryptedAddressFilter('sender_address', 2, 3, 4);
+    expect(expr).toContain('sender_address_hash = $3');
+    expect(expr).toContain('sender_address_hash = $4');
+    expect(expr).toContain('sender_address = $2');
+  });
+});


### PR DESCRIPTION
## PR Description

This PR adds row-level encryption for `sender_address` and `recipient_address` in the `streams` table using PostgreSQL `pgcrypto` with an application-managed symmetric key.

### What changed

- Added `PGCRYPTO_KEY` and optional `PGCRYPTO_KEY_PREVIOUS` support to config validation
- Added reusable encryption/decryption helpers for addresses in pgcryptoEncryption.ts
- Added query helper functions for encrypted address selection, insertion, and filtering in streams.ts
- Updated streamRepository.ts to use encrypted address write/read logic and hash-based filters
- Added a database migration:
  - Enables `pgcrypto`
  - Adds encrypted `sender_address` / `recipient_address` support
  - Adds hash columns and indexes for address filtering
- Added documentation for PII encryption design in pii-encryption.md
- Added targeted unit tests:
  - pgcryptoEncryption.test.ts
  - extended env.test.ts
- Updated dependency metadata to support TypeScript testing tools

### this matters because

- Protects sensitive stream address data at rest
- Keeps searchable filtering using deterministic HMAC hashes
- Supports safe key rotation through previous key support
- Keeps migration and runtime behavior explicit and auditable

### Validation

- ✅ `npx vitest run pgcryptoEncryption.test.ts src/config/env.test.ts`
- ✅ Branch created and pushed as `feature/pgcrypto-address-encryption`

### Files added/updated

- pgcryptoEncryption.ts
- streams.ts
- streamRepository.ts
- env.ts
- env.test.ts
- 20260601_enable_pgcrypto_encrypt_addresses.ts
- pii-encryption.md
- pgcryptoEncryption.test.ts
- package.json
- package-lock.json

close #284 