### PR TITLE
fix(rpc): add fallback cache early expiry

### DIFF
--- a/docs/stellar-rpc.md
+++ b/docs/stellar-rpc.md
@@ -16,13 +16,29 @@ The breaker is configured with `RPC_CB_FAILURE_THRESHOLD`, `RPC_CB_WINDOW_MS`, `
 
 Successful RPC responses are stored in Redis under keys beginning with `rpc:cache::`. The default TTL is 300 seconds and can be changed with `RPC_FALLBACK_CACHE_TTL_SECONDS`.
 
+Each cache write stores a small metadata envelope next to the response value: write time, expiry time, configured TTL, and the last refresh duration. Readers remain compatible with older raw JSON entries, but only envelope entries can participate in early refresh.
+
 Cache keys use fixed operation names. Parameterized calls, such as account existence checks, include a SHA-256 hash of the parameter rather than raw account data. This prevents key injection, keeps key length bounded, and avoids writing account identifiers into Redis keys.
+
+When the circuit is `CLOSED`, the fallback cache can smooth hot-key TTL boundaries with XFetch-style probabilistic early expiry. If an entry is close enough to expiry, one request starts a background refresh while the current request still receives the cached value. Concurrent callers keep receiving the cached value and do not all stampede the Stellar RPC provider.
+
+The early-expiry beta factor is controlled by `RPC_FALLBACK_CACHE_EARLY_EXPIRY_BETA`:
+
+- Default: `0` (disabled).
+- Set a positive value, such as `1`, to enable closed-circuit cache reads and early refresh.
+- Larger values refresh earlier and more aggressively.
 
 When the circuit is `OPEN`:
 
 1. A cache hit returns the stale last-known-good response and increments `rpc_circuit_open_fallback_hits_total`.
 2. A cache miss increments `rpc_circuit_open_fallback_misses_total` and propagates `CircuitOpenError`.
 3. HTTP requests executed through `rpcDegradationMiddleware` include `X-RPC-Cache: stale` when a stale RPC response was used.
+
+Closed-circuit cache behavior emits:
+
+- `rpc_fallback_cache_hits_total`
+- `rpc_fallback_cache_misses_total`
+- `rpc_fallback_cache_early_refreshes_total`
 
 Redis cache read/write failures are logged as warnings and treated as misses or no-op writes. The fallback cache must not become a hard dependency for normal RPC calls.
 

--- a/src/metrics/rpcMetrics.ts
+++ b/src/metrics/rpcMetrics.ts
@@ -18,3 +18,38 @@ export const rpcCircuitOpenFallbackMissesTotal =
     labelNames: ['operation'] as const,
     registers: [registry],
   });
+
+export const rpcFallbackCacheHitsTotal =
+  (registry.getSingleMetric('rpc_fallback_cache_hits_total') as Counter<'operation'>) ||
+  new Counter({
+    name: 'rpc_fallback_cache_hits_total',
+    help: 'Total Stellar RPC calls served from the Redis fallback cache while the circuit breaker is CLOSED',
+    labelNames: ['operation'] as const,
+    registers: [registry],
+  });
+
+export const rpcFallbackCacheMissesTotal =
+  (registry.getSingleMetric('rpc_fallback_cache_misses_total') as Counter<'operation'>) ||
+  new Counter({
+    name: 'rpc_fallback_cache_misses_total',
+    help: 'Total Stellar RPC calls that missed the Redis fallback cache while the circuit breaker is CLOSED',
+    labelNames: ['operation'] as const,
+    registers: [registry],
+  });
+
+export const rpcFallbackCacheEarlyRefreshesTotal =
+  (registry.getSingleMetric('rpc_fallback_cache_early_refreshes_total') as Counter<'operation'>) ||
+  new Counter({
+    name: 'rpc_fallback_cache_early_refreshes_total',
+    help: 'Total probabilistic early refreshes started for Stellar RPC fallback cache entries',
+    labelNames: ['operation'] as const,
+    registers: [registry],
+  });
+
+export function deRegisterRpcMetrics(): void {
+  registry.removeSingleMetric('rpc_circuit_open_fallback_hits_total');
+  registry.removeSingleMetric('rpc_circuit_open_fallback_misses_total');
+  registry.removeSingleMetric('rpc_fallback_cache_hits_total');
+  registry.removeSingleMetric('rpc_fallback_cache_misses_total');
+  registry.removeSingleMetric('rpc_fallback_cache_early_refreshes_total');
+}

--- a/src/redis/rpcFallbackCache.ts
+++ b/src/redis/rpcFallbackCache.ts
@@ -16,10 +16,36 @@ import { logger } from '../lib/logger.js';
 
 export const RPC_FALLBACK_CACHE_PREFIX = 'rpc:cache::';
 const SAFE_OPERATION = /^[A-Za-z0-9._-]+$/;
+const RPC_FALLBACK_CACHE_ENVELOPE_VERSION = 1;
+
+export interface RpcFallbackCacheEntry<T> {
+  value: T;
+  writtenAt: number;
+  expiresAt: number;
+  ttlSeconds: number;
+  refreshDurationMs: number;
+}
+
+interface RpcFallbackCacheEnvelope<T> extends RpcFallbackCacheEntry<T> {
+  version: typeof RPC_FALLBACK_CACHE_ENVELOPE_VERSION;
+}
+
+export interface RpcFallbackCacheSetOptions {
+  nowMs?: number;
+  refreshDurationMs?: number;
+}
 
 export interface RpcFallbackCache {
   get<T>(operation: string, cacheParts?: readonly string[]): Promise<T | null>;
   set<T>(operation: string, value: T, ttlSeconds: number, cacheParts?: readonly string[]): Promise<void>;
+  getEntry?<T>(operation: string, cacheParts?: readonly string[]): Promise<RpcFallbackCacheEntry<T> | null>;
+  setEntry?<T>(
+    operation: string,
+    value: T,
+    ttlSeconds: number,
+    cacheParts?: readonly string[],
+    options?: RpcFallbackCacheSetOptions,
+  ): Promise<void>;
 }
 
 export function hashCachePart(value: string): string {
@@ -40,6 +66,52 @@ function buildCacheKey(operation: string, cacheParts: readonly string[] = []): s
   return `${RPC_FALLBACK_CACHE_PREFIX}${[operation, ...cacheParts].join('::')}`;
 }
 
+function isCacheEnvelope<T>(value: unknown): value is RpcFallbackCacheEnvelope<T> {
+  return typeof value === 'object'
+    && value !== null
+    && (value as { version?: unknown }).version === RPC_FALLBACK_CACHE_ENVELOPE_VERSION
+    && 'value' in value
+    && typeof (value as { writtenAt?: unknown }).writtenAt === 'number'
+    && typeof (value as { expiresAt?: unknown }).expiresAt === 'number'
+    && typeof (value as { ttlSeconds?: unknown }).ttlSeconds === 'number'
+    && typeof (value as { refreshDurationMs?: unknown }).refreshDurationMs === 'number';
+}
+
+function createCacheEnvelope<T>(
+  value: T,
+  ttlSeconds: number,
+  options: RpcFallbackCacheSetOptions = {},
+): RpcFallbackCacheEnvelope<T> {
+  const writtenAt = options.nowMs ?? Date.now();
+  return {
+    version: RPC_FALLBACK_CACHE_ENVELOPE_VERSION,
+    value,
+    writtenAt,
+    expiresAt: writtenAt + ttlSeconds * 1000,
+    ttlSeconds,
+    refreshDurationMs: Math.max(1, Math.floor(options.refreshDurationMs ?? 1)),
+  };
+}
+
+function parseCachedValue<T>(raw: string): T {
+  const parsed = JSON.parse(raw) as unknown;
+  return isCacheEnvelope<T>(parsed) ? parsed.value : parsed as T;
+}
+
+function parseCacheEntry<T>(raw: string): RpcFallbackCacheEntry<T> | null {
+  const parsed = JSON.parse(raw) as unknown;
+  if (!isCacheEnvelope<T>(parsed)) {
+    return null;
+  }
+  return {
+    value: parsed.value,
+    writtenAt: parsed.writtenAt,
+    expiresAt: parsed.expiresAt,
+    ttlSeconds: parsed.ttlSeconds,
+    refreshDurationMs: parsed.refreshDurationMs,
+  };
+}
+
 export class RedisRpcFallbackCache implements RpcFallbackCache {
   constructor(private readonly client: RedisClient) {}
 
@@ -49,10 +121,30 @@ export class RedisRpcFallbackCache implements RpcFallbackCache {
     try {
       const raw = await this.client.get(key);
       if (raw === null) return null;
-      return JSON.parse(raw) as T;
+      return parseCachedValue<T>(raw);
     } catch (err) {
       logger.warn('Stellar RPC fallback cache read failed', undefined, {
         event: 'rpc_fallback_cache_read_failed',
+        operation,
+        error: err instanceof Error ? err.message : String(err),
+      });
+      return null;
+    }
+  }
+
+  async getEntry<T>(
+    operation: string,
+    cacheParts: readonly string[] = [],
+  ): Promise<RpcFallbackCacheEntry<T> | null> {
+    const key = buildCacheKey(operation, cacheParts);
+
+    try {
+      const raw = await this.client.get(key);
+      if (raw === null) return null;
+      return parseCacheEntry<T>(raw);
+    } catch (err) {
+      logger.warn('Stellar RPC fallback cache metadata read failed', undefined, {
+        event: 'rpc_fallback_cache_metadata_read_failed',
         operation,
         error: err instanceof Error ? err.message : String(err),
       });
@@ -66,6 +158,16 @@ export class RedisRpcFallbackCache implements RpcFallbackCache {
     ttlSeconds: number,
     cacheParts: readonly string[] = [],
   ): Promise<void> {
+    return this.setEntry(operation, value, ttlSeconds, cacheParts);
+  }
+
+  async setEntry<T>(
+    operation: string,
+    value: T,
+    ttlSeconds: number,
+    cacheParts: readonly string[] = [],
+    options: RpcFallbackCacheSetOptions = {},
+  ): Promise<void> {
     const key = buildCacheKey(operation, cacheParts);
 
     if (!Number.isInteger(ttlSeconds) || ttlSeconds < 1) {
@@ -78,7 +180,7 @@ export class RedisRpcFallbackCache implements RpcFallbackCache {
     }
 
     try {
-      await this.client.set(key, JSON.stringify(value), { ex: ttlSeconds });
+      await this.client.set(key, JSON.stringify(createCacheEnvelope(value, ttlSeconds, options)), { ex: ttlSeconds });
     } catch (err) {
       logger.warn('Stellar RPC fallback cache write failed', undefined, {
         event: 'rpc_fallback_cache_write_failed',
@@ -97,6 +199,14 @@ export class NoOpRpcFallbackCache implements RpcFallbackCache {
   async set<T>(): Promise<void> {
     return;
   }
+
+  async getEntry<T>(): Promise<RpcFallbackCacheEntry<T> | null> {
+    return null;
+  }
+
+  async setEntry<T>(): Promise<void> {
+    return;
+  }
 }
 
 export class InMemoryRpcFallbackCache implements RpcFallbackCache {
@@ -112,7 +222,23 @@ export class InMemoryRpcFallbackCache implements RpcFallbackCache {
       return null;
     }
 
-    return JSON.parse(entry.value) as T;
+    return parseCachedValue<T>(entry.value);
+  }
+
+  async getEntry<T>(
+    operation: string,
+    cacheParts: readonly string[] = [],
+  ): Promise<RpcFallbackCacheEntry<T> | null> {
+    const key = buildCacheKey(operation, cacheParts);
+    const entry = this.entries.get(key);
+    if (!entry) return null;
+
+    if (entry.expiresAt <= Date.now()) {
+      this.entries.delete(key);
+      return null;
+    }
+
+    return parseCacheEntry<T>(entry.value);
   }
 
   async set<T>(
@@ -121,10 +247,21 @@ export class InMemoryRpcFallbackCache implements RpcFallbackCache {
     ttlSeconds: number,
     cacheParts: readonly string[] = [],
   ): Promise<void> {
+    return this.setEntry(operation, value, ttlSeconds, cacheParts);
+  }
+
+  async setEntry<T>(
+    operation: string,
+    value: T,
+    ttlSeconds: number,
+    cacheParts: readonly string[] = [],
+    options: RpcFallbackCacheSetOptions = {},
+  ): Promise<void> {
     const key = buildCacheKey(operation, cacheParts);
+    const envelope = createCacheEnvelope(value, ttlSeconds, options);
     this.entries.set(key, {
-      value: JSON.stringify(value),
-      expiresAt: Date.now() + ttlSeconds * 1000,
+      value: JSON.stringify(envelope),
+      expiresAt: envelope.expiresAt,
     });
   }
 

--- a/src/services/stellar-rpc.ts
+++ b/src/services/stellar-rpc.ts
@@ -25,11 +25,15 @@ import {
   RedisRpcFallbackCache,
   hashCachePart,
   type RpcFallbackCache,
+  type RpcFallbackCacheEntry,
 } from '../redis/rpcFallbackCache.js';
 import { createRedisClient } from '../redis/client.js';
 import {
   rpcCircuitOpenFallbackHitsTotal,
   rpcCircuitOpenFallbackMissesTotal,
+  rpcFallbackCacheEarlyRefreshesTotal,
+  rpcFallbackCacheHitsTotal,
+  rpcFallbackCacheMissesTotal,
 } from '../metrics/rpcMetrics.js';
 
 // ── Types ─────────────────────────────────────────────────────────────────────
@@ -60,6 +64,8 @@ export interface StellarRpcServiceOptions extends CircuitBreakerOptions, RpcCall
   fallbackCacheTtlSeconds?: number;
   /** Optional cache injection for tests or alternate Redis lifecycle ownership. */
   fallbackCache?: RpcFallbackCache;
+  /** XFetch-style beta factor. Set to 0 to disable early-expiry reads. */
+  fallbackCacheEarlyExpiryBeta?: number;
 }
 
 interface RpcRequestMetadata {
@@ -222,6 +228,8 @@ export class StellarRpcService {
   private readonly timeoutMs: number;
   private readonly fallbackCache: RpcFallbackCache;
   private readonly fallbackCacheTtlSeconds: number;
+  private readonly fallbackCacheEarlyExpiryBeta: number;
+  private readonly earlyRefreshes = new Map<string, Promise<void>>();
 
   constructor(
     private readonly getClient: () => RawRpcClient,
@@ -231,6 +239,7 @@ export class StellarRpcService {
     this.timeoutMs = opts.timeoutMs ?? 5_000;
     this.fallbackCache = opts.fallbackCache ?? new NoOpRpcFallbackCache();
     this.fallbackCacheTtlSeconds = opts.fallbackCacheTtlSeconds ?? 300;
+    this.fallbackCacheEarlyExpiryBeta = Math.max(0, opts.fallbackCacheEarlyExpiryBeta ?? 0);
   }
 
   getCircuitState(): CircuitState { return this.breaker.getState(); }
@@ -312,9 +321,22 @@ export class StellarRpcService {
     fn: () => Promise<T>,
     opts: RpcCallOptions = {},
   ): Promise<T> {
+    if (this.breaker.getState() === 'CLOSED' && this.fallbackCacheEarlyExpiryBeta > 0) {
+      const cached = await this.getClosedCircuitCacheEntry<T>(operation, cacheParts);
+      if (cached !== null) {
+        rpcFallbackCacheHitsTotal.inc({ operation });
+        if (shouldEarlyRefresh(cached, this.fallbackCacheEarlyExpiryBeta)) {
+          this.startEarlyRefresh(operation, cacheParts, fn, opts);
+        }
+        return cached.value;
+      }
+      rpcFallbackCacheMissesTotal.inc({ operation });
+    }
+
     try {
+      const refreshStartedAt = Date.now();
       const result = await this.breaker.call(() => this.callWithTimeout(fn, operation, opts));
-      await this.fallbackCache.set(operation, result, this.fallbackCacheTtlSeconds, cacheParts);
+      await this.writeFallbackCache(operation, result, cacheParts, Date.now() - refreshStartedAt);
       return result;
     } catch (err) {
       if (!(err instanceof CircuitOpenError)) {
@@ -339,6 +361,57 @@ export class StellarRpcService {
       });
       throw err;
     }
+  }
+
+  private async getClosedCircuitCacheEntry<T>(
+    operation: string,
+    cacheParts: readonly string[],
+  ): Promise<RpcFallbackCacheEntry<T> | null> {
+    if (!this.fallbackCache.getEntry) return null;
+    return this.fallbackCache.getEntry<T>(operation, cacheParts);
+  }
+
+  private startEarlyRefresh<T>(
+    operation: string,
+    cacheParts: readonly string[],
+    fn: () => Promise<T>,
+    opts: RpcCallOptions,
+  ): void {
+    const refreshKey = buildRefreshKey(operation, cacheParts);
+    if (this.earlyRefreshes.has(refreshKey)) return;
+
+    rpcFallbackCacheEarlyRefreshesTotal.inc({ operation });
+    const refreshStartedAt = Date.now();
+    const refresh = this.breaker.call(() => this.callWithTimeout(fn, operation, opts))
+      .then((result) => this.writeFallbackCache(operation, result, cacheParts, Date.now() - refreshStartedAt))
+      .catch((err: unknown) => {
+        logger.warn('Stellar RPC fallback cache early refresh failed', undefined, {
+          event: 'rpc_fallback_cache_early_refresh_failed',
+          operation,
+          error: err instanceof Error ? err.message : String(err),
+        });
+      })
+      .finally(() => {
+        this.earlyRefreshes.delete(refreshKey);
+      });
+
+    this.earlyRefreshes.set(refreshKey, refresh);
+  }
+
+  private async writeFallbackCache<T>(
+    operation: string,
+    value: T,
+    cacheParts: readonly string[],
+    refreshDurationMs: number = 1,
+  ): Promise<void> {
+    if (this.fallbackCache.setEntry) {
+      await this.fallbackCache.setEntry(operation, value, this.fallbackCacheTtlSeconds, cacheParts, {
+        refreshDurationMs,
+      });
+      return;
+    }
+
+    await this.fallbackCache.set(operation, value, this.fallbackCacheTtlSeconds, cacheParts);
   }
 
   private async callWithTimeout<T>(
@@ -429,6 +502,30 @@ function logFailure(operation: string, err: RpcProviderError, durationMs: number
 
 // ── Singleton ─────────────────────────────────────────────────────────────────
 
+function buildRefreshKey(operation: string, cacheParts: readonly string[]): string {
+  return `${operation}::${cacheParts.join('::')}`;
+}
+
+/**
+ * XFetch-style probabilistic early expiry. As the Redis TTL boundary nears,
+ * this becomes more likely to return true. The caller still serves the cached
+ * response and starts a single background refresh so concurrent requests do not
+ * stampede the Stellar RPC provider.
+ */
+function shouldEarlyRefresh<T>(
+  entry: RpcFallbackCacheEntry<T>,
+  beta: number,
+  nowMs: number = Date.now(),
+  random: () => number = Math.random,
+): boolean {
+  if (beta <= 0) return false;
+  if (entry.expiresAt <= nowMs) return true;
+
+  const refreshDurationMs = Math.max(1, entry.refreshDurationMs);
+  const uniform = Math.max(Number.EPSILON, Math.min(1, random()));
+  return nowMs - beta * refreshDurationMs * Math.log(uniform) >= entry.expiresAt;
+}
+
 let _service: StellarRpcService | null = null;
 
 export function getStellarRpcService(getClient?: () => RawRpcClient): StellarRpcService {
@@ -443,6 +540,7 @@ export function getStellarRpcService(getClient?: () => RawRpcClient): StellarRpc
       resetTimeoutMs: parseInt(process.env.RPC_CB_RESET_TIMEOUT_MS ?? '60000', 10),
       timeoutMs: parseInt(process.env.RPC_TIMEOUT_MS ?? '5000', 10),
       fallbackCacheTtlSeconds: parseInt(process.env.RPC_FALLBACK_CACHE_TTL_SECONDS ?? '300', 10),
+      fallbackCacheEarlyExpiryBeta: parseFloat(process.env.RPC_FALLBACK_CACHE_EARLY_EXPIRY_BETA ?? '0'),
       fallbackCache: redisFallbackCache,
     });
   }
@@ -481,6 +579,10 @@ function createConfiguredRpcFallbackCache(): RpcFallbackCache {
     async get<T>(operation: string, cacheParts?: readonly string[]): Promise<T | null> {
       return (await getCache()).get<T>(operation, cacheParts);
     },
+    async getEntry<T>(operation: string, cacheParts?: readonly string[]) {
+      const cache = await getCache();
+      return cache.getEntry ? cache.getEntry<T>(operation, cacheParts) : null;
+    },
     async set<T>(
       operation: string,
       value: T,
@@ -488,6 +590,19 @@ function createConfiguredRpcFallbackCache(): RpcFallbackCache {
       cacheParts?: readonly string[],
     ): Promise<void> {
       return (await getCache()).set<T>(operation, value, ttlSeconds, cacheParts);
+    },
+    async setEntry<T>(
+      operation: string,
+      value: T,
+      ttlSeconds: number,
+      cacheParts?: readonly string[],
+      options?: Parameters<NonNullable<RpcFallbackCache['setEntry']>>[4],
+    ): Promise<void> {
+      const cache = await getCache();
+      if (cache.setEntry) {
+        return cache.setEntry<T>(operation, value, ttlSeconds, cacheParts, options);
+      }
+      return cache.set<T>(operation, value, ttlSeconds, cacheParts);
     },
   };
 }

--- a/tests/services/stellarRpc.fallback.test.ts
+++ b/tests/services/stellarRpc.fallback.test.ts
@@ -11,6 +11,12 @@ import {
   InMemoryRpcFallbackCache,
   type RpcFallbackCache,
 } from '../../src/redis/rpcFallbackCache.js';
+import {
+  deRegisterRpcMetrics,
+  rpcFallbackCacheEarlyRefreshesTotal,
+  rpcFallbackCacheHitsTotal,
+  rpcFallbackCacheMissesTotal,
+} from '../../src/metrics/rpcMetrics.js';
 
 function makeClient(fn: () => Promise<{ sequence: number }>): RawRpcClient {
   return { getLatestLedger: fn };
@@ -23,6 +29,7 @@ describe('StellarRpcService fallback cache', () => {
   });
 
   afterEach(() => {
+    deRegisterRpcMetrics();
     vi.useRealTimers();
     vi.restoreAllMocks();
   });
@@ -173,5 +180,75 @@ describe('StellarRpcService fallback cache', () => {
     expect(res.status).toBe(200);
     expect(res.headers['x-rpc-cache']).toBe('stale');
     expect(res.body).toEqual({ sequence: 500 });
+  });
+
+  it('stores cache metadata while preserving value reads', async () => {
+    const cache = new InMemoryRpcFallbackCache();
+    const svc = new StellarRpcService(
+      () => makeClient(vi.fn(async () => ({ sequence: 600 }))),
+      { fallbackCache: cache, fallbackCacheTtlSeconds: 60 },
+    );
+
+    await expect(svc.getLatestLedger()).resolves.toEqual({ sequence: 600 });
+
+    await expect(cache.get('getLatestLedger')).resolves.toEqual({ sequence: 600 });
+    const entry = await cache.getEntry<{ sequence: number }>('getLatestLedger');
+    expect(entry?.value).toEqual({ sequence: 600 });
+    expect(entry?.writtenAt).toBe(Date.now());
+    expect(entry?.expiresAt).toBe(Date.now() + 60_000);
+    expect(entry?.ttlSeconds).toBe(60);
+    expect(entry?.refreshDurationMs).toBeGreaterThanOrEqual(1);
+  });
+
+  it('serves a CLOSED-cache hit and starts one probabilistic early refresh', async () => {
+    const cache = new InMemoryRpcFallbackCache();
+    await cache.setEntry(
+      'getLatestLedger',
+      { sequence: 700 },
+      60,
+      [],
+      { nowMs: Date.now() - 59_500, refreshDurationMs: 1_000 },
+    );
+    let resolver: ((value: { sequence: number }) => void) | undefined;
+    const getLatestLedger = vi.fn(() => new Promise<{ sequence: number }>((resolve) => {
+      resolver = resolve;
+    }));
+    const randomSpy = vi.spyOn(Math, 'random').mockReturnValue(Number.EPSILON);
+    const svc = new StellarRpcService(
+      () => makeClient(getLatestLedger),
+      { fallbackCache: cache, fallbackCacheTtlSeconds: 60, fallbackCacheEarlyExpiryBeta: 1 },
+    );
+
+    const first = await svc.getLatestLedger();
+    const second = await svc.getLatestLedger();
+
+    expect(first).toEqual({ sequence: 700 });
+    expect(second).toEqual({ sequence: 700 });
+    expect(getLatestLedger).toHaveBeenCalledTimes(1);
+
+    resolver?.({ sequence: 701 });
+    await vi.runAllTimersAsync();
+
+    await expect(cache.get('getLatestLedger')).resolves.toEqual({ sequence: 701 });
+    const hits = await rpcFallbackCacheHitsTotal.get();
+    expect(hits.values[0]?.value).toBe(2);
+    const refreshes = await rpcFallbackCacheEarlyRefreshesTotal.get();
+    expect(refreshes.values[0]?.value).toBe(1);
+    randomSpy.mockRestore();
+  });
+
+  it('records CLOSED-cache misses before the first live RPC fill', async () => {
+    const cache = new InMemoryRpcFallbackCache();
+    const getLatestLedger = vi.fn(async () => ({ sequence: 800 }));
+    const svc = new StellarRpcService(
+      () => makeClient(getLatestLedger),
+      { fallbackCache: cache, fallbackCacheTtlSeconds: 60, fallbackCacheEarlyExpiryBeta: 1 },
+    );
+
+    await expect(svc.getLatestLedger()).resolves.toEqual({ sequence: 800 });
+
+    const misses = await rpcFallbackCacheMissesTotal.get();
+    expect(misses.values[0]?.labels).toEqual({ operation: 'getLatestLedger' });
+    expect(misses.values[0]?.value).toBe(1);
   });
 });


### PR DESCRIPTION
## Summary
- add versioned metadata envelopes to RedisRpcFallbackCache while keeping legacy raw JSON reads compatible
- add opt-in XFetch-style early expiry with single-flight background refresh for CLOSED-circuit Stellar RPC cache reads
- expose hit/miss/early-refresh metrics and document RPC_FALLBACK_CACHE_EARLY_EXPIRY_BETA

Closes #360

## Tests
- node .\node_modules\vitest\vitest.mjs run tests/services/stellarRpc.fallback.test.ts tests/stellar-rpc.test.ts tests/incidents/rpc_outage.test.ts
- node .\node_modules\typescript\bin\tsc --noEmit --pretty false 2>&1 | Select-String -Pattern '^src/(redis/rpcFallbackCache|services/stellar-rpc|metrics/rpcMetrics)\.ts|^tests/services/stellarRpc\.fallback\.test\.ts'

Note: full repository tsc still reports existing unrelated baseline errors, including src/config/health.ts/test.ts and missing dotenv typings; no touched-file TypeScript errors were emitted by the filtered check.