### PR TITLE
fix(streams): use BigInt-safe decimal amount checks

### DIFF
--- a/src/routes/streams.ts
+++ b/src/routes/streams.ts
@@ -52,6 +52,7 @@ import { Router } from 'express';
 import type { NextFunction, Request, Response } from 'express';
 import crypto from 'crypto';
 import {
+  compareDecimalStringToZero,
   validateDecimalString,
   validateAmountFields,
 } from '../serialization/decimal.js';
@@ -312,13 +313,13 @@ function normalizeCreateInput(body: Record<string, unknown>): NormalizedCreateIn
 
   const depositResult = validateDecimalString(depositAmount ?? '0', 'depositAmount');
   const validatedDeposit = depositResult.valid && depositResult.value ? depositResult.value : '0';
-  if (depositAmount !== undefined && parseFloat(validatedDeposit) <= 0) {
+  if (depositAmount !== undefined && compareDecimalStringToZero(validatedDeposit) <= 0) {
     throw validationError('depositAmount must be greater than zero');
   }
 
   const rateResult = validateDecimalString(ratePerSecond ?? '0', 'ratePerSecond');
   const validatedRate = rateResult.valid && rateResult.value ? rateResult.value : '0';
-  if (ratePerSecond !== undefined && parseFloat(validatedRate) < 0) {
+  if (ratePerSecond !== undefined && compareDecimalStringToZero(validatedRate) < 0) {
     throw validationError('ratePerSecond cannot be negative');
   }
 
@@ -1074,5 +1075,4 @@ streamsRouter.get(
 );
 
 export function _resetStreams(): void {}
-
 

--- a/src/serialization/decimal.ts
+++ b/src/serialization/decimal.ts
@@ -64,6 +64,31 @@ export function normalizeDecimalString(value: string): string {
 }
 
 /**
+ * Compare a validated decimal string against zero without converting it to a
+ * JavaScript number.
+ *
+ * This preserves sign checks for values beyond Number.MAX_SAFE_INTEGER and for
+ * high-precision fractional values that `parseFloat` can round to +/-0.
+ *
+ * @returns -1 when negative, 0 when mathematically zero, and 1 when positive.
+ * @throws DecimalSerializationError when the input is not a valid decimal string.
+ */
+export function compareDecimalStringToZero(value: string): -1 | 0 | 1 {
+  const validated = validateDecimalString(value);
+  if (!validated.valid || !validated.value) {
+    throw validated.error!;
+  }
+
+  const normalized = validated.value;
+  const unsigned = normalized.replace(/^[+-]/, '');
+  const [integerPart, fractionalPart = ''] = unsigned.split('.');
+  const hasNonZeroDigit = `${integerPart}${fractionalPart}`.split('').some((digit) => digit !== '0');
+
+  if (!hasNonZeroDigit) return 0;
+  return normalized.startsWith('-') ? -1 : 1;
+}
+
+/**
  * Error codes for decimal serialization failures
  */
 export enum DecimalErrorCode {

--- a/tests/decimal.test.ts
+++ b/tests/decimal.test.ts
@@ -9,6 +9,7 @@
  */
 
 import {
+  compareDecimalStringToZero,
   validateDecimalString,
   serializeToDecimalString,
   deserializeToNumber,
@@ -66,6 +67,33 @@ describe('Decimal String Serialization Policy', () => {
     it('handles negative values', () => {
       expect(normalizeDecimalString('-100.50')).toBe('-100.5');
       expect(normalizeDecimalString('-1.0')).toBe('-1');
+    });
+  });
+
+  describe('compareDecimalStringToZero', () => {
+    it('compares values above Number.MAX_SAFE_INTEGER without rounding', () => {
+      expect(compareDecimalStringToZero('9007199254740993')).toBe(1);
+      expect(compareDecimalStringToZero('-9007199254740993')).toBe(-1);
+    });
+
+    it('treats normalized zeros as zero', () => {
+      expect(compareDecimalStringToZero('0')).toBe(0);
+      expect(compareDecimalStringToZero('+0.0000000')).toBe(0);
+      expect(compareDecimalStringToZero('-0.0000000')).toBe(0);
+    });
+
+    it('preserves high-precision fractional signs that parseFloat underflows', () => {
+      const tinyPositive = `0.${'0'.repeat(400)}1`;
+      const tinyNegative = `-0.${'0'.repeat(400)}1`;
+
+      expect(Number.parseFloat(tinyPositive)).toBe(0);
+      expect(Object.is(Number.parseFloat(tinyNegative), -0)).toBe(true);
+      expect(compareDecimalStringToZero(tinyPositive)).toBe(1);
+      expect(compareDecimalStringToZero(tinyNegative)).toBe(-1);
+    });
+
+    it('throws on malformed decimal strings', () => {
+      expect(() => compareDecimalStringToZero('1e10')).toThrow(DecimalSerializationError);
     });
   });
 

--- a/tests/routes/streams.test.ts
+++ b/tests/routes/streams.test.ts
@@ -558,6 +558,35 @@ describe('streams routes', () => {
       expect(res.body.data.depositAmount).toBe('0.0000001');
       expect(res.body.data.ratePerSecond).toBe('0.0000116');
     });
+
+    it('accepts large and high-precision decimal strings without numeric coercion', async () => {
+      const preciseBody = {
+        ...validBody,
+        depositAmount: '9007199254740993.000000000000000001',
+        ratePerSecond: '+0.000000000000000001',
+      };
+      mockUpsertStream.mockResolvedValue({
+        created: true,
+        stream: makeDbRecord({
+          amount: '9007199254740993.000000000000000001',
+          rate_per_second: '+0.000000000000000001',
+        }),
+      });
+
+      const res = await post(preciseBody, uniqueKey());
+
+      expect(res.status).toBe(201);
+      expect(mockUpsertStream).toHaveBeenCalledTimes(1);
+      expect(mockUpsertStream.mock.calls[0]?.[0]).toEqual(
+        expect.objectContaining({
+          amount: '9007199254740993.000000000000000001',
+          remaining_amount: '9007199254740993.000000000000000001',
+          rate_per_second: '+0.000000000000000001',
+        }),
+      );
+      expect(res.body.data.depositAmount).toBe('9007199254740993.000000000000000001');
+      expect(res.body.data.ratePerSecond).toBe('+0.000000000000000001');
+    });
   });
 
   // ── DELETE /api/streams/:id ───────────────────────────────────────────────


### PR DESCRIPTION
Fixes #353.

## Summary
- Adds `compareDecimalStringToZero()` so amount sign/zero checks stay in decimal-string space instead of using `parseFloat`.
- Replaces stream-create `depositAmount` and `ratePerSecond` float comparisons with the decimal helper.
- Adds regression coverage for values above `Number.MAX_SAFE_INTEGER` and high-precision fractional values that can underflow in `parseFloat`.

## Validation
- `npm run test -- tests/decimal.test.ts` (83 passed)
- `npm run test -- tests/decimal.test.ts tests/routes/streams.test.ts -t "compareDecimalStringToZero|large and high-precision"` (5 passed, focused)
- `npm run build` currently fails on existing repository-wide TypeScript errors unrelated to this change, including `src/config/health.ts`, `src/db/repositories/streamRepository.ts`, AWS SDK test deps, and existing route/test typings.

## Security notes
- No amount validation path converts route amount fields to JavaScript `number` for positivity checks.
- Negative, zero, large, and high-precision signs are derived from normalized decimal strings.