### PR TITLE
fix(webhooks): route exhausted retries to DLQ

### DIFF
--- a/src/webhooks/service.ts
+++ b/src/webhooks/service.ts
@@ -99,6 +99,24 @@ function extractAttemptNumber(payload: unknown): number {
     : 1;
 }
 
+function enqueuePermanentFailureToDlq(
+  delivery: WebhookDelivery,
+  failureReason: string,
+): string | undefined {
+  const alreadyQueued = webhookDeliveryStore
+    .getDeadLetterQueueItems()
+    .some((item) => item.deliveryId === delivery.deliveryId);
+
+  if (alreadyQueued) {
+    logger.warn('Webhook permanent failure already exists in dead-letter queue', undefined, {
+      deliveryId: delivery.deliveryId,
+    });
+    return undefined;
+  }
+
+  return webhookDeliveryStore.addToDeadLetterQueue(delivery, failureReason);
+}
+
 export class WebhookService {
   private policy: WebhookRetryPolicy;
 
@@ -219,6 +237,12 @@ export class WebhookService {
 
         delivery.attempts.push(attempt);
         webhookDeliveryStore.store(delivery);
+        if (delivery.status === 'permanent_failure') {
+          enqueuePermanentFailureToDlq(
+            delivery,
+            `HTTP ${response.status} after ${attemptNumber} attempt${attemptNumber === 1 ? '' : 's'}`,
+          );
+        }
         webhookDeliveriesTotal.inc({ outcome: 'failed' });
       }
     } catch (error) {
@@ -250,6 +274,12 @@ export class WebhookService {
 
       delivery.attempts.push(attempt);
       webhookDeliveryStore.store(delivery);
+      if (delivery.status === 'permanent_failure') {
+        enqueuePermanentFailureToDlq(
+          delivery,
+          `${errorMessage} after ${attemptNumber} attempt${attemptNumber === 1 ? '' : 's'}`,
+        );
+      }
       webhookDeliveriesTotal.inc({ outcome: 'failed' });
     } finally {
       const durationSeconds = (Date.now() - startTime) / 1000;

--- a/tests/webhooks.test.ts
+++ b/tests/webhooks.test.ts
@@ -151,6 +151,12 @@ describe('WebhookService', () => {
     expect(delivery.status).toBe('permanent_failure');
     expect(delivery.attempts.length).toBe(1);
     expect(delivery.attempts[0].statusCode).toBe(404);
+
+    const dlqItems = webhookDeliveryStore.getDeadLetterQueueItems();
+    expect(dlqItems).toHaveLength(1);
+    expect(dlqItems[0].deliveryId).toBe(delivery.deliveryId);
+    expect(dlqItems[0].originalDelivery.attempts).toHaveLength(1);
+    expect(dlqItems[0].failureReason).toContain('HTTP 404');
   });
 
   it('respects max attempts', async () => {
@@ -191,6 +197,44 @@ describe('WebhookService', () => {
 
     expect(delivery.attempts.length).toBe(2);
     expect(delivery.status).toBe('permanent_failure');
+
+    const dlqItems = webhookDeliveryStore.getDeadLetterQueueItems();
+    expect(dlqItems).toHaveLength(1);
+    expect(dlqItems[0].deliveryId).toBe(delivery.deliveryId);
+    expect(dlqItems[0].originalDelivery.attempts).toHaveLength(2);
+    expect(dlqItems[0].failureReason).toContain('HTTP 503');
+  });
+
+  it('does not enqueue duplicate DLQ entries when permanent failure is retried', async () => {
+    const service = new WebhookService({
+      maxAttempts: 1,
+      initialBackoffMs: 100,
+      backoffMultiplier: 2,
+      maxBackoffMs: 1000,
+      jitterPercent: 0,
+      timeoutMs: 5000,
+      retryableStatusCodes: [500, 502, 503, 504, 408, 429],
+    });
+    const delivery = {
+      id: 'delivery_duplicate_dlq',
+      deliveryId: 'deliv_duplicate_dlq',
+      eventId: 'event_duplicate_dlq',
+      eventType: 'stream.created' as const,
+      endpointUrl: 'https://example.com/webhook',
+      status: 'pending' as const,
+      attempts: [],
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+      payload: '{"test": "data"}',
+    };
+    mockFetchResponses.set('https://example.com/webhook', new Response(null, { status: 503 }));
+
+    await service.attemptDelivery(delivery, 'secret123', '123456');
+    await service.attemptDelivery(delivery, 'secret123', '123457');
+
+    const dlqItems = webhookDeliveryStore.getDeadLetterQueueItems();
+    expect(dlqItems).toHaveLength(1);
+    expect(dlqItems[0].deliveryId).toBe(delivery.deliveryId);
   });
 
   it('sends correct headers', async () => {


### PR DESCRIPTION
## Summary
- enqueue permanently failed webhook deliveries into the dead-letter queue from WebhookService.attemptDelivery
- include HTTP/network failure reasons and avoid duplicate DLQ entries for the same delivery
- add regression coverage for 4xx permanent failures, exhausted retry attempts, and duplicate DLQ protection

Closes #346

## Tests
- node .\node_modules\vitest\vitest.mjs run tests/webhooks.test.ts -t 'does not retry on 4xx response|respects max attempts|does not enqueue duplicate DLQ entries|Dead-Letter Queue'
- node .\node_modules\vitest\vitest.mjs run tests/metrics/businessMetrics.test.ts -t 'Webhook Service metrics'