### PR TITLE
feat: wire RedisIdempotencyStore for stream creation with config-driven TTL

### DIFF
--- a/docs/api/idempotency.md
+++ b/docs/api/idempotency.md
@@ -1,39 +1,103 @@
 # Idempotency
 
-Fluxora Backend supports idempotency for POST requests to ensure that replaying a request with the same `Idempotency-Key` returns the exact same response without re-executing the underlying business logic.
+Fluxora Backend supports idempotency for `POST /api/streams` to ensure that replaying a request with the same `Idempotency-Key` returns the exact same response without re-executing the underlying business logic.
 
 ## How it Works
 
-1. **First Request**: The client sends a `POST` request with a unique `Idempotency-Key` header.
-2. **Hashing**: The backend computes a SHA-256 hash of the canonicalized request body (keys sorted, whitespace stripped).
-3. **Storage**: The backend stores the hash along with the full HTTP response (status code and body) in a Redis-backed store (or in-memory for local development).
-4. **Subsequent Requests**: If a request with the same `Idempotency-Key` is received:
-   - If the incoming body hash matches the stored hash, the cached response is returned with the header `Idempotency-Replayed: true`.
-   - If the incoming body hash does **not** match the stored hash, a `409 Conflict` is returned.
+1. **First request** — the client sends `POST /api/streams` with a unique `Idempotency-Key` header.
+2. **Fingerprinting** — the backend computes a SHA-256 hex digest of the canonicalized request body (keys sorted, whitespace stripped).
+3. **Cache lookup** — the backend checks the Redis-backed idempotency store keyed by `Idempotency-Key`.
+4. **Cache miss** — the stream is created normally. The response (status code + body + fingerprint) is stored in Redis with the configured TTL.
+5. **Subsequent requests** — if a request with the same `Idempotency-Key` is received:
+   - **Same body hash** → the cached response is returned immediately with `Idempotency-Replayed: true`. No DB write occurs.
+   - **Different body hash** → `409 Conflict` is returned. The cached response is **not** overwritten.
 
-## Conflict Detection
+## Backing Store
 
-If an `Idempotency-Key` is reused with a different request body, the API returns a `409 Conflict` to prevent accidental execution of different operations under the same key.
+| `REDIS_ENABLED` | Store used | Cross-instance dedup |
+| --- | --- | --- |
+| `true` (default) | `RedisIdempotencyStore` | Yes |
+| `false` | `NoOpIdempotencyStore` | No — every request is treated as a first request |
 
-### 409 Conflict Response
+The Redis store is wired at startup by `wireIdempotencyStore()` in `src/app.ts`. Each key is stored under the namespace `fluxora:idempotency:<key>` with the configured TTL.
+
+### Degraded mode (`REDIS_ENABLED=false`)
+
+When Redis is disabled, a `NoOpIdempotencyStore` is installed and a warning is logged:
+
+```text
+Redis disabled — stream idempotency running in NoOp mode; cross-instance duplicate protection is not enforced
+```
+
+Requests are still processed; they just lack cross-instance duplicate protection. Use this mode only in local development or single-instance deployments where duplicate requests are not a concern.
+
+### Redis outage
+
+If the Redis connection **fails at startup**, `idempotencyDependency` is set to `unavailable` and all subsequent `POST /api/streams` requests return **503 Service Unavailable** rather than silently creating duplicate streams:
 
 ```json
 {
-  "error": "idempotency_conflict",
-  "stored_hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
-  "incoming_hash": "84882194165f12e84865f1a50c60832f05929680a6b72d244983057e62d4994d"
+  "success": false,
+  "error": {
+    "code": "SERVICE_UNAVAILABLE",
+    "message": "Idempotency processing is temporarily unavailable. Retry after dependency health is restored."
+  }
+}
+```
+
+If Redis goes down **after** a successful startup connection, the per-request `onStateChange` callback in `RedisIdempotencyStore` flips `idempotencyDependency` to unavailable on the first failed operation, and back to healthy on the first successful one (i.e., after ioredis reconnects).
+
+## Configuration
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `REDIS_ENABLED` | `true` | Enable / disable Redis backing. Set to `false` for local dev or single-node deployments. |
+| `REDIS_URL` | `redis://localhost:6379` | Redis connection URL. |
+| `REDIS_MODE` | `standalone` | `standalone`, `sentinel`, or `cluster`. |
+| `IDEMPOTENCY_TTL_SECONDS` | `86400` (24 h) | How long an idempotency entry is retained. Valid range: 1–604 800 s (7 days). |
+
+## Conflict Detection
+
+If an `Idempotency-Key` is reused with a **different** request body, the API returns `409 Conflict` to prevent executing a different operation under the same key:
+
+```json
+{
+  "success": false,
+  "error": {
+    "code": "CONFLICT",
+    "message": "Idempotency-Key has already been used for a different request payload",
+    "detail": { "hint": "Use a new Idempotency-Key or retry with the original request body" }
+  }
 }
 ```
 
 ## Constraints
 
-- **Method**: Idempotency is only supported for `POST` requests.
-- **Header**: `Idempotency-Key` must be between 1 and 128 characters and contain only `A-Z a-z 0-9 : _ -`.
-- **TTL**: Idempotency records are typically stored for 24 hours.
+- **Method**: Idempotency is only enforced for `POST /api/streams`.
+- **Header format**: `Idempotency-Key` must be 1–128 characters, `[A-Za-z0-9:_-]` only.
+- **TTL**: Entries expire after `IDEMPOTENCY_TTL_SECONDS` (default 24 h). Indefinite retention is not possible.
 
 ## Canonicalization
 
-To ensure consistent hashing, the request body is normalized before hashing:
-- All object keys are sorted alphabetically.
+The request body is normalized before hashing to ensure consistent fingerprints regardless of JSON serialization order or whitespace:
+
+- All object keys are sorted alphabetically (recursively).
 - All unnecessary whitespace is removed.
-- Nested objects and arrays are normalized recursively.
+- The normalized string is hashed with SHA-256.
+
+Two bodies that differ only in key order or spacing produce the **same** fingerprint and trigger a replay rather than a conflict.
+
+## Security Notes
+
+- The raw `Idempotency-Key` value is **never** written to logs. Only its byte length is recorded.
+- Stored fingerprints are SHA-256 digests, not the raw body, so Redis compromise does not expose request payloads.
+- A different payload under the same key cannot silently overwrite a cached response — it always produces a 409.
+- The Redis TTL prevents indefinite retention; there is no way to store an entry without an expiry.
+
+## Response Headers
+
+| Header | Value | Present on |
+| --- | --- | --- |
+| `Idempotency-Key` | Echo of the submitted key | All 2xx responses to `POST /api/streams` |
+| `Idempotency-Replayed` | `true` | Replayed (cached) responses |
+| `Idempotency-Replayed` | `false` | First-time (freshly created) responses |

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,7 +1,7 @@
 import express from 'express';
 import type { Express, Request, Response, NextFunction } from 'express';
 import type pg from 'pg';
-import { streamsRouter } from './routes/streams.js';
+import { streamsRouter, setIdempotencyStore, setIdempotencyDependencyState } from './routes/streams.js';
 import { healthRouter } from './routes/health.js';
 import { indexerRouter } from './routes/indexer.js';
 import { auditRouter } from './routes/audit.js';
@@ -12,7 +12,11 @@ import { webhooksRouter } from './routes/webhooks.js';
 import { privacyRouter } from './routes/privacy.js';
 import { privacyHeaders } from './middleware/pii.js';
 import type { Config } from './config/env.js';
+import { loadConfig } from './config/env.js';
 import type { HealthCheckManager } from './config/health.js';
+import { createRedisClient } from './redis/client.js';
+import { RedisIdempotencyStore, NoOpIdempotencyStore } from './redis/idempotencyStore.js';
+import { logger } from './lib/logger.js';
 import { cspNonceMiddleware, createHelmetMiddleware } from './middleware/helmet.js';
 import { metricsRouter } from './routes/metrics.js';
 import { correlationIdMiddleware } from './middleware/correlationId.js';
@@ -53,6 +57,71 @@ export interface AppOptions {
   pool?: pg.Pool;
 }
 
+/**
+ * Wire the idempotency backing store for POST /api/streams.
+ *
+ * When `REDIS_ENABLED=true` (the default): creates a `RedisIdempotencyStore`
+ * backed by the configured Redis instance and calls `setIdempotencyStore()`.
+ * The `onStateChange` callback flips `idempotencyDependency` to unavailable on
+ * Redis errors so that subsequent `POST /api/streams` requests return 503
+ * instead of silently losing cross-instance duplicate protection.
+ * A shutdown hook is registered to close the Redis connection cleanly.
+ *
+ * When `REDIS_ENABLED=false`: installs a `NoOpIdempotencyStore` and logs a
+ * warning about degraded idempotency semantics (no cross-instance dedup).
+ *
+ * The TTL is sourced from `config.idempotencyTtlSeconds`
+ * (`IDEMPOTENCY_TTL_SECONDS` env var, default 86 400 s / 24 h).
+ *
+ * This function never rejects — all errors are caught and logged internally.
+ */
+async function wireIdempotencyStore(config: Config): Promise<void> {
+  if (!config.redisEnabled) {
+    logger.warn(
+      'Redis disabled — stream idempotency running in NoOp mode; cross-instance duplicate protection is not enforced',
+      undefined,
+      { component: 'idempotency-store', ttlSeconds: config.idempotencyTtlSeconds },
+    );
+    setIdempotencyStore(new NoOpIdempotencyStore(), config.idempotencyTtlSeconds);
+    return;
+  }
+
+  try {
+    const redisClient = await createRedisClient({
+      url: config.redisUrl,
+      enabled: config.redisEnabled,
+      mode: config.redisMode,
+      sentinelHosts: config.redisSentinelHosts,
+      sentinelName: config.redisSentinelName,
+      clusterNodes: config.redisClusterNodes,
+    });
+
+    const store = new RedisIdempotencyStore(redisClient, {
+      onStateChange: (healthy: boolean) =>
+        setIdempotencyDependencyState(healthy ? 'healthy' : 'unavailable'),
+    });
+
+    setIdempotencyStore(store, config.idempotencyTtlSeconds);
+    addShutdownHook(() => store.close());
+
+    logger.info(
+      'Redis idempotency store wired',
+      undefined,
+      { component: 'idempotency-store', ttlSeconds: config.idempotencyTtlSeconds },
+    );
+  } catch (err) {
+    logger.warn(
+      'Redis connection failed for idempotency store — POST /api/streams will return 503 until Redis is restored',
+      undefined,
+      {
+        component: 'idempotency-store',
+        error: err instanceof Error ? err.message : String(err),
+      },
+    );
+    setIdempotencyDependencyState('unavailable');
+  }
+}
+
 export function createApp(options: AppOptions = {}): Express {
   const app = express();
   const env = options.env ?? (process.env as Record<string, string | undefined>);
@@ -77,6 +146,10 @@ export function createApp(options: AppOptions = {}): Express {
   if (options.pool) {
     app.locals.vacuumInterval = startVacuumCollector(options.pool);
   }
+
+  // Wire the Redis-backed idempotency store (fire-and-forget; errors handled internally).
+  const appConfig = options.config ?? loadConfig();
+  void wireIdempotencyStore(appConfig);
 
   app.use(privacyHeaders);
   app.use(cspNonceMiddleware);

--- a/src/redis/idempotencyStore.ts
+++ b/src/redis/idempotencyStore.ts
@@ -8,15 +8,20 @@
  * Graceful degradation
  * --------------------
  * If Redis is unavailable (get/set throws), the store logs a warning and
- * returns null / silently skips the write.  The route handler treats a null
- * get() as a cache miss and proceeds normally — idempotency is best-effort
- * when the store is down rather than a hard failure.
+ * returns null / silently skips the write.  The optional `onStateChange`
+ * callback is invoked with `false` on error and `true` on recovery so that
+ * callers can flip an upstream dependency-health flag (→ 503 rather than
+ * silently losing idempotency guarantees).
  *
  * Security notes
  * --------------
  * - Keys are namespaced under `fluxora:idempotency:` to avoid collisions.
  * - The raw Idempotency-Key value is never logged; only its length is.
- * - TTL is enforced by Redis EX so entries are automatically evicted.
+ * - Stored fingerprints are SHA-256 of the normalised request body, so a
+ *   different payload under the same key cannot silently overwrite a cached
+ *   response — it produces a 409 CONFLICT instead.
+ * - TTL is enforced by Redis EX so entries are automatically evicted after
+ *   the configured window (default 86 400 s / 24 h).
  * - The stored value is JSON-serialised; no eval or dynamic code paths.
  *
  * @module redis/idempotencyStore
@@ -28,7 +33,7 @@ export const IDEMPOTENCY_KEY_PREFIX = 'fluxora:idempotency:';
 
 /** Shape stored in Redis for each idempotency entry. */
 export interface IdempotentEntry<T = unknown> {
-  /** SHA-256 fingerprint of the normalised request body. */
+  /** SHA-256 hex digest of the normalised request body. */
   requestFingerprint: string;
   /** HTTP status code of the original response. */
   statusCode: number;
@@ -48,10 +53,38 @@ export interface IdempotencyStore<T = unknown> {
    * Silently no-ops on Redis unavailability.
    */
   set(key: string, entry: IdempotentEntry<T>, ttlSeconds: number): Promise<void>;
+
+  /** Release any external resources (e.g. Redis connection) held by this store. */
+  close(): Promise<void>;
+}
+
+/** Options for {@link RedisIdempotencyStore}. */
+export interface RedisIdempotencyStoreOptions {
+  /**
+   * Called with `true` after every successful Redis operation (indicating
+   * the store is healthy) and with `false` after every error (indicating
+   * the store is degraded).  Use this to flip an upstream dependency-health
+   * flag so that callers can return 503 instead of silently losing guarantees.
+   *
+   * The callback is never called when the store is not used (e.g. NoOp).
+   * Idempotency-Key values are never passed to this callback.
+   */
+  onStateChange?: (healthy: boolean) => void;
 }
 
 export class RedisIdempotencyStore<T = unknown> implements IdempotencyStore<T> {
-  constructor(private readonly client: RedisClient) {}
+  private readonly onStateChange?: (healthy: boolean) => void;
+
+  /**
+   * @param client  The Redis client to use for storage.
+   * @param options Optional callbacks for health-state reporting.
+   */
+  constructor(
+    private readonly client: RedisClient,
+    options?: RedisIdempotencyStoreOptions,
+  ) {
+    this.onStateChange = options?.onStateChange;
+  }
 
   private buildKey(key: string): string {
     return `${IDEMPOTENCY_KEY_PREFIX}${key}`;
@@ -60,9 +93,11 @@ export class RedisIdempotencyStore<T = unknown> implements IdempotencyStore<T> {
   async get(key: string): Promise<IdempotentEntry<T> | null> {
     try {
       const raw = await this.client.get(this.buildKey(key));
+      this.onStateChange?.(true);
       if (raw === null) return null;
       return JSON.parse(raw) as IdempotentEntry<T>;
     } catch (err) {
+      this.onStateChange?.(false);
       console.warn('[IdempotencyStore] Redis get failed — degrading to pass-through', {
         keyLength: key.length,
         error: err instanceof Error ? err.message : String(err),
@@ -74,26 +109,33 @@ export class RedisIdempotencyStore<T = unknown> implements IdempotencyStore<T> {
   async set(key: string, entry: IdempotentEntry<T>, ttlSeconds: number): Promise<void> {
     try {
       await this.client.set(this.buildKey(key), JSON.stringify(entry), { ex: ttlSeconds });
+      this.onStateChange?.(true);
     } catch (err) {
+      this.onStateChange?.(false);
       console.warn('[IdempotencyStore] Redis set failed — idempotency not persisted', {
         keyLength: key.length,
         error: err instanceof Error ? err.message : String(err),
       });
     }
   }
+
+  async close(): Promise<void> {
+    await this.client.close();
+  }
 }
 
 /**
- * No-op store used when Redis is disabled or unavailable at startup.
+ * No-op store used when Redis is disabled (`REDIS_ENABLED=false`).
  * Every get() is a miss; every set() is a silent no-op.
  * The route handler degrades gracefully: requests are processed normally
- * but duplicate protection is not enforced.
+ * but duplicate protection is not enforced across instances or restarts.
  */
 export class NoOpIdempotencyStore<T = unknown> implements IdempotencyStore<T> {
   async get(_key: string): Promise<IdempotentEntry<T> | null> {
     return null;
   }
   async set(_key: string, _entry: IdempotentEntry<T>, _ttlSeconds: number): Promise<void> {}
+  async close(): Promise<void> {}
 }
 
 /**
@@ -114,6 +156,10 @@ export class InMemoryIdempotencyStore<T = unknown> implements IdempotencyStore<T
   }
 
   clear(): void {
+    this.store.clear();
+  }
+
+  async close(): Promise<void> {
     this.store.clear();
   }
 }

--- a/src/routes/streams.ts
+++ b/src/routes/streams.ts
@@ -26,8 +26,10 @@
  *   - Same key + diff body  → 409 CONFLICT
  *   - Missing / bad key     → 400 VALIDATION_ERROR
  *
- * The idempotency store is in-memory (Map) for this iteration.  In production
- * it should be backed by Redis with a 24-hour TTL.
+ * The idempotency store defaults to in-memory at module load and is replaced
+ * at startup with a RedisIdempotencyStore when Redis is available
+ * (REDIS_ENABLED=true, the default).  TTL is driven by IDEMPOTENCY_TTL_SECONDS
+ * (default 86 400 s / 24 h).  See src/app.ts wireIdempotencyStore().
  *
  * Failure modes
  * -------------
@@ -125,7 +127,8 @@ const streamListingDependency = { state: 'healthy' as DependencyState };
 const idempotencyDependency   = { state: 'healthy' as DependencyState };
 
 // Idempotency store — starts as InMemoryIdempotencyStore; replaced at startup
-// with a RedisIdempotencyStore when Redis is available.
+// by wireIdempotencyStore() in app.ts with a RedisIdempotencyStore when Redis
+// is available (REDIS_ENABLED=true).
 let idempotencyStore: IdempotencyStore<ReturnType<typeof successResponse<Stream>>> =
   new InMemoryIdempotencyStore();
 
@@ -160,12 +163,17 @@ export function resetStreamIdempotencyStore(): void {
  * Replace the idempotency store implementation.
  * Called at startup with a RedisIdempotencyStore, and in tests with a
  * FakeRedisClient-backed store or a NoOpIdempotencyStore.
+ *
+ * The parameter is typed as `IdempotencyStore<unknown>` so callers do not
+ * need to import the route's private `Stream` / `successResponse` types.
+ * The cast below is safe because the route handler always stores and reads
+ * values of the correct shape.
  */
 export function setIdempotencyStore(
-  store: IdempotencyStore<ReturnType<typeof successResponse<Stream>>>,
+  store: IdempotencyStore<unknown>,
   ttlSeconds?: number,
 ): void {
-  idempotencyStore = store;
+  idempotencyStore = store as IdempotencyStore<ReturnType<typeof successResponse<Stream>>>;
   if (ttlSeconds !== undefined) idempotencyTtlSeconds = ttlSeconds;
 }
 
@@ -314,7 +322,7 @@ function normalizeCreateInput(body: Record<string, unknown>): NormalizedCreateIn
 }
 
 function fingerprintInput(input: NormalizedCreateInput): string {
-  return JSON.stringify(input);
+  return crypto.createHash('sha256').update(JSON.stringify(input)).digest('hex');
 }
 
 /** Wrap DB errors so pool exhaustion surfaces as 503. */

--- a/tests/redis/idempotencyStore.test.ts
+++ b/tests/redis/idempotencyStore.test.ts
@@ -10,12 +10,17 @@
  *  - NoOpIdempotencyStore always returns null / never throws
  *  - Key namespacing (fluxora:idempotency: prefix)
  *  - Serialisation round-trip preserves status code and body exactly
+ *  - onStateChange callback — called false on errors, true on success
+ *  - cross-instance replay — two store instances sharing one FakeRedisClient
+ *  - close() — delegates to client.close() / clears InMemory / no-ops on NoOp
+ *  - InMemoryIdempotencyStore full semantics
  */
 
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import {
   RedisIdempotencyStore,
   NoOpIdempotencyStore,
+  InMemoryIdempotencyStore,
   IDEMPOTENCY_KEY_PREFIX,
   type IdempotentEntry,
 } from '../../src/redis/idempotencyStore.js';
@@ -159,5 +164,166 @@ describe('NoOpIdempotencyStore', () => {
   it('get after set still returns null (pass-through semantics)', async () => {
     await store.set('key-x', makeEntry(), 60);
     expect(await store.get('key-x')).toBeNull();
+  });
+
+  it('close() resolves without throwing', async () => {
+    await expect(store.close()).resolves.toBeUndefined();
+  });
+});
+
+// ── InMemoryIdempotencyStore ──────────────────────────────────────────────────
+
+describe('InMemoryIdempotencyStore', () => {
+  let store: InMemoryIdempotencyStore;
+
+  beforeEach(() => {
+    store = new InMemoryIdempotencyStore();
+  });
+
+  it('returns null on cache miss', async () => {
+    expect(await store.get('key-1')).toBeNull();
+  });
+
+  it('returns stored entry on cache hit', async () => {
+    const entry = makeEntry();
+    await store.set('key-1', entry, 60);
+    expect(await store.get('key-1')).toEqual(entry);
+  });
+
+  it('ignores TTL parameter (in-memory, no expiry)', async () => {
+    const entry = makeEntry();
+    await store.set('key-ttl', entry, 1); // very short TTL is ignored
+    expect(await store.get('key-ttl')).toEqual(entry);
+  });
+
+  it('close() clears all stored entries', async () => {
+    await store.set('k1', makeEntry(), 60);
+    await store.close();
+    expect(await store.get('k1')).toBeNull();
+  });
+});
+
+// ── RedisIdempotencyStore.onStateChange callback ──────────────────────────────
+
+describe('RedisIdempotencyStore — onStateChange', () => {
+  let fake: FakeRedisClient;
+  let stateChanges: boolean[];
+  let store: RedisIdempotencyStore;
+
+  beforeEach(() => {
+    fake = new FakeRedisClient();
+    stateChanges = [];
+    store = new RedisIdempotencyStore(fake, {
+      onStateChange: (healthy) => stateChanges.push(healthy),
+    });
+  });
+
+  it('calls onStateChange(true) after a successful get (cache miss)', async () => {
+    await store.get('key-1');
+    expect(stateChanges).toContain(true);
+  });
+
+  it('calls onStateChange(true) after a successful set', async () => {
+    await store.set('key-1', makeEntry(), 60);
+    expect(stateChanges).toContain(true);
+  });
+
+  it('calls onStateChange(false) when Redis get throws', async () => {
+    fake.throwOnNext('get');
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    await store.get('key-err');
+    expect(stateChanges).toContain(false);
+    warnSpy.mockRestore();
+  });
+
+  it('calls onStateChange(false) when Redis set throws', async () => {
+    fake.throwOnNext('set');
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    await store.set('key-err', makeEntry(), 60);
+    expect(stateChanges).toContain(false);
+    warnSpy.mockRestore();
+  });
+
+  it('recovers: onStateChange(true) fires on the next successful operation after a failure', async () => {
+    fake.throwOnNext('get');
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    await store.get('key-fail'); // error → false
+    warnSpy.mockRestore();
+    await store.get('key-ok');   // success → true
+    expect(stateChanges).toEqual([false, true]);
+  });
+
+  it('does not call onStateChange when no options are provided', async () => {
+    const plainStore = new RedisIdempotencyStore(fake);
+    // Should not throw
+    await plainStore.set('k', makeEntry(), 60);
+    await plainStore.get('k');
+    // No assertion needed — absence of throw is sufficient
+  });
+});
+
+// ── RedisIdempotencyStore.close() ─────────────────────────────────────────────
+
+describe('RedisIdempotencyStore — close()', () => {
+  it('calls close() on the underlying Redis client', async () => {
+    const fake = new FakeRedisClient();
+    const closeSpy = vi.spyOn(fake, 'close');
+    const store = new RedisIdempotencyStore(fake);
+    await store.close();
+    expect(closeSpy).toHaveBeenCalledOnce();
+  });
+});
+
+// ── Cross-instance replay (two stores, one shared FakeRedisClient) ────────────
+
+describe('RedisIdempotencyStore — cross-instance replay', () => {
+  let sharedFake: FakeRedisClient;
+  let instanceA: RedisIdempotencyStore;
+  let instanceB: RedisIdempotencyStore;
+
+  beforeEach(() => {
+    sharedFake = new FakeRedisClient();
+    instanceA = new RedisIdempotencyStore(sharedFake);
+    instanceB = new RedisIdempotencyStore(sharedFake);
+  });
+
+  it('instance B replays a 201 written by instance A (same key + same body)', async () => {
+    const entry = makeEntry({ statusCode: 201 });
+    await instanceA.set('idem-key', entry, 86400);
+
+    const replayed = await instanceB.get('idem-key');
+    expect(replayed).not.toBeNull();
+    expect(replayed?.statusCode).toBe(201);
+    expect(replayed?.requestFingerprint).toBe(entry.requestFingerprint);
+    expect(replayed?.body).toEqual(entry.body);
+  });
+
+  it('instance B detects a conflict (same key, different fingerprint) written by instance A', async () => {
+    const entryA = makeEntry({ requestFingerprint: 'fp-from-instance-a' });
+    await instanceA.set('conflict-key', entryA, 86400);
+
+    const retrieved = await instanceB.get('conflict-key');
+    // The route handler (not the store) enforces the 409 — the store just
+    // returns the stored entry so the caller can compare fingerprints.
+    expect(retrieved?.requestFingerprint).toBe('fp-from-instance-a');
+  });
+
+  it('instance A and B store to isolated keys', async () => {
+    await instanceA.set('key-a', makeEntry({ requestFingerprint: 'fp-a' }), 60);
+    await instanceB.set('key-b', makeEntry({ requestFingerprint: 'fp-b' }), 60);
+
+    expect((await instanceA.get('key-b'))?.requestFingerprint).toBe('fp-b');
+    expect((await instanceB.get('key-a'))?.requestFingerprint).toBe('fp-a');
+  });
+
+  it('TTL is forwarded correctly from config-derived value', async () => {
+    const setSpy = vi.spyOn(sharedFake, 'set');
+    const configTtl = 86400; // matches IDEMPOTENCY_TTL_SECONDS default
+    await instanceA.set('key-ttl', makeEntry(), configTtl);
+    expect(setSpy).toHaveBeenCalledWith(
+      `${IDEMPOTENCY_KEY_PREFIX}key-ttl`,
+      expect.any(String),
+      { ex: configTtl },
+    );
   });
 });

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -12,6 +12,9 @@
 
 process.env.NODE_ENV = process.env.NODE_ENV ?? 'test';
 process.env.RATE_LIMIT_ENABLED = process.env.RATE_LIMIT_ENABLED ?? 'false';
+// Disable Redis in tests to prevent connection attempts to a non-existent server.
+// Tests that need Redis semantics use FakeRedisClient or InMemoryIdempotencyStore directly.
+process.env.REDIS_ENABLED = process.env.REDIS_ENABLED ?? 'false';
 process.env.DATABASE_URL =
   process.env.DATABASE_URL ?? 'postgresql://localhost/fluxora_test';
 process.env.JWT_SECRET =


### PR DESCRIPTION
- In src/app.ts, add wireIdempotencyStore() which constructs a RedisIdempotencyStore from the shared Redis client and calls setIdempotencyStore() with config.idempotencyTtlSeconds (IDEMPOTENCY_TTL_SECONDS, default 86400s). Falls back to NoOpIdempotencyStore with a degraded-mode
  warning when REDIS_ENABLED=false.

- A Redis connection failure at startup calls setIdempotencyDependencyState('unavailable') so POST /api/streams returns 503 rather than silently losing cross-instance idempotency guarantees. The onStateChange callback in RedisIdempotencyStore
  flips the dependency state on per-request errors and recoveries.

- Register a shutdown hook to close the idempotency store's Redis connection.

- Upgrade fingerprintInput() in streams.ts to SHA-256 (was raw JSON.stringify)
  so stored fingerprints are fixed-length and don't leak payload content in Redis.

- Widen setIdempotencyStore() parameter to IdempotencyStore<unknown> so callers
  don't need to import the route's private Stream/successResponse types.

- Add close(): Promise<void> to the IdempotencyStore interface and implement in
  all three concrete classes.

- Add RedisIdempotencyStoreOptions with onStateChange callback.

fixes #325