### PR TITLE
fix(validation): reject duplicate batch stream identities

### DIFF
--- a/src/validation/schemas.ts
+++ b/src/validation/schemas.ts
@@ -17,11 +17,17 @@ export const DECIMAL_STRING_REGEX = /^[+-]?\d+(\.\d+)?$/;
 /** Regex for valid Stellar public keys: G followed by 55 base32 characters */
 export const STELLAR_PUBLIC_KEY_REGEX = /^G[A-Z2-7]{55}$/;
 
+/** Regex for a 64-character lowercase or uppercase hexadecimal transaction hash */
+export const TRANSACTION_HASH_REGEX = /^[0-9a-fA-F]{64}$/;
+
 /** Reusable decimal-string field schema */
 function decimalStringField(fieldName: string) {
   return z
     .string({ error: `${fieldName} must be a decimal string, not a number` })
-    .regex(DECIMAL_STRING_REGEX, `${fieldName} must be a valid decimal string (e.g. "100", "0.0000116")`);
+    .regex(
+      DECIMAL_STRING_REGEX,
+      `${fieldName} must be a valid decimal string (e.g. "100", "0.0000116")`
+    );
 }
 
 /** Reusable Stellar public key field schema */
@@ -40,40 +46,97 @@ function stellarPublicKeyField(fieldName: string) {
  * - depositAmount / ratePerSecond: decimal strings only (not numbers)
  * - startTime / endTime: non-negative integers when provided
  */
-export const StreamBatchCreateSchema = z.object({
-  streams: z.array(CreateStreamSchema).max(100, { message: 'Maximum of 100 streams per batch' })
+export const CreateStreamSchema = z.object({
+  sender: stellarPublicKeyField('sender'),
+  recipient: stellarPublicKeyField('recipient'),
+  depositAmount: decimalStringField('depositAmount'),
+  ratePerSecond: decimalStringField('ratePerSecond'),
+  startTime: z
+    .number()
+    .int('startTime must be an integer Unix timestamp')
+    .nonnegative('startTime must be non-negative')
+    .optional(),
+  endTime: z
+    .number()
+    .int('endTime must be an integer Unix timestamp')
+    .nonnegative('endTime must be non-negative')
+    .optional(),
 });
 
+export type CreateStreamInput = z.infer<typeof CreateStreamSchema>;
+
+/**
+ * Schema for stream entries submitted through batch ingestion.
+ *
+ * The chain event identity fields are required here so the batch validator can
+ * reject duplicate work before any database write or idempotency reservation.
+ */
+export const BatchStreamCreateSchema = CreateStreamSchema.extend({
+  transaction_hash: z
+    .string({ error: 'transaction_hash must be a string' })
+    .regex(TRANSACTION_HASH_REGEX, 'transaction_hash must be a 64-character hexadecimal string'),
+  event_index: z
+    .number({ error: 'event_index must be a number' })
+    .int('event_index must be an integer')
+    .nonnegative('event_index must be non-negative'),
+});
+
+export type BatchStreamCreateInput = z.infer<typeof BatchStreamCreateSchema>;
+
+/** Build the per-row idempotency identity used to reject duplicates within a batch. */
+function batchStreamIdentityKey(stream: BatchStreamCreateInput): string {
+  return `${stream.sender}|${stream.recipient}|${stream.transaction_hash.toLowerCase()}|${stream.event_index}`;
+}
+
+export const StreamBatchCreateSchema = z
+  .object({
+    streams: z
+      .array(BatchStreamCreateSchema)
+      .max(100, { message: 'Maximum of 100 streams per batch' }),
+  })
+  .superRefine((batch, ctx) => {
+    const firstSeenByIdentity = new Map<string, number>();
+
+    for (const [index, stream] of batch.streams.entries()) {
+      const identity = batchStreamIdentityKey(stream);
+      const firstIndex = firstSeenByIdentity.get(identity);
+
+      if (firstIndex !== undefined) {
+        ctx.addIssue({
+          code: 'custom',
+          path: ['streams', index],
+          message: `Duplicate stream identity at index ${index}; first seen at index ${firstIndex}`,
+        });
+        continue;
+      }
+
+      firstSeenByIdentity.set(identity, index);
+    }
+  });
+
 export type StreamBatchCreateInput = {
-  streams: CreateStreamInput[];
+  streams: BatchStreamCreateInput[];
 };
 
 /**
  * Schema for GET /api/streams query parameters.
  */
 export const ListStreamsQuerySchema = z.object({
-  limit: z
-    .string()
-    .regex(/^\d+$/, 'limit must be an integer between 1 and 100')
-    .optional(),
+  limit: z.string().regex(/^\d+$/, 'limit must be an integer between 1 and 100').optional(),
   cursor: z.string().optional(),
-  include_total: z.enum(['true', 'false'], {
-    error: 'include_total must be true or false',
-  }).optional(),
+  include_total: z
+    .enum(['true', 'false'], {
+      error: 'include_total must be true or false',
+    })
+    .optional(),
 });
 
 /**
  * Schema for DLQ list query parameters.
  */
 export const DlqListQuerySchema = z.object({
-  limit: z
-    .string()
-    .regex(/^\d+$/, 'limit must be an integer between 1 and 100')
-    .optional(),
-  offset: z
-    .string()
-    .regex(/^\d+$/, 'offset must be a non-negative integer')
-    .optional(),
+  limit: z.string().regex(/^\d+$/, 'limit must be an integer between 1 and 100').optional(),
+  offset: z.string().regex(/^\d+$/, 'offset must be a non-negative integer').optional(),
   topic: z.string().optional(),
 });
 
@@ -83,7 +146,7 @@ export const DlqListQuerySchema = z.object({
  */
 export function parseBody<T>(
   schema: z.ZodSchema<T>,
-  data: unknown,
+  data: unknown
 ): { success: true; data: T } | { success: false; issues: z.ZodIssue[] } {
   const result = schema.safeParse(data);
   if (result.success) return { success: true, data: result.data };

--- a/tests/validation-edge-cases.test.ts
+++ b/tests/validation-edge-cases.test.ts
@@ -1,505 +1,570 @@
 /**
  * Edge case and failure mode tests for validation
- * 
+ *
  * Covers:
  * - Boundary conditions (min/max values)
  * - Abuse scenarios (oversized payloads, excessive nesting)
  * - Type coercion edge cases
  * - Duplicate detection
  * - Idempotency guarantees
- * 
+ *
  * These tests ensure the API behaves predictably under stress
  * and malicious input conditions.
  */
 
 import { describe, it, expect } from 'vitest';
 import {
-    ValidationError,
-    validateStellarAddress,
-    validateAmount,
-    validateRatePerSecond,
-    validateTimestamp,
-    validateCreateStreamRequest,
-    validateStreamId,
-    validateJsonDepth,
-    validateRequestSize,
+  ValidationError,
+  validateStellarAddress,
+  validateAmount,
+  validateRatePerSecond,
+  validateTimestamp,
+  validateCreateStreamRequest,
+  validateStreamId,
+  validateJsonDepth,
+  validateRequestSize,
 } from '../src/config/validation';
+import { CreateStreamSchema, StreamBatchCreateSchema } from '../src/validation/schemas';
 
 describe('Validation Edge Cases & Failure Modes', () => {
-    describe('Abuse Scenarios: Oversized Payloads', () => {
-        it('should reject request exceeding 256 KiB', () => {
-            const maxSize = 256 * 1024; // 256 KiB
-            expect(() => validateRequestSize(maxSize + 1, maxSize)).toThrow(ValidationError);
-        });
-
-        it('should accept request at exactly 256 KiB', () => {
-            const maxSize = 256 * 1024;
-            expect(() => validateRequestSize(maxSize, maxSize)).not.toThrow();
-        });
-
-        it('should reject extremely large payloads', () => {
-            const maxSize = 256 * 1024;
-            expect(() => validateRequestSize(1024 * 1024 * 100, maxSize)).toThrow(ValidationError);
-        });
-
-        it('should provide size information in error', () => {
-            const maxSize = 256 * 1024;
-            try {
-                validateRequestSize(maxSize + 1000, maxSize);
-                expect.fail('Should have thrown');
-            } catch (e) {
-                expect(e).toBeInstanceOf(ValidationError);
-                expect((e as ValidationError).message).toContain('exceeds maximum');
-            }
-        });
+  describe('Abuse Scenarios: Oversized Payloads', () => {
+    it('should reject request exceeding 256 KiB', () => {
+      const maxSize = 256 * 1024; // 256 KiB
+      expect(() => validateRequestSize(maxSize + 1, maxSize)).toThrow(ValidationError);
     });
 
-    describe('Abuse Scenarios: Deeply Nested JSON', () => {
-        it('should reject deeply nested objects', () => {
-            let obj: any = { value: 1 };
-            for (let i = 0; i < 20; i++) {
-                obj = { nested: obj };
-            }
-            expect(() => validateJsonDepth(obj, 5)).toThrow(ValidationError);
-        });
+    it('should accept request at exactly 256 KiB', () => {
+      const maxSize = 256 * 1024;
+      expect(() => validateRequestSize(maxSize, maxSize)).not.toThrow();
+    });
 
-        it('should reject deeply nested arrays', () => {
-            let arr: any = [1];
-            for (let i = 0; i < 20; i++) {
-                arr = [arr];
-            }
-            expect(() => validateJsonDepth(arr, 5)).toThrow(ValidationError);
-        });
+    it('should reject extremely large payloads', () => {
+      const maxSize = 256 * 1024;
+      expect(() => validateRequestSize(1024 * 1024 * 100, maxSize)).toThrow(ValidationError);
+    });
 
-        it('should reject mixed nested structures', () => {
-            const obj = {
-                a: [
-                    {
-                        b: [
-                            {
-                                c: [
-                                    {
-                                        d: [
-                                            {
-                                                e: [{ f: 1 }],
-                                            },
-                                        ],
-                                    },
-                                ],
-                            },
-                        ],
-                    },
+    it('should provide size information in error', () => {
+      const maxSize = 256 * 1024;
+      try {
+        validateRequestSize(maxSize + 1000, maxSize);
+        expect.fail('Should have thrown');
+      } catch (e) {
+        expect(e).toBeInstanceOf(ValidationError);
+        expect((e as ValidationError).message).toContain('exceeds maximum');
+      }
+    });
+  });
+
+  describe('Abuse Scenarios: Deeply Nested JSON', () => {
+    it('should reject deeply nested objects', () => {
+      let obj: any = { value: 1 };
+      for (let i = 0; i < 20; i++) {
+        obj = { nested: obj };
+      }
+      expect(() => validateJsonDepth(obj, 5)).toThrow(ValidationError);
+    });
+
+    it('should reject deeply nested arrays', () => {
+      let arr: any = [1];
+      for (let i = 0; i < 20; i++) {
+        arr = [arr];
+      }
+      expect(() => validateJsonDepth(arr, 5)).toThrow(ValidationError);
+    });
+
+    it('should reject mixed nested structures', () => {
+      const obj = {
+        a: [
+          {
+            b: [
+              {
+                c: [
+                  {
+                    d: [
+                      {
+                        e: [{ f: 1 }],
+                      },
+                    ],
+                  },
                 ],
-            };
-            expect(() => validateJsonDepth(obj, 5)).toThrow(ValidationError);
-        });
-
-        it('should accept shallow structures', () => {
-            const obj = {
-                a: 1,
-                b: 2,
-                c: { d: 3, e: 4 },
-                f: [1, 2, 3],
-            };
-            expect(() => validateJsonDepth(obj, 10)).not.toThrow();
-        });
-
-        it('should provide depth information in error', () => {
-            const obj = { a: { b: { c: { d: 1 } } } };
-            try {
-                validateJsonDepth(obj, 2);
-                expect.fail('Should have thrown');
-            } catch (e) {
-                expect(e).toBeInstanceOf(ValidationError);
-                expect((e as ValidationError).message).toContain('depth');
-            }
-        });
+              },
+            ],
+          },
+        ],
+      };
+      expect(() => validateJsonDepth(obj, 5)).toThrow(ValidationError);
     });
 
-    describe('Boundary Conditions: Amount Validation', () => {
-        it('should accept minimum valid amount (1 stroop)', () => {
-            expect(validateAmount('1')).toBe('1');
-        });
-
-        it('should accept maximum valid amount', () => {
-            const maxAmount = '9223372036854775807';
-            expect(validateAmount(maxAmount)).toBe(maxAmount);
-        });
-
-        it('should reject amount exceeding max by 1', () => {
-            const overMax = '9223372036854775808';
-            expect(() => validateAmount(overMax)).toThrow(ValidationError);
-        });
-
-        it('should reject zero', () => {
-            expect(() => validateAmount('0')).toThrow(ValidationError);
-        });
-
-        it('should reject negative amounts', () => {
-            expect(() => validateAmount('-1')).toThrow(ValidationError);
-            expect(() => validateAmount('-999999999')).toThrow(ValidationError);
-        });
-
-        it('should reject decimal amounts', () => {
-            expect(() => validateAmount('100.5')).toThrow(ValidationError);
-            expect(() => validateAmount('0.1')).toThrow(ValidationError);
-        });
-
-        it('should reject scientific notation', () => {
-            expect(() => validateAmount('1e10')).toThrow(ValidationError);
-            expect(() => validateAmount('1E+10')).toThrow(ValidationError);
-        });
-
-        it('should reject leading zeros (but accept them as valid integers)', () => {
-            // Leading zeros are technically valid in JSON numbers
-            expect(validateAmount('00100')).toBe('00100');
-        });
-
-        it('should reject whitespace in amount', () => {
-            expect(() => validateAmount(' 100 ')).toThrow(ValidationError);
-        });
-
-        it('should reject empty string', () => {
-            expect(() => validateAmount('')).toThrow(ValidationError);
-        });
-
-        it('should handle very large number strings', () => {
-            const huge = '99999999999999999999999999999999';
-            expect(() => validateAmount(huge)).toThrow(ValidationError);
-        });
+    it('should accept shallow structures', () => {
+      const obj = {
+        a: 1,
+        b: 2,
+        c: { d: 3, e: 4 },
+        f: [1, 2, 3],
+      };
+      expect(() => validateJsonDepth(obj, 10)).not.toThrow();
     });
 
-    describe('Boundary Conditions: Stellar Address Validation', () => {
-        it('should accept valid Stellar public key', () => {
-            const valid = 'GBBD47UZQ5CYVVEUVRYNQZX3G5KRZTAYF5XSVS2UKMCCWW5LJJLXNVQX';
-            expect(validateStellarAddress(valid)).toBe(valid);
-        });
+    it('should provide depth information in error', () => {
+      const obj = { a: { b: { c: { d: 1 } } } };
+      try {
+        validateJsonDepth(obj, 2);
+        expect.fail('Should have thrown');
+      } catch (e) {
+        expect(e).toBeInstanceOf(ValidationError);
+        expect((e as ValidationError).message).toContain('depth');
+      }
+    });
+  });
 
-        it('should reject address with wrong prefix', () => {
-            const invalid = 'SBBD47UZQ5CYVVEUVRYNQZX3G5KRZTAYF5XSVS2UKMCCWW5LJJLXNVQX';
-            expect(() => validateStellarAddress(invalid)).toThrow(ValidationError);
-        });
-
-        it('should reject address with wrong length', () => {
-            const tooShort = 'GBBD47UZQ5CYVVEUVRYNQZX3G5KRZTAYF5XSVS2UKMCCWW5LJJLXNVQ';
-            const tooLong = 'GBBD47UZQ5CYVVEUVRYNQZX3G5KRZTAYF5XSVS2UKMCCWW5LJJLXNVQXX';
-            expect(() => validateStellarAddress(tooShort)).toThrow(ValidationError);
-            expect(() => validateStellarAddress(tooLong)).toThrow(ValidationError);
-        });
-
-        it('should reject address with invalid characters', () => {
-            const invalid = 'GBBD47UZQ5CYVVEUVRYNQZX3G5KRZTAYF5XSVS2UKMCCWW5LJJLXNVQ0'; // 0 is invalid
-            expect(() => validateStellarAddress(invalid)).toThrow(ValidationError);
-        });
-
-        it('should reject lowercase address', () => {
-            const lowercase = 'gbbd47uzq5cyvveuvrynqzx3g5krztayf5xsvs2ukmccww5ljjlxnvqx';
-            expect(() => validateStellarAddress(lowercase)).toThrow(ValidationError);
-        });
-
-        it('should reject empty string', () => {
-            expect(() => validateStellarAddress('')).toThrow(ValidationError);
-        });
-
-        it('should reject null-like values', () => {
-            expect(() => validateStellarAddress(null as any)).toThrow(ValidationError);
-            expect(() => validateStellarAddress(undefined as any)).toThrow(ValidationError);
-        });
-
-        it('should reject whitespace-only string', () => {
-            expect(() => validateStellarAddress('   ')).toThrow(ValidationError);
-        });
+  describe('Boundary Conditions: Amount Validation', () => {
+    it('should accept minimum valid amount (1 stroop)', () => {
+      expect(validateAmount('1')).toBe('1');
     });
 
-    describe('Boundary Conditions: Timestamp Validation', () => {
-        it('should accept future timestamp', () => {
-            const future = Math.floor(Date.now() / 1000) + 3600;
-            expect(validateTimestamp(future)).toBe(future);
-        });
-
-        it('should accept current timestamp', () => {
-            const now = Math.floor(Date.now() / 1000);
-            expect(validateTimestamp(now)).toBe(now);
-        });
-
-        it('should accept recent timestamp (within 1 hour)', () => {
-            const recent = Math.floor(Date.now() / 1000) - 1800;
-            expect(validateTimestamp(recent)).toBe(recent);
-        });
-
-        it('should accept timestamp exactly 1 hour ago', () => {
-            const oneHourAgo = Math.floor(Date.now() / 1000) - 3600;
-            expect(validateTimestamp(oneHourAgo)).toBe(oneHourAgo);
-        });
-
-        it('should reject timestamp older than 1 hour', () => {
-            const tooOld = Math.floor(Date.now() / 1000) - 3601;
-            expect(() => validateTimestamp(tooOld)).toThrow(ValidationError);
-        });
-
-        it('should reject very old timestamp', () => {
-            const veryOld = Math.floor(Date.now() / 1000) - 86400 * 365; // 1 year ago
-            expect(() => validateTimestamp(veryOld)).toThrow(ValidationError);
-        });
-
-        it('should handle string timestamps', () => {
-            const future = String(Math.floor(Date.now() / 1000) + 3600);
-            expect(validateTimestamp(future)).toBe(Number(future));
-        });
-
-        it('should reject invalid timestamp strings', () => {
-            expect(() => validateTimestamp('not-a-number')).toThrow(ValidationError);
-        });
-
-        it('should reject NaN', () => {
-            expect(() => validateTimestamp(NaN)).toThrow(ValidationError);
-        });
+    it('should accept maximum valid amount', () => {
+      const maxAmount = '9223372036854775807';
+      expect(validateAmount(maxAmount)).toBe(maxAmount);
     });
 
-    describe('Duplicate Submission Detection', () => {
-        it('should detect identical requests', () => {
-            const request = {
-                sender: 'GBBD47UZQ5CYVVEUVRYNQZX3G5KRZTAYF5XSVS2UKMCCWW5LJJLXNVQX',
-                recipient: 'GBRPYHIL2CI3WHZDTOOQFC6EB4KJJGUJJBBX7XNLG5DBNVQWDADUZSQX',
-                depositAmount: '1000000000',
-                ratePerSecond: '100000',
-                startTime: Math.floor(Date.now() / 1000) + 3600,
-            };
-
-            // Both should validate successfully
-            const result1 = validateCreateStreamRequest(request);
-            const result2 = validateCreateStreamRequest(request);
-
-            expect(result1).toEqual(result2);
-        });
-
-        it('should detect when only one field differs', () => {
-            const base = {
-                sender: 'GBBD47UZQ5CYVVEUVRYNQZX3G5KRZTAYF5XSVS2UKMCCWW5LJJLXNVQX',
-                recipient: 'GBRPYHIL2CI3WHZDTOOQFC6EB4KJJGUJJBBX7XNLG5DBNVQWDADUZSQX',
-                depositAmount: '1000000000',
-                ratePerSecond: '100000',
-                startTime: Math.floor(Date.now() / 1000) + 3600,
-            };
-
-            const variations = [
-                { ...base, depositAmount: '2000000000' },
-                { ...base, ratePerSecond: '200000' },
-                { ...base, startTime: base.startTime + 1 },
-            ];
-
-            const baseResult = validateCreateStreamRequest(base);
-            variations.forEach((variation) => {
-                const result = validateCreateStreamRequest(variation);
-                expect(result).not.toEqual(baseResult);
-            });
-        });
+    it('should reject amount exceeding max by 1', () => {
+      const overMax = '9223372036854775808';
+      expect(() => validateAmount(overMax)).toThrow(ValidationError);
     });
 
-    describe('Type Coercion Edge Cases', () => {
-        it('should handle numeric strings for amounts', () => {
-            expect(validateAmount('1000')).toBe('1000');
-        });
-
-        it('should handle numeric values for amounts', () => {
-            expect(validateAmount(1000)).toBe('1000');
-        });
-
-        it('should handle string timestamps', () => {
-            const future = Math.floor(Date.now() / 1000) + 3600;
-            expect(validateTimestamp(String(future))).toBe(future);
-        });
-
-        it('should handle numeric timestamps', () => {
-            const future = Math.floor(Date.now() / 1000) + 3600;
-            expect(validateTimestamp(future)).toBe(future);
-        });
-
-        it('should reject boolean values for amounts', () => {
-            expect(() => validateAmount(true as any)).toThrow(ValidationError);
-        });
-
-        it('should reject object values for amounts', () => {
-            expect(() => validateAmount({} as any)).toThrow(ValidationError);
-        });
-
-        it('should reject array values for amounts', () => {
-            expect(() => validateAmount([] as any)).toThrow(ValidationError);
-        });
+    it('should reject zero', () => {
+      expect(() => validateAmount('0')).toThrow(ValidationError);
     });
 
-    describe('Stream ID Validation', () => {
-        it('should accept valid stream ID', () => {
-            expect(validateStreamId('stream-1704067200')).toBe('stream-1704067200');
-        });
-
-        it('should reject ID without stream prefix', () => {
-            expect(() => validateStreamId('1704067200')).toThrow(ValidationError);
-        });
-
-        it('should reject ID with wrong prefix', () => {
-            expect(() => validateStreamId('flow-1704067200')).toThrow(ValidationError);
-        });
-
-        it('should reject ID with non-numeric suffix', () => {
-            expect(() => validateStreamId('stream-abc')).toThrow(ValidationError);
-        });
-
-        it('should reject empty ID', () => {
-            expect(() => validateStreamId('')).toThrow(ValidationError);
-        });
-
-        it('should reject ID with extra characters', () => {
-            expect(() => validateStreamId('stream-1704067200-extra')).toThrow(ValidationError);
-        });
+    it('should reject negative amounts', () => {
+      expect(() => validateAmount('-1')).toThrow(ValidationError);
+      expect(() => validateAmount('-999999999')).toThrow(ValidationError);
     });
 
-    describe('Rate Per Second Validation', () => {
-        it('should accept valid rate', () => {
-            expect(validateRatePerSecond('100000')).toBe('100000');
-        });
-
-        it('should accept minimum rate (1)', () => {
-            expect(validateRatePerSecond('1')).toBe('1');
-        });
-
-        it('should reject zero rate', () => {
-            expect(() => validateRatePerSecond('0')).toThrow(ValidationError);
-        });
-
-        it('should reject negative rate', () => {
-            expect(() => validateRatePerSecond('-100')).toThrow(ValidationError);
-        });
-
-        it('should reject decimal rate', () => {
-            expect(() => validateRatePerSecond('100.5')).toThrow(ValidationError);
-        });
+    it('should reject decimal amounts', () => {
+      expect(() => validateAmount('100.5')).toThrow(ValidationError);
+      expect(() => validateAmount('0.1')).toThrow(ValidationError);
     });
 
-    describe('Create Stream Request Validation', () => {
-        const validRequest = {
-            sender: 'GBBD47UZQ5CYVVEUVRYNQZX3G5KRZTAYF5XSVS2UKMCCWW5LJJLXNVQX',
-            recipient: 'GBRPYHIL2CI3WHZDTOOQFC6EB4KJJGUJJBBX7XNLG5DBNVQWDADUZSQX',
-            depositAmount: '1000000000',
-            ratePerSecond: '100000',
-            startTime: Math.floor(Date.now() / 1000) + 3600,
-        };
-
-        it('should accept valid request', () => {
-            const result = validateCreateStreamRequest(validRequest);
-            expect(result.sender).toBe(validRequest.sender);
-        });
-
-        it('should reject request with same sender and recipient', () => {
-            const invalid = {
-                ...validRequest,
-                recipient: validRequest.sender,
-            };
-            expect(() => validateCreateStreamRequest(invalid)).toThrow(ValidationError);
-        });
-
-        it('should reject request with insufficient deposit', () => {
-            const invalid = {
-                ...validRequest,
-                depositAmount: '50000',
-                ratePerSecond: '100000',
-            };
-            expect(() => validateCreateStreamRequest(invalid)).toThrow(ValidationError);
-        });
-
-        it('should accept request with deposit equal to rate', () => {
-            const valid = {
-                ...validRequest,
-                depositAmount: '100000',
-                ratePerSecond: '100000',
-            };
-            expect(() => validateCreateStreamRequest(valid)).not.toThrow();
-        });
-
-        it('should reject non-object request', () => {
-            expect(() => validateCreateStreamRequest('not an object')).toThrow(ValidationError);
-            expect(() => validateCreateStreamRequest(null)).toThrow(ValidationError);
-            expect(() => validateCreateStreamRequest([])).toThrow(ValidationError);
-        });
-
-        it('should reject request with missing fields', () => {
-            const incomplete = {
-                sender: validRequest.sender,
-                recipient: validRequest.recipient,
-                // missing depositAmount, ratePerSecond, startTime
-            };
-            expect(() => validateCreateStreamRequest(incomplete)).toThrow(ValidationError);
-        });
-
-        it('should reject request with invalid sender', () => {
-            const invalid = {
-                ...validRequest,
-                sender: 'invalid-address',
-            };
-            expect(() => validateCreateStreamRequest(invalid)).toThrow(ValidationError);
-        });
-
-        it('should reject request with invalid recipient', () => {
-            const invalid = {
-                ...validRequest,
-                recipient: 'invalid-address',
-            };
-            expect(() => validateCreateStreamRequest(invalid)).toThrow(ValidationError);
-        });
-
-        it('should reject request with invalid amount', () => {
-            const invalid = {
-                ...validRequest,
-                depositAmount: '-1000',
-            };
-            expect(() => validateCreateStreamRequest(invalid)).toThrow(ValidationError);
-        });
-
-        it('should reject request with invalid rate', () => {
-            const invalid = {
-                ...validRequest,
-                ratePerSecond: '0',
-            };
-            expect(() => validateCreateStreamRequest(invalid)).toThrow(ValidationError);
-        });
-
-        it('should reject request with old timestamp', () => {
-            const invalid = {
-                ...validRequest,
-                startTime: Math.floor(Date.now() / 1000) - 7200,
-            };
-            expect(() => validateCreateStreamRequest(invalid)).toThrow(ValidationError);
-        });
+    it('should reject scientific notation', () => {
+      expect(() => validateAmount('1e10')).toThrow(ValidationError);
+      expect(() => validateAmount('1E+10')).toThrow(ValidationError);
     });
 
-    describe('Error Information Completeness', () => {
-        it('should include field name in validation error', () => {
-            try {
-                validateStellarAddress('invalid', 'customField');
-                expect.fail('Should have thrown');
-            } catch (e) {
-                expect(e).toBeInstanceOf(ValidationError);
-                expect((e as ValidationError).field).toBe('customField');
-            }
-        });
-
-        it('should include value in validation error', () => {
-            try {
-                validateAmount('-100');
-                expect.fail('Should have thrown');
-            } catch (e) {
-                expect(e).toBeInstanceOf(ValidationError);
-                expect((e as ValidationError).value).toBe('-100');
-            }
-        });
-
-        it('should provide actionable error messages', () => {
-            try {
-                validateStellarAddress('invalid');
-                expect.fail('Should have thrown');
-            } catch (e) {
-                expect((e as ValidationError).message).toContain('valid Stellar');
-            }
-        });
+    it('should reject leading zeros (but accept them as valid integers)', () => {
+      // Leading zeros are technically valid in JSON numbers
+      expect(validateAmount('00100')).toBe('00100');
     });
+
+    it('should reject whitespace in amount', () => {
+      expect(() => validateAmount(' 100 ')).toThrow(ValidationError);
+    });
+
+    it('should reject empty string', () => {
+      expect(() => validateAmount('')).toThrow(ValidationError);
+    });
+
+    it('should handle very large number strings', () => {
+      const huge = '99999999999999999999999999999999';
+      expect(() => validateAmount(huge)).toThrow(ValidationError);
+    });
+  });
+
+  describe('Boundary Conditions: Stellar Address Validation', () => {
+    it('should accept valid Stellar public key', () => {
+      const valid = 'GBBD47UZQ5CYVVEUVRYNQZX3G5KRZTAYF5XSVS2UKMCCWW5LJJLXNVQX';
+      expect(validateStellarAddress(valid)).toBe(valid);
+    });
+
+    it('should reject address with wrong prefix', () => {
+      const invalid = 'SBBD47UZQ5CYVVEUVRYNQZX3G5KRZTAYF5XSVS2UKMCCWW5LJJLXNVQX';
+      expect(() => validateStellarAddress(invalid)).toThrow(ValidationError);
+    });
+
+    it('should reject address with wrong length', () => {
+      const tooShort = 'GBBD47UZQ5CYVVEUVRYNQZX3G5KRZTAYF5XSVS2UKMCCWW5LJJLXNVQ';
+      const tooLong = 'GBBD47UZQ5CYVVEUVRYNQZX3G5KRZTAYF5XSVS2UKMCCWW5LJJLXNVQXX';
+      expect(() => validateStellarAddress(tooShort)).toThrow(ValidationError);
+      expect(() => validateStellarAddress(tooLong)).toThrow(ValidationError);
+    });
+
+    it('should reject address with invalid characters', () => {
+      const invalid = 'GBBD47UZQ5CYVVEUVRYNQZX3G5KRZTAYF5XSVS2UKMCCWW5LJJLXNVQ0'; // 0 is invalid
+      expect(() => validateStellarAddress(invalid)).toThrow(ValidationError);
+    });
+
+    it('should reject lowercase address', () => {
+      const lowercase = 'gbbd47uzq5cyvveuvrynqzx3g5krztayf5xsvs2ukmccww5ljjlxnvqx';
+      expect(() => validateStellarAddress(lowercase)).toThrow(ValidationError);
+    });
+
+    it('should reject empty string', () => {
+      expect(() => validateStellarAddress('')).toThrow(ValidationError);
+    });
+
+    it('should reject null-like values', () => {
+      expect(() => validateStellarAddress(null as any)).toThrow(ValidationError);
+      expect(() => validateStellarAddress(undefined as any)).toThrow(ValidationError);
+    });
+
+    it('should reject whitespace-only string', () => {
+      expect(() => validateStellarAddress('   ')).toThrow(ValidationError);
+    });
+  });
+
+  describe('Boundary Conditions: Timestamp Validation', () => {
+    it('should accept future timestamp', () => {
+      const future = Math.floor(Date.now() / 1000) + 3600;
+      expect(validateTimestamp(future)).toBe(future);
+    });
+
+    it('should accept current timestamp', () => {
+      const now = Math.floor(Date.now() / 1000);
+      expect(validateTimestamp(now)).toBe(now);
+    });
+
+    it('should accept recent timestamp (within 1 hour)', () => {
+      const recent = Math.floor(Date.now() / 1000) - 1800;
+      expect(validateTimestamp(recent)).toBe(recent);
+    });
+
+    it('should accept timestamp exactly 1 hour ago', () => {
+      const oneHourAgo = Math.floor(Date.now() / 1000) - 3600;
+      expect(validateTimestamp(oneHourAgo)).toBe(oneHourAgo);
+    });
+
+    it('should reject timestamp older than 1 hour', () => {
+      const tooOld = Math.floor(Date.now() / 1000) - 3601;
+      expect(() => validateTimestamp(tooOld)).toThrow(ValidationError);
+    });
+
+    it('should reject very old timestamp', () => {
+      const veryOld = Math.floor(Date.now() / 1000) - 86400 * 365; // 1 year ago
+      expect(() => validateTimestamp(veryOld)).toThrow(ValidationError);
+    });
+
+    it('should handle string timestamps', () => {
+      const future = String(Math.floor(Date.now() / 1000) + 3600);
+      expect(validateTimestamp(future)).toBe(Number(future));
+    });
+
+    it('should reject invalid timestamp strings', () => {
+      expect(() => validateTimestamp('not-a-number')).toThrow(ValidationError);
+    });
+
+    it('should reject NaN', () => {
+      expect(() => validateTimestamp(NaN)).toThrow(ValidationError);
+    });
+  });
+
+  describe('Duplicate Submission Detection', () => {
+    it('should detect identical requests', () => {
+      const request = {
+        sender: 'GBBD47UZQ5CYVVEUVRYNQZX3G5KRZTAYF5XSVS2UKMCCWW5LJJLXNVQX',
+        recipient: 'GBRPYHIL2CI3WHZDTOOQFC6EB4KJJGUJJBBX7XNLG5DBNVQWDADUZSQX',
+        depositAmount: '1000000000',
+        ratePerSecond: '100000',
+        startTime: Math.floor(Date.now() / 1000) + 3600,
+      };
+
+      // Both should validate successfully
+      const result1 = validateCreateStreamRequest(request);
+      const result2 = validateCreateStreamRequest(request);
+
+      expect(result1).toEqual(result2);
+    });
+
+    it('should detect when only one field differs', () => {
+      const base = {
+        sender: 'GBBD47UZQ5CYVVEUVRYNQZX3G5KRZTAYF5XSVS2UKMCCWW5LJJLXNVQX',
+        recipient: 'GBRPYHIL2CI3WHZDTOOQFC6EB4KJJGUJJBBX7XNLG5DBNVQWDADUZSQX',
+        depositAmount: '1000000000',
+        ratePerSecond: '100000',
+        startTime: Math.floor(Date.now() / 1000) + 3600,
+      };
+
+      const variations = [
+        { ...base, depositAmount: '2000000000' },
+        { ...base, ratePerSecond: '200000' },
+        { ...base, startTime: base.startTime + 1 },
+      ];
+
+      const baseResult = validateCreateStreamRequest(base);
+      variations.forEach((variation) => {
+        const result = validateCreateStreamRequest(variation);
+        expect(result).not.toEqual(baseResult);
+      });
+    });
+  });
+
+  describe('Type Coercion Edge Cases', () => {
+    it('should handle numeric strings for amounts', () => {
+      expect(validateAmount('1000')).toBe('1000');
+    });
+
+    it('should handle numeric values for amounts', () => {
+      expect(validateAmount(1000)).toBe('1000');
+    });
+
+    it('should handle string timestamps', () => {
+      const future = Math.floor(Date.now() / 1000) + 3600;
+      expect(validateTimestamp(String(future))).toBe(future);
+    });
+
+    it('should handle numeric timestamps', () => {
+      const future = Math.floor(Date.now() / 1000) + 3600;
+      expect(validateTimestamp(future)).toBe(future);
+    });
+
+    it('should reject boolean values for amounts', () => {
+      expect(() => validateAmount(true as any)).toThrow(ValidationError);
+    });
+
+    it('should reject object values for amounts', () => {
+      expect(() => validateAmount({} as any)).toThrow(ValidationError);
+    });
+
+    it('should reject array values for amounts', () => {
+      expect(() => validateAmount([] as any)).toThrow(ValidationError);
+    });
+  });
+
+  describe('Stream ID Validation', () => {
+    it('should accept valid stream ID', () => {
+      expect(validateStreamId('stream-1704067200')).toBe('stream-1704067200');
+    });
+
+    it('should reject ID without stream prefix', () => {
+      expect(() => validateStreamId('1704067200')).toThrow(ValidationError);
+    });
+
+    it('should reject ID with wrong prefix', () => {
+      expect(() => validateStreamId('flow-1704067200')).toThrow(ValidationError);
+    });
+
+    it('should reject ID with non-numeric suffix', () => {
+      expect(() => validateStreamId('stream-abc')).toThrow(ValidationError);
+    });
+
+    it('should reject empty ID', () => {
+      expect(() => validateStreamId('')).toThrow(ValidationError);
+    });
+
+    it('should reject ID with extra characters', () => {
+      expect(() => validateStreamId('stream-1704067200-extra')).toThrow(ValidationError);
+    });
+  });
+
+  describe('Rate Per Second Validation', () => {
+    it('should accept valid rate', () => {
+      expect(validateRatePerSecond('100000')).toBe('100000');
+    });
+
+    it('should accept minimum rate (1)', () => {
+      expect(validateRatePerSecond('1')).toBe('1');
+    });
+
+    it('should reject zero rate', () => {
+      expect(() => validateRatePerSecond('0')).toThrow(ValidationError);
+    });
+
+    it('should reject negative rate', () => {
+      expect(() => validateRatePerSecond('-100')).toThrow(ValidationError);
+    });
+
+    it('should reject decimal rate', () => {
+      expect(() => validateRatePerSecond('100.5')).toThrow(ValidationError);
+    });
+  });
+
+  describe('Create Stream Request Validation', () => {
+    const validRequest = {
+      sender: 'GBBD47UZQ5CYVVEUVRYNQZX3G5KRZTAYF5XSVS2UKMCCWW5LJJLXNVQX',
+      recipient: 'GBRPYHIL2CI3WHZDTOOQFC6EB4KJJGUJJBBX7XNLG5DBNVQWDADUZSQX',
+      depositAmount: '1000000000',
+      ratePerSecond: '100000',
+      startTime: Math.floor(Date.now() / 1000) + 3600,
+    };
+
+    it('should accept valid request', () => {
+      const result = validateCreateStreamRequest(validRequest);
+      expect(result.sender).toBe(validRequest.sender);
+    });
+
+    it('should reject request with same sender and recipient', () => {
+      const invalid = {
+        ...validRequest,
+        recipient: validRequest.sender,
+      };
+      expect(() => validateCreateStreamRequest(invalid)).toThrow(ValidationError);
+    });
+
+    it('should reject request with insufficient deposit', () => {
+      const invalid = {
+        ...validRequest,
+        depositAmount: '50000',
+        ratePerSecond: '100000',
+      };
+      expect(() => validateCreateStreamRequest(invalid)).toThrow(ValidationError);
+    });
+
+    it('should accept request with deposit equal to rate', () => {
+      const valid = {
+        ...validRequest,
+        depositAmount: '100000',
+        ratePerSecond: '100000',
+      };
+      expect(() => validateCreateStreamRequest(valid)).not.toThrow();
+    });
+
+    it('should reject non-object request', () => {
+      expect(() => validateCreateStreamRequest('not an object')).toThrow(ValidationError);
+      expect(() => validateCreateStreamRequest(null)).toThrow(ValidationError);
+      expect(() => validateCreateStreamRequest([])).toThrow(ValidationError);
+    });
+
+    it('should reject request with missing fields', () => {
+      const incomplete = {
+        sender: validRequest.sender,
+        recipient: validRequest.recipient,
+        // missing depositAmount, ratePerSecond, startTime
+      };
+      expect(() => validateCreateStreamRequest(incomplete)).toThrow(ValidationError);
+    });
+
+    it('should reject request with invalid sender', () => {
+      const invalid = {
+        ...validRequest,
+        sender: 'invalid-address',
+      };
+      expect(() => validateCreateStreamRequest(invalid)).toThrow(ValidationError);
+    });
+
+    it('should reject request with invalid recipient', () => {
+      const invalid = {
+        ...validRequest,
+        recipient: 'invalid-address',
+      };
+      expect(() => validateCreateStreamRequest(invalid)).toThrow(ValidationError);
+    });
+
+    it('should reject request with invalid amount', () => {
+      const invalid = {
+        ...validRequest,
+        depositAmount: '-1000',
+      };
+      expect(() => validateCreateStreamRequest(invalid)).toThrow(ValidationError);
+    });
+
+    it('should reject request with invalid rate', () => {
+      const invalid = {
+        ...validRequest,
+        ratePerSecond: '0',
+      };
+      expect(() => validateCreateStreamRequest(invalid)).toThrow(ValidationError);
+    });
+
+    it('should reject request with old timestamp', () => {
+      const invalid = {
+        ...validRequest,
+        startTime: Math.floor(Date.now() / 1000) - 7200,
+      };
+      expect(() => validateCreateStreamRequest(invalid)).toThrow(ValidationError);
+    });
+
+    it('should accept the same valid request through the Zod create stream schema', () => {
+      const result = CreateStreamSchema.safeParse(validRequest);
+
+      expect(result.success).toBe(true);
+    });
+  });
+
+  describe('Stream Batch Create Schema', () => {
+    const baseStream = {
+      sender: 'GBBD47UZQ5CYVVEUVRYNQZX3G5KRZTAYF5XSVS2UKMCCWW5LJJLXNVQX',
+      recipient: 'GBRPYHIL2CI3WHZDTOOQFC6EB4KJJGUJJBBX7XNLG5DBNVQWDADUZSQX',
+      depositAmount: '1000000000',
+      ratePerSecond: '100000',
+      startTime: 1704067200,
+      endTime: 0,
+      transaction_hash: 'a'.repeat(64),
+      event_index: 0,
+    };
+
+    it('should accept distinct stream identities within one batch', () => {
+      const result = StreamBatchCreateSchema.safeParse({
+        streams: [
+          baseStream,
+          { ...baseStream, event_index: 1 },
+          { ...baseStream, transaction_hash: 'b'.repeat(64), event_index: 0 },
+        ],
+      });
+
+      expect(result.success).toBe(true);
+    });
+
+    it('should reject duplicate stream identities and point at the duplicate index', () => {
+      const result = StreamBatchCreateSchema.safeParse({
+        streams: [
+          baseStream,
+          { ...baseStream, event_index: 1 },
+          { ...baseStream, depositAmount: '2000000000' },
+        ],
+      });
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.issues[0]?.path).toEqual(['streams', 2]);
+        expect(result.error.issues[0]?.message).toContain('Duplicate stream identity');
+      }
+    });
+
+    it('should keep the existing maximum batch size cap', () => {
+      const streams = Array.from({ length: 101 }, (_, index) => ({
+        ...baseStream,
+        transaction_hash: index.toString(16).padStart(64, '0'),
+        event_index: index,
+      }));
+
+      const result = StreamBatchCreateSchema.safeParse({ streams });
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(
+          result.error.issues.some((issue) => issue.message === 'Maximum of 100 streams per batch')
+        ).toBe(true);
+      }
+    });
+  });
+
+  describe('Error Information Completeness', () => {
+    it('should include field name in validation error', () => {
+      try {
+        validateStellarAddress('invalid', 'customField');
+        expect.fail('Should have thrown');
+      } catch (e) {
+        expect(e).toBeInstanceOf(ValidationError);
+        expect((e as ValidationError).field).toBe('customField');
+      }
+    });
+
+    it('should include value in validation error', () => {
+      try {
+        validateAmount('-100');
+        expect.fail('Should have thrown');
+      } catch (e) {
+        expect(e).toBeInstanceOf(ValidationError);
+        expect((e as ValidationError).value).toBe('-100');
+      }
+    });
+
+    it('should provide actionable error messages', () => {
+      try {
+        validateStellarAddress('invalid');
+        expect.fail('Should have thrown');
+      } catch (e) {
+        expect((e as ValidationError).message).toContain('valid Stellar');
+      }
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- add a concrete CreateStreamSchema export used by stream validation
- add BatchStreamCreateSchema with transaction_hash/event_index identity fields
- reject duplicate (sender, recipient, transaction_hash, event_index) tuples within StreamBatchCreateSchema and point the validation error at the duplicate index
- cover distinct batches, mixed duplicate batches, and the existing 100-stream batch cap

Fixes #365.

## Validation
- pnpm test -- tests/validation-edge-cases.test.ts
- pnpm exec eslint src/validation/schemas.ts tests/validation-edge-cases.test.ts (existing test-file no-explicit-any warnings only)
- pnpm exec tsc --noEmit --skipLibCheck --target ES2022 --module NodeNext --moduleResolution NodeNext --types node src/validation/schemas.ts

## Security notes
The duplicate check runs at the Zod boundary before downstream writes or idempotency reservation, preventing intra-batch duplicate amplification before database work starts.