### PR TITLE
fix(validation): reject duplicate stream batch entries

### DIFF
--- a/src/validation/schemas.ts
+++ b/src/validation/schemas.ts
@@ -32,6 +32,14 @@ function stellarPublicKeyField(fieldName: string) {
     .regex(STELLAR_PUBLIC_KEY_REGEX, `${fieldName} must be a valid Stellar public key (G...)`);
 }
 
+/** Reusable non-negative integer field schema */
+function nonNegativeIntegerField(fieldName: string) {
+  return z
+    .number({ error: `${fieldName} must be a number` })
+    .int(`${fieldName} must be an integer`)
+    .nonnegative(`${fieldName} must be non-negative`);
+}
+
 /**
  * Schema for POST /api/streams body.
  *
@@ -40,13 +48,66 @@ function stellarPublicKeyField(fieldName: string) {
  * - depositAmount / ratePerSecond: decimal strings only (not numbers)
  * - startTime / endTime: non-negative integers when provided
  */
-export const StreamBatchCreateSchema = z.object({
-  streams: z.array(CreateStreamSchema).max(100, { message: 'Maximum of 100 streams per batch' })
+export const CreateStreamSchema = z.object({
+  sender: stellarPublicKeyField('sender'),
+  recipient: stellarPublicKeyField('recipient'),
+  depositAmount: decimalStringField('depositAmount').optional(),
+  ratePerSecond: decimalStringField('ratePerSecond').optional(),
+  startTime: nonNegativeIntegerField('startTime').optional(),
+  endTime: nonNegativeIntegerField('endTime').optional(),
 });
 
-export type StreamBatchCreateInput = {
-  streams: CreateStreamInput[];
-};
+export type CreateStreamInput = z.infer<typeof CreateStreamSchema>;
+
+/**
+ * Schema for batch stream creation at the indexing boundary.
+ *
+ * The duplicate guard keys entries by the same per-row idempotency coordinates
+ * enforced by the streams table: `(transaction_hash, event_index)`.
+ */
+export const StreamBatchCreateSchema = z.object({
+  streams: z
+    .array(z.object({
+      id: z.string({ error: 'id must be a string' }).min(1, 'id must be a non-empty string'),
+      sender_address: stellarPublicKeyField('sender_address'),
+      recipient_address: stellarPublicKeyField('recipient_address'),
+      amount: decimalStringField('amount'),
+      streamed_amount: decimalStringField('streamed_amount'),
+      remaining_amount: decimalStringField('remaining_amount'),
+      rate_per_second: decimalStringField('rate_per_second'),
+      start_time: nonNegativeIntegerField('start_time'),
+      end_time: nonNegativeIntegerField('end_time'),
+      contract_id: z
+        .string({ error: 'contract_id must be a string' })
+        .min(1, 'contract_id must be a non-empty string'),
+      transaction_hash: z
+        .string({ error: 'transaction_hash must be a string' })
+        .min(1, 'transaction_hash must be a non-empty string'),
+      event_index: nonNegativeIntegerField('event_index'),
+    }))
+    .max(100, { message: 'Maximum of 100 streams per batch' })
+}).superRefine((batch, ctx) => {
+  // superRefine lets the validation error identify the offending duplicate row.
+  const seen = new Map<string, number>();
+
+  batch.streams.forEach((stream, index) => {
+    const identityKey = JSON.stringify([stream.transaction_hash, stream.event_index]);
+    const firstIndex = seen.get(identityKey);
+
+    if (firstIndex !== undefined) {
+      ctx.addIssue({
+        code: 'custom',
+        path: ['streams', index],
+        message: `Duplicate stream identity tuple at index ${index}; first seen at index ${firstIndex}`,
+      });
+      return;
+    }
+
+    seen.set(identityKey, index);
+  });
+});
+
+export type StreamBatchCreateInput = z.infer<typeof StreamBatchCreateSchema>;
 
 /**
  * Schema for GET /api/streams query parameters.

--- a/tests/validation-edge-cases.test.ts
+++ b/tests/validation-edge-cases.test.ts
@@ -24,6 +24,28 @@ import {
     validateJsonDepth,
     validateRequestSize,
 } from '../src/config/validation';
+import { StreamBatchCreateSchema } from '../src/validation/schemas';
+
+const VALID_SENDER = 'GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN7';
+const VALID_RECIPIENT = 'GBDEVU63Y6NTHJQQZIKVTC23NWLQVP3WJ2RI2OTSJTNYOIGICST6DUXR';
+
+function makeBatchStream(index: number, overrides: Record<string, unknown> = {}) {
+    return {
+        id: `stream-tx-${index}-${index}`,
+        sender_address: VALID_SENDER,
+        recipient_address: VALID_RECIPIENT,
+        amount: '1000.0000000',
+        streamed_amount: '0',
+        remaining_amount: '1000.0000000',
+        rate_per_second: '0.0000116',
+        start_time: 1700000000 + index,
+        end_time: 0,
+        contract_id: 'api-created',
+        transaction_hash: `tx-${index}`,
+        event_index: index,
+        ...overrides,
+    };
+}
 
 describe('Validation Edge Cases & Failure Modes', () => {
     describe('Abuse Scenarios: Oversized Payloads', () => {
@@ -293,6 +315,66 @@ describe('Validation Edge Cases & Failure Modes', () => {
                 const result = validateCreateStreamRequest(variation);
                 expect(result).not.toEqual(baseResult);
             });
+        });
+
+        it('accepts a batch whose stream identity tuples are all distinct', () => {
+            const result = StreamBatchCreateSchema.safeParse({
+                streams: [
+                    makeBatchStream(0),
+                    makeBatchStream(1),
+                    makeBatchStream(2),
+                ],
+            });
+
+            expect(result.success).toBe(true);
+        });
+
+        it('rejects a mixed batch with a duplicate transaction hash and event index', () => {
+            const result = StreamBatchCreateSchema.safeParse({
+                streams: [
+                    makeBatchStream(0, { transaction_hash: 'same-tx', event_index: 7 }),
+                    makeBatchStream(1),
+                    makeBatchStream(2, { transaction_hash: 'same-tx', event_index: 7 }),
+                ],
+            });
+
+            expect(result.success).toBe(false);
+            if (result.success) return;
+
+            expect(result.error.issues).toHaveLength(1);
+            expect(result.error.issues[0]?.path).toEqual(['streams', 2]);
+            expect(result.error.issues[0]?.message).toContain('first seen at index 0');
+        });
+
+        it('rejects all-duplicate batches and reports each offending index', () => {
+            const result = StreamBatchCreateSchema.safeParse({
+                streams: [
+                    makeBatchStream(0, { transaction_hash: 'dup-tx', event_index: 0 }),
+                    makeBatchStream(1, { transaction_hash: 'dup-tx', event_index: 0 }),
+                    makeBatchStream(2, { transaction_hash: 'dup-tx', event_index: 0 }),
+                ],
+            });
+
+            expect(result.success).toBe(false);
+            if (result.success) return;
+
+            expect(result.error.issues.map((issue) => issue.path)).toEqual([
+                ['streams', 1],
+                ['streams', 2],
+            ]);
+        });
+
+        it('keeps the 100 stream batch size cap unchanged', () => {
+            const maxBatch = Array.from({ length: 100 }, (_, index) => makeBatchStream(index));
+            const oversizedBatch = Array.from({ length: 101 }, (_, index) => makeBatchStream(index));
+
+            expect(StreamBatchCreateSchema.safeParse({ streams: maxBatch }).success).toBe(true);
+
+            const oversized = StreamBatchCreateSchema.safeParse({ streams: oversizedBatch });
+            expect(oversized.success).toBe(false);
+            if (oversized.success) return;
+
+            expect(oversized.error.issues.some((issue) => issue.message.includes('Maximum of 100'))).toBe(true);
         });
     });
 


### PR DESCRIPTION
## Summary
- Adds intra-batch duplicate validation to `StreamBatchCreateSchema`.
- Keys duplicate detection by `(transaction_hash, event_index)`, matching the streams table per-row idempotency constraint.
- Reports the validation issue at the offending duplicate stream index.
- Preserves the existing 100-stream batch cap.
- Restores the missing `CreateStreamSchema` export used by the routes module on `main`.

## Security notes
- Duplicate amplification is rejected during schema validation before DB write/idempotency work.
- The duplicate check is O(n) over the capped batch size.

## Tests
- `npm test -- tests/validation-edge-cases.test.ts` (75 passed)
- `./node_modules/.bin/eslint.cmd --no-warn-ignored src/validation/schemas.ts tests/validation-edge-cases.test.ts` (0 errors, existing warnings in the touched test file)

## Known existing validation blockers
- `npm run build` currently fails on `main` with unrelated TypeScript errors across config/DB/webhook/test modules, including missing `dotenv` types and existing missing exports. No new build errors are introduced in the touched validation schema/test path.

Closes #365