### PR TITLE
fix(indexer): report stale replay cursors

### DIFF
--- a/docs/api/sse-streams.md
+++ b/docs/api/sse-streams.md
@@ -57,6 +57,11 @@ curl -N \
 ### Behavior
 When `Last-Event-ID` is provided, the server queries the `ContractEventStore` to replay historical events that occurred after the specified cursor before switching to live broadcast delivery.
 
+If the event store returns `STALE_CURSOR`, the supplied cursor has been evicted,
+usually because a reorg rollback removed it. The server emits an SSE `error`
+event with code `STALE_CURSOR` and closes the response; clients should discard
+that cursor and re-sync from the last trusted `fromLedger` checkpoint.
+
 ---
 
 ## Connection Limits and Maximum Duration

--- a/docs/indexer.md
+++ b/docs/indexer.md
@@ -132,6 +132,14 @@ Get current replay progress and indexer status.
 curl http://localhost:3000/internal/indexer/status
 ```
 
+### Cursor replay recovery
+
+Consumers that resume from a stored `afterEventId` must treat `STALE_CURSOR`
+as a signal that the cursor row was removed, for example by a reorg rollback.
+The correct recovery path is to discard that cursor and re-sync from the last
+trusted `fromLedger` checkpoint, then continue normal cursor replay from the
+new page results.
+
 ## Database Schema
 
 ### Tables

--- a/src/indexer/store.ts
+++ b/src/indexer/store.ts
@@ -3,6 +3,17 @@ import { StreamEventReplayFilter, StreamEventReplayResult, StreamEventRecord } f
 
 export type InsertContractEventsResult = { insertedEventIds: string[]; duplicateEventIds: string[]; };
 
+export const STALE_CURSOR_ERROR_CODE = 'STALE_CURSOR';
+
+export class StaleCursorError extends Error {
+  public readonly code = STALE_CURSOR_ERROR_CODE;
+
+  constructor(public readonly afterEventId: string) {
+    super(`Replay cursor '${afterEventId}' no longer exists; resync from fromLedger`);
+    this.name = 'StaleCursorError';
+  }
+}
+
 /** Record of a chain reorg that evicted previously stored events. */
 export interface ReorgRecord {
   /** The ledger at which the fork occurred — all events at or above this were evicted. */
@@ -90,8 +101,7 @@ export class InMemoryContractEventStore implements ContractEventStore {
     if (filter.afterEventId !== undefined) {
       const idx = results.findIndex((r) => r.eventId === filter.afterEventId);
       if (idx === -1) {
-        // Unknown cursor — treat as "past end of store", return empty
-        results = [];
+        throw new StaleCursorError(filter.afterEventId);
       } else {
         results = results.slice(idx + 1);
       }
@@ -254,17 +264,16 @@ export class PostgresContractEventStore implements ContractEventStore {
         `SELECT ledger FROM ${this.tableName} WHERE event_id = $1 LIMIT 1`,
         [filter.afterEventId],
       );
-      if (cursorResult.rows.length > 0) {
-        const cursorRow = cursorResult.rows[0];
-        if (cursorRow) {
-          const cursorLedger = cursorRow.ledger;
-          values.push(cursorLedger, filter.afterEventId);
-          conditions.push(
-            `(ledger > $${values.length - 1} OR (ledger = $${values.length - 1} AND event_id > $${values.length}))`,
-          );
-        }
+      const cursorRow = cursorResult.rows[0];
+      if (!cursorRow) {
+        throw new StaleCursorError(filter.afterEventId);
       }
-      // If cursor row not found, return empty (cursor is past the end of the store)
+
+      const cursorLedger = cursorRow.ledger;
+      values.push(cursorLedger, filter.afterEventId);
+      conditions.push(
+        `(ledger > $${values.length - 1} OR (ledger = $${values.length - 1} AND event_id > $${values.length}))`,
+      );
     }
 
     const where = conditions.length > 0 ? `WHERE ${conditions.join(' AND ')}` : '';

--- a/src/routes/streams.ts
+++ b/src/routes/streams.ts
@@ -82,6 +82,7 @@ import { isTerminalStatus } from '../streams/status.js';
 import { streamsCreatedTotal, sseConnectionsRejectedTotal } from '../metrics/businessMetrics.js';
 import { verifyWsToken } from '../middleware/tokenAuth.js';
 import { getStreamHub, type StreamUpdateEvent } from '../ws/hub.js';
+import { STALE_CURSOR_ERROR_CODE, StaleCursorError } from '../indexer/store.js';
 import { getClientIp } from '../ws/connectionLimiter.js';
 import {
   eventMatchesStreamId,
@@ -1042,6 +1043,22 @@ streamsRouter.get(
             pagesRead++;
           } while (cursor !== undefined && !cleanedUp && pagesRead < SSE_REPLAY_MAX_PAGES);
         } catch (err) {
+          if (err instanceof StaleCursorError) {
+            writeSse(
+              `event: error\ndata: ${JSON.stringify({
+                code: STALE_CURSOR_ERROR_CODE,
+                message: 'Replay cursor no longer exists; resync from fromLedger',
+              })}\n\n`,
+            );
+            warn('SSE replay cursor is stale', {
+              afterEventId: err.afterEventId,
+              requestId,
+            });
+            res.end();
+            cleanup('stale_cursor');
+            return;
+          }
+
           warn('Failed to replay SSE events from store', {
             error: err instanceof Error ? err.message : String(err),
             requestId,
@@ -1074,5 +1091,3 @@ streamsRouter.get(
 );
 
 export function _resetStreams(): void {}
-
-

--- a/src/ws/hub.ts
+++ b/src/ws/hub.ts
@@ -37,7 +37,7 @@ import type { Server } from 'http';
 import type { DedupCache as IDedupCache } from '../redis/dedup.js';
 import { InMemoryDedupCache } from '../redis/dedup.js';
 import { verifyWsToken } from '../middleware/tokenAuth.js';
-import type { ContractEventStore } from '../indexer/store.js';
+import { STALE_CURSOR_ERROR_CODE, StaleCursorError, type ContractEventStore } from '../indexer/store.js';
 import { SSE_STREAM_UPDATE_EVENT, sseEventBus } from '../streams/sseEmitter.js';
 import type { StreamEventReplayFilter } from '../db/types.js';
 import { getTracer } from '../tracing/hooks.js';
@@ -774,7 +774,20 @@ export class StreamHub extends EventEmitter {
         ...(cursor !== undefined ? { afterEventId: cursor } : {}),
         limit: pageSize,
       };
-      const result = await this.eventStore.getEvents(pageFilter);
+      let result: Awaited<ReturnType<ContractEventStore['getEvents']>>;
+      try {
+        result = await this.eventStore.getEvents(pageFilter);
+      } catch (err) {
+        if (err instanceof StaleCursorError) {
+          this.sendError(
+            ws,
+            STALE_CURSOR_ERROR_CODE,
+            'Replay cursor no longer exists; resync from fromLedger',
+          );
+          return;
+        }
+        throw err;
+      }
 
       for (const event of result.events) {
         if (ws.readyState !== WebSocket.OPEN) return;

--- a/tests/indexer-store.stale-cursor.test.ts
+++ b/tests/indexer-store.stale-cursor.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from 'vitest';
+import {
+  InMemoryContractEventStore,
+  PostgresContractEventStore,
+  StaleCursorError,
+} from '../src/indexer/store.js';
+import type { ContractEventRecord } from '../src/indexer/types.js';
+
+function makeRecord(eventId: string, ledger: number): ContractEventRecord {
+  return {
+    eventId,
+    ledger,
+    contractId: 'C1',
+    topic: 'stream.created',
+    txHash: `tx-${eventId}`,
+    txIndex: 0,
+    operationIndex: 0,
+    eventIndex: 0,
+    payload: { amount: '1.0000000' },
+    happenedAt: '2026-01-01T00:00:00.000Z',
+    ledgerHash: `hash-${ledger}`,
+  };
+}
+
+describe('ContractEventStore stale cursor handling', () => {
+  it('throws STALE_CURSOR from memory store when afterEventId no longer exists', async () => {
+    const store = new InMemoryContractEventStore();
+    await store.insertMany([makeRecord('e1', 100)]);
+
+    await expect(store.getEvents({ afterEventId: 'evicted-cursor' }))
+      .rejects.toMatchObject({ code: 'STALE_CURSOR', afterEventId: 'evicted-cursor' });
+  });
+
+  it('keeps normal end-of-store cursor reads as an empty page', async () => {
+    const store = new InMemoryContractEventStore();
+    await store.insertMany([makeRecord('e1', 100)]);
+
+    const result = await store.getEvents({ afterEventId: 'e1' });
+
+    expect(result.events).toEqual([]);
+    expect(result.total).toBe(0);
+    expect(result.nextCursor).toBeUndefined();
+  });
+
+  it('throws STALE_CURSOR from Postgres store when the cursor lookup misses', async () => {
+    const store = new PostgresContractEventStore({
+      query: async <T>() => ({ rows: [] as T[], rowCount: 0 }),
+    });
+
+    await expect(store.getEvents({ afterEventId: 'evicted-cursor' }))
+      .rejects.toBeInstanceOf(StaleCursorError);
+  });
+
+  it('uses the Postgres cursor boundary when the cursor lookup succeeds', async () => {
+    const queries: Array<{ sql: string; values?: unknown[] }> = [];
+    const store = new PostgresContractEventStore({
+      query: async <T>(sql: string, values?: unknown[]) => {
+        queries.push({ sql, values });
+        if (sql.includes('WHERE event_id = $1')) {
+          return { rows: [{ ledger: 100 }] as T[], rowCount: 1 };
+        }
+        if (sql.includes('COUNT(*)')) {
+          return { rows: [{ count: '0' }] as T[], rowCount: 1 };
+        }
+        return { rows: [] as T[], rowCount: 0 };
+      },
+    });
+
+    await store.getEvents({ afterEventId: 'e1' });
+
+    expect(queries[1]?.values).toEqual([100, 'e1']);
+    expect(queries[2]?.sql).toContain('event_id > $2');
+  });
+});

--- a/tests/routes/streams-sse.test.ts
+++ b/tests/routes/streams-sse.test.ts
@@ -19,6 +19,7 @@ import {
   getActiveSseConnectionCount,
 } from '../../src/streams/sseConnectionLimiter.js';
 import { sseActiveConnectionsGauge, sseConnectionsRejectedTotal } from '../../src/metrics/businessMetrics.js';
+import { StaleCursorError } from '../../src/indexer/store.js';
 
 // ── Mock the repository and Redis before importing the app ──────────────────────────────
 const mockGetById = vi.fn();
@@ -412,6 +413,33 @@ describe('GET /api/streams/:id/events (SSE Endpoint)', () => {
       afterEventId: 'evt-99',
       limit: 100,
     });
+  });
+
+  it('returns a STALE_CURSOR SSE error when Last-Event-ID was evicted', async () => {
+    mockGetById.mockResolvedValue(makeDbRecord({ id: 'stream-123' }));
+    mockGetEvents.mockRejectedValue(new StaleCursorError('evt-evicted'));
+
+    const resPromise = new Promise<string>((resolve) => {
+      const req = http.get({
+        hostname: '127.0.0.1',
+        port,
+        path: '/api/streams/stream-123/events',
+        headers: {
+          'Last-Event-ID': 'evt-evicted',
+        },
+      }, (res) => {
+        let data = '';
+        res.on('data', (chunk) => {
+          data += chunk.toString();
+        });
+        res.on('end', () => resolve(data));
+      });
+      req.on('error', () => resolve(''));
+    });
+
+    const output = await resPromise;
+    expect(output).toContain('event: error');
+    expect(output).toContain('"code":"STALE_CURSOR"');
   });
 
   it('streams live events via sseEventBus', async () => {

--- a/tests/ws.test.ts
+++ b/tests/ws.test.ts
@@ -1032,6 +1032,20 @@ describe('StreamHub.replayFromCursor — event store replay', () => {
     ws.close();
   });
 
+  it('sends STALE_CURSOR when afterEventId has been evicted', async () => {
+    await store.insertMany([makeStoreRecord('e1', 100)]);
+
+    const ws = await connect(port);
+    const msgPromise = nextMessage(ws);
+    send(ws, { type: 'replay', afterEventId: 'evicted-cursor' });
+    const msg = await msgPromise;
+
+    expect((msg as any).type).toBe('error');
+    expect((msg as any).code).toBe('STALE_CURSOR');
+
+    ws.close();
+  });
+
   it('sends stream_replay_complete immediately when store is empty', async () => {
     const ws = await connect(port);
     const msgsPromise = collectMessages(ws, 1);


### PR DESCRIPTION
## Summary
- return a typed STALE_CURSOR error when event-store replay cursors are missing
- surface stale cursors to WebSocket replay clients and SSE Last-Event-ID clients
- document the recovery contract: discard the cursor and resync from fromLedger

## Tests
- node ./node_modules/vitest/vitest.mjs run tests/indexer-store.stale-cursor.test.ts
- node ./node_modules/vitest/vitest.mjs run tests/ws.test.ts -t 'StreamHub.replayFromCursor|STALE_CURSOR|current tail'
- node ./node_modules/vitest/vitest.mjs run tests/routes/streams-sse.test.ts -t 'Last-Event-ID|STALE_CURSOR'

Closes #351