### PR TITLE
fix(auth): clamp JWT revocation TTL to exp

### DIFF
--- a/src/redis/jwtRevocationStore.ts
+++ b/src/redis/jwtRevocationStore.ts
@@ -16,6 +16,17 @@ const DEFAULT_REVOCATION_TTL_SECONDS = 7 * 24 * 60 * 60; // 604800 seconds
 
 let redis: Redis | null = null;
 
+export interface JwtRevocationOptions {
+  ttl?: number;
+  exp: number;
+  nowSeconds?: number;
+}
+
+export interface JwtRevocationResult {
+  revoked: boolean;
+  ttlSeconds: number;
+}
+
 /**
  * Lazily initialize and return the shared Redis client.
  * Reuses the same connection across calls.
@@ -55,8 +66,39 @@ function buildKey(jti: string): string {
   return `${REVOCATION_PREFIX}:${jti}`;
 }
 
+function assertPositiveInteger(value: number, field: string): void {
+  if (!Number.isInteger(value) || value <= 0) {
+    throw new TypeError(`${field} must be a positive integer`);
+  }
+}
+
+function resolveRevocationTtl(input: number | JwtRevocationOptions | undefined): number {
+  if (typeof input === 'number' || input === undefined) {
+    const ttl = input ?? DEFAULT_REVOCATION_TTL_SECONDS;
+    assertPositiveInteger(ttl, 'ttl');
+    return ttl;
+  }
+
+  const { ttl, exp, nowSeconds = Date.now() / 1000 } = input;
+  assertPositiveInteger(exp, 'exp');
+  if (ttl !== undefined) {
+    assertPositiveInteger(ttl, 'ttl');
+  }
+
+  return Math.max(0, Math.ceil(exp - nowSeconds));
+}
+
 /**
  * Revoke a JWT by its jti claim, storing it in Redis with a TTL.
+ *
+ * When an `exp` claim is provided, the Redis TTL is derived from the token's
+ * remaining lifetime (`ceil(exp - now)`). Caller TTLs are accepted for input
+ * validation, but the JWT expiry remains authoritative so a revoked token
+ * cannot become accepted again before natural expiry, and Redis does not store
+ * revocations past token expiry. Already-expired tokens are treated as no-ops.
+ *
+ * The numeric TTL overload is kept for legacy callers that cannot supply `exp`.
+ * New JWT revocation flows should pass `{ exp, ttl }`.
  *
  * @param jti — The JWT ID (jti) claim to revoke
  * @param ttl — Time-to-live in seconds. Defaults to 7 days.
@@ -67,13 +109,19 @@ function buildKey(jti: string): string {
  * - Overwrites any existing entry (idempotent — duplicate revocations are safe)
  * - Logs revocation for audit trail
  */
-export async function revoke(jti: string, ttl: number = DEFAULT_REVOCATION_TTL_SECONDS): Promise<void> {
+export async function revoke(
+  jti: string,
+  options?: number | JwtRevocationOptions,
+): Promise<JwtRevocationResult> {
   if (!jti || typeof jti !== 'string') {
     throw new TypeError('jti must be a non-empty string');
   }
 
+  const ttl = resolveRevocationTtl(options);
+
   if (ttl <= 0) {
-    throw new TypeError('ttl must be a positive integer');
+    info('JWT revocation skipped for expired token', { jti });
+    return { revoked: false, ttlSeconds: 0 };
   }
 
   const client = getRedisClient();
@@ -81,6 +129,7 @@ export async function revoke(jti: string, ttl: number = DEFAULT_REVOCATION_TTL_S
 
   await client.set(key, '1', 'EX', ttl);
   info('JWT revoked', { jti, ttlSeconds: ttl });
+  return { revoked: true, ttlSeconds: ttl };
 }
 
 /**

--- a/src/routes/auth.ts
+++ b/src/routes/auth.ts
@@ -1,7 +1,7 @@
 import { Router, Request, Response } from 'express';
 import { z } from 'zod';
 import { generateToken } from '../lib/auth.js';
-import { validationError, unauthorized, asyncHandler, forbidden } from '../middleware/errorHandler.js';
+import { validationError, unauthorized, asyncHandler } from '../middleware/errorHandler.js';
 import { info } from '../utils/logger.js';
 import { getConfig } from '../config/env.js';
 import { verifyIdToken } from '../services/oidcProvider.js';
@@ -124,6 +124,7 @@ authRouter.post(
 
 const RevokeRequestSchema = z.object({
   jti: z.string().min(1, 'jti is required'),
+  exp: z.coerce.number().int().positive('exp is required'),
   ttl: z.coerce.number().int().positive().optional(),
 });
 
@@ -134,7 +135,9 @@ const RevokeRequestSchema = z.object({
  *     summary: Revoke a JWT by its jti claim
  *     description: |
  *       Admin-only endpoint to immediately invalidate a JWT before its natural expiry.
- *       Adds the jti to the Redis-backed revocation list with a TTL.
+ *       Adds the jti to the Redis-backed revocation list. The stored TTL is
+ *       derived from the token exp claim (`max(0, exp - now)`) so revocation
+ *       covers the full remaining token lifetime without storing past expiry.
  *     tags:
  *       - auth
  *     security:
@@ -149,9 +152,12 @@ const RevokeRequestSchema = z.object({
  *               jti:
  *                 type: string
  *                 description: JWT ID (jti) claim to revoke
+ *               exp:
+ *                 type: integer
+ *                 description: JWT exp claim as a Unix timestamp in seconds
  *               ttl:
  *                 type: integer
- *                 description: Time-to-live in seconds (optional, defaults to 7 days)
+ *                 description: Optional caller TTL. It is validated, then bounded by exp.
  *     responses:
  *       200:
  *         description: Token revoked successfully
@@ -184,16 +190,25 @@ authRouter.post(
       throw validationError('Invalid revocation request', result.error.format());
     }
 
-    const { jti, ttl } = result.data;
+    const { jti, exp, ttl } = result.data;
 
-    await revoke(jti, ttl);
+    const revocation = await revoke(jti, { exp, ttl });
 
-    info('JWT revoked via admin endpoint', { jti, ttlSeconds: ttl, revokedBy: (req.user as any)?.address, requestId });
+    const revokedBy = (req.user as { address?: string } | undefined)?.address;
+
+    info('JWT revoked via admin endpoint', {
+      jti,
+      ttlSeconds: revocation.ttlSeconds,
+      revoked: revocation.revoked,
+      revokedBy,
+      requestId,
+    });
 
     res.json({
       success: true,
       jti,
-      ttl: ttl ?? null,
+      revoked: revocation.revoked,
+      ttl: revocation.ttlSeconds,
     });
   })
 );

--- a/tests/routes/auth.revoke.test.ts
+++ b/tests/routes/auth.revoke.test.ts
@@ -1,0 +1,95 @@
+import express from 'express';
+import type { NextFunction, Request, Response } from 'express';
+import request from 'supertest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockRevoke = vi.fn();
+
+vi.mock('../../src/redis/jwtRevocationStore.js', () => ({
+  revoke: mockRevoke,
+}));
+
+vi.mock('../../src/middleware/auth.js', async () => {
+  const actual = await vi.importActual<typeof import('../../src/middleware/auth.js')>(
+    '../../src/middleware/auth.js',
+  );
+
+  return {
+    ...actual,
+    requirePermission: () => (req: Request, _res: Response, next: NextFunction) => {
+      req.user = { address: 'GADMIN', permissions: [actual.Permission.ADMIN_PAUSE] };
+      next();
+    },
+  };
+});
+
+vi.mock('../../src/utils/logger.js', () => ({
+  info: vi.fn(),
+  warn: vi.fn(),
+  debug: vi.fn(),
+}));
+
+const { authRouter } = await import('../../src/routes/auth.js');
+
+function createTestApp() {
+  const app = express();
+  app.use(express.json());
+  app.use('/api/auth', authRouter);
+  app.use((err: unknown, _req: Request, res: Response, _next: NextFunction) => {
+    const error = err as { status?: number; statusCode?: number; code?: string; message?: string; details?: unknown };
+    res.status(error.status ?? error.statusCode ?? 500).json({
+      error: {
+        code: error.code,
+        message: error.message,
+        details: error.details,
+      },
+    });
+  });
+  return app;
+}
+
+describe('POST /api/auth/revoke', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRevoke.mockResolvedValue({ revoked: true, ttlSeconds: 3600 });
+  });
+
+  it('passes jti, exp, and caller ttl to the revocation store', async () => {
+    const app = createTestApp();
+
+    const response = await request(app)
+      .post('/api/auth/revoke')
+      .send({
+        jti: 'jti-route',
+        exp: 1_700_003_600,
+        ttl: 60,
+      })
+      .expect(200);
+
+    expect(mockRevoke).toHaveBeenCalledWith('jti-route', {
+      exp: 1_700_003_600,
+      ttl: 60,
+    });
+    expect(response.body).toMatchObject({
+      success: true,
+      jti: 'jti-route',
+      revoked: true,
+      ttl: 3600,
+    });
+  });
+
+  it('rejects revoke requests without an exp claim', async () => {
+    const app = createTestApp();
+
+    const response = await request(app)
+      .post('/api/auth/revoke')
+      .send({
+        jti: 'jti-route',
+        ttl: 60,
+      })
+      .expect(400);
+
+    expect(mockRevoke).not.toHaveBeenCalled();
+    expect(response.body.error.code).toBe('VALIDATION_ERROR');
+  });
+});

--- a/tests/unit/redis/jwtRevocationStore.test.ts
+++ b/tests/unit/redis/jwtRevocationStore.test.ts
@@ -45,7 +45,7 @@ describe('revoke', () => {
   it('stores jti in Redis with SET and EX', async () => {
     mockRedis.set.mockResolvedValue('OK');
 
-    await revoke('jti-123', 3600);
+    const result = await revoke('jti-123', 3600);
 
     expect(mockRedis.set).toHaveBeenCalledWith(
       'jwt:revoked:jti-123',
@@ -53,6 +53,7 @@ describe('revoke', () => {
       'EX',
       3600,
     );
+    expect(result).toEqual({ revoked: true, ttlSeconds: 3600 });
   });
 
   it('uses default TTL when not provided', async () => {
@@ -83,6 +84,73 @@ describe('revoke', () => {
     );
   });
 
+  it('derives TTL from exp when caller TTL is longer than remaining token lifetime', async () => {
+    mockRedis.set.mockResolvedValue('OK');
+
+    const result = await revoke('jti-long-ttl', {
+      ttl: 7200,
+      exp: 1_700_003_600,
+      nowSeconds: 1_700_000_000,
+    });
+
+    expect(mockRedis.set).toHaveBeenCalledWith(
+      'jwt:revoked:jti-long-ttl',
+      '1',
+      'EX',
+      3600,
+    );
+    expect(result).toEqual({ revoked: true, ttlSeconds: 3600 });
+  });
+
+  it('derives TTL from exp when caller TTL is shorter than remaining token lifetime', async () => {
+    mockRedis.set.mockResolvedValue('OK');
+
+    const result = await revoke('jti-short-ttl', {
+      ttl: 60,
+      exp: 1_700_003_600,
+      nowSeconds: 1_700_000_000,
+    });
+
+    expect(mockRedis.set).toHaveBeenCalledWith(
+      'jwt:revoked:jti-short-ttl',
+      '1',
+      'EX',
+      3600,
+    );
+    expect(result).toEqual({ revoked: true, ttlSeconds: 3600 });
+  });
+
+  it('derives TTL from exp when caller TTL equals remaining token lifetime', async () => {
+    mockRedis.set.mockResolvedValue('OK');
+
+    const result = await revoke('jti-equal-ttl', {
+      ttl: 3600,
+      exp: 1_700_003_600,
+      nowSeconds: 1_700_000_000,
+    });
+
+    expect(mockRedis.set).toHaveBeenCalledWith(
+      'jwt:revoked:jti-equal-ttl',
+      '1',
+      'EX',
+      3600,
+    );
+    expect(result).toEqual({ revoked: true, ttlSeconds: 3600 });
+  });
+
+  it('treats already-expired tokens as revocation no-ops', async () => {
+    mockRedis.set.mockResolvedValue('OK');
+
+    const result = await revoke('jti-expired', {
+      ttl: 3600,
+      exp: 1_699_999_990,
+      nowSeconds: 1_700_000_000,
+    });
+
+    expect(result).toEqual({ revoked: false, ttlSeconds: 0 });
+    expect(mockRedis.set).not.toHaveBeenCalled();
+  });
+
   it('rejects empty jti', async () => {
     await expect(revoke('', 3600)).rejects.toThrow('jti must be a non-empty string');
   });
@@ -97,6 +165,12 @@ describe('revoke', () => {
 
   it('rejects negative TTL', async () => {
     await expect(revoke('jti-000', -1)).rejects.toThrow('ttl must be a positive integer');
+  });
+
+  it('rejects exp-aware revocation when exp is missing', async () => {
+    await expect(revoke('jti-missing-exp', { ttl: 3600 } as unknown as { exp: number })).rejects.toThrow(
+      'exp must be a positive integer',
+    );
   });
 
   it('rejects TTL less than current time (effectively expired)', async () => {


### PR DESCRIPTION
## Summary

- Derive JWT revocation TTL from the token `exp` claim when available.
- Keep the revocation entry alive for the token's full remaining lifetime, even if a caller supplies a shorter TTL.
- Avoid storing revocation keys past natural token expiry, and treat already-expired tokens as no-ops.
- Require `exp` on the admin revoke route and document the TTL contract in the route TSDoc.

## Security Notes

- This closes the revoked-token reacceptance window caused by caller TTLs shorter than the token lifetime.
- Caller TTLs are still validated, but `exp` is authoritative for the stored Redis TTL.
- Expired tokens do not allocate Redis memory.

## Tests

- `npm test -- tests/unit/redis/jwtRevocationStore.test.ts tests/routes/auth.revoke.test.ts` - 23 tests passed
- `npx eslint src/redis/jwtRevocationStore.ts src/routes/auth.ts tests/unit/redis/jwtRevocationStore.test.ts tests/routes/auth.revoke.test.ts` - 0 errors, 1 existing `no-explicit-any` warning in the pre-existing Redis test case
- `git diff --check`

## Notes

- `npm install` on Windows is blocked by the existing Linux-only `@rolldown/binding-linux-x64-gnu` devDependency in the lockfile.
- `npm run build` remains blocked by existing repository-wide TypeScript errors in unrelated config/db/webhook/test files; no touched-file-specific build error was observed before the baseline errors.

Closes #359
