### PR TITLE
fix(requests): use request timeout error code

### DIFF
--- a/docs/ABI_STABILITY.md
+++ b/docs/ABI_STABILITY.md
@@ -246,6 +246,7 @@ Every error response uses this envelope:
 | `UNAUTHORIZED` | 401 | Missing or invalid authentication token |
 | `FORBIDDEN` | 403 | Authenticated but insufficient permissions |
 | `PAYLOAD_TOO_LARGE` | 413 | Request body exceeds 256 KiB |
+| `REQUEST_TIMEOUT` | 408 | Request socket timed out before the server completed a response |
 | `TOO_MANY_REQUESTS` | 429 | Rate limit exceeded |
 | `METHOD_NOT_ALLOWED` | 405 | HTTP method not supported on this path |
 | `INTERNAL_ERROR` | 500 | Unexpected server error |

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1137,6 +1137,7 @@ components:
                 - FORBIDDEN
                 - PAYLOAD_TOO_LARGE
                 - TOO_MANY_REQUESTS
+                - REQUEST_TIMEOUT
                 - SERVICE_UNAVAILABLE
                 - INTERNAL_ERROR
                 - DECIMAL_ERROR

--- a/src/app.ts
+++ b/src/app.ts
@@ -23,7 +23,11 @@ import { correlationIdMiddleware } from './middleware/correlationId.js';
 import { corsAllowlistMiddleware } from './middleware/cors.js';
 import { requestLoggerMiddleware } from './middleware/requestLogger.js';
 import { errorHandler } from './middleware/errorHandler.js';
-import { bodySizeLimitMiddleware, BODY_LIMIT_BYTES } from './middleware/requestProtection.js';
+import {
+  bodySizeLimitMiddleware,
+  requestTimeoutMiddleware,
+  BODY_LIMIT_BYTES,
+} from './middleware/requestProtection.js';
 import { apiVersionMiddleware } from './middleware/apiVersion.js';
 import { httpMetrics } from './middleware/httpMetrics.js';
 import { isShuttingDown, addShutdownHook } from './shutdown.js';
@@ -151,6 +155,7 @@ export function createApp(options: AppOptions = {}): Express {
   const appConfig = options.config ?? loadConfig();
   void wireIdempotencyStore(appConfig);
 
+  app.use(requestTimeoutMiddleware(options.requestTimeoutMs ?? appConfig.requestTimeoutMs));
   app.use(privacyHeaders);
   app.use(cspNonceMiddleware);
   app.use(createHelmetMiddleware());
@@ -175,6 +180,9 @@ export function createApp(options: AppOptions = {}): Express {
   if (options.includeTestRoutes) {
     app.get('/__test/error', () => {
       throw new Error('Intentional test error');
+    });
+    app.get('/__test/timeout', () => {
+      return;
     });
   }
 

--- a/src/middleware/errorHandler.ts
+++ b/src/middleware/errorHandler.ts
@@ -19,6 +19,7 @@ export enum ApiErrorCode {
   PAYLOAD_TOO_LARGE = 'PAYLOAD_TOO_LARGE',
   TOO_MANY_REQUESTS = 'TOO_MANY_REQUESTS',
   METHOD_NOT_ALLOWED = 'METHOD_NOT_ALLOWED',
+  REQUEST_TIMEOUT = 'REQUEST_TIMEOUT',
   INTERNAL_ERROR = 'INTERNAL_ERROR',
   SERVICE_UNAVAILABLE = 'SERVICE_UNAVAILABLE',
   UNPROCESSABLE_ENTITY = 'UNPROCESSABLE_ENTITY',
@@ -157,6 +158,10 @@ export function payloadTooLarge(message: string, details?: unknown): ApiError {
 
 export function tooManyRequests(message: string, details?: unknown): ApiError {
   return new ApiError(ApiErrorCode.TOO_MANY_REQUESTS, message, 429, details);
+}
+
+export function requestTimeout(message: string): ApiError {
+  return new ApiError(ApiErrorCode.REQUEST_TIMEOUT, message, 408);
 }
 
 export function gatewayTimeout(message: string): ApiError {

--- a/src/middleware/requestProtection.ts
+++ b/src/middleware/requestProtection.ts
@@ -23,7 +23,7 @@
  */
 
 import type { Request, Response, NextFunction } from 'express';
-import { ApiErrorCode, payloadTooLarge, validationError } from './errorHandler.js';
+import { payloadTooLarge, requestTimeout, validationError } from './errorHandler.js';
 
 // ── Idempotency-Key constants ─────────────────────────────────────────────────
 
@@ -165,12 +165,9 @@ export function requestTimeoutMiddleware(timeoutMs: number): (req: Request, res:
   return (req: Request, res: Response, next: NextFunction): void => {
     req.socket.setTimeout(timeoutMs, () => {
       if (!res.headersSent) {
-        next(
-          Object.assign(new Error(`Request timed out after ${timeoutMs}ms`), {
-            statusCode: 408,
-            code: ApiErrorCode.INTERNAL_ERROR,
-          }),
-        );
+        res.setHeader('Connection', 'close');
+        next(requestTimeout(`Request timed out after ${timeoutMs}ms`));
+        return;
       }
       req.socket.destroy();
     });

--- a/src/openapi/spec.ts
+++ b/src/openapi/spec.ts
@@ -94,6 +94,7 @@ const errorResponses = {
   '401': { description: 'Unauthorized', content: { 'application/json': { schema: ErrorEnvelope } } },
   '403': { description: 'Forbidden', content: { 'application/json': { schema: ErrorEnvelope } } },
   '404': { description: 'Not found', content: { 'application/json': { schema: ErrorEnvelope } } },
+  '408': { description: 'Request timeout', content: { 'application/json': { schema: ErrorEnvelope } } },
   '409': { description: 'Conflict', content: { 'application/json': { schema: ErrorEnvelope } } },
   '422': { description: 'Unprocessable entity', content: { 'application/json': { schema: ErrorEnvelope } } },
   '429': { description: 'Too many requests', content: { 'application/json': { schema: ErrorEnvelope } } },

--- a/tests/requestProtection.test.ts
+++ b/tests/requestProtection.test.ts
@@ -9,15 +9,16 @@
  *   - BODY_LIMIT_BYTES constant: exported value equals 256 KiB
  */
 
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import express from 'express';
 import request from 'supertest';
 import {
   BODY_LIMIT_BYTES,
   bodySizeLimitMiddleware,
   jsonDepthMiddleware,
+  requestTimeoutMiddleware,
 } from '../src/middleware/requestProtection.js';
-import { errorHandler } from '../src/middleware/errorHandler.js';
+import { ApiError, ApiErrorCode, errorHandler } from '../src/middleware/errorHandler.js';
 
 function buildApp() {
   const app = express();
@@ -106,5 +107,41 @@ describe('jsonDepthMiddleware', () => {
 
     const res = await request(appWithGet).get('/ping');
     expect(res.status).toBe(200);
+  });
+});
+
+describe('requestTimeoutMiddleware', () => {
+  it('passes a REQUEST_TIMEOUT ApiError to next on socket timeout', () => {
+    let timeoutCallback: (() => void) | undefined;
+    const req = {
+      socket: {
+        setTimeout: (_ms: number, callback?: () => void) => {
+          timeoutCallback = callback;
+        },
+        destroy: () => undefined,
+      },
+    };
+    const res = {
+      headersSent: false,
+      setHeader: () => undefined,
+      on: () => res,
+    };
+    const next = vi.fn();
+
+    requestTimeoutMiddleware(123)(
+      req as any,
+      res as any,
+      next,
+    );
+
+    expect(next).toHaveBeenCalledTimes(1);
+    timeoutCallback?.();
+
+    expect(next).toHaveBeenCalledTimes(2);
+    const err = next.mock.calls[1]?.[0];
+    expect(err).toBeInstanceOf(ApiError);
+    expect(err.code).toBe(ApiErrorCode.REQUEST_TIMEOUT);
+    expect(err.statusCode).toBe(408);
+    expect(err.message).toBe('Request timed out after 123ms');
   });
 });


### PR DESCRIPTION
## Summary
- add REQUEST_TIMEOUT to ApiErrorCode and expose a 408 helper
- route socket request timeouts through the standard ApiError envelope instead of INTERNAL_ERROR
- wire requestTimeoutMiddleware into createApp and document the new stable code

Closes #367

## Tests
- node .\node_modules\vitest\vitest.mjs run src/app.test.ts tests/requestProtection.test.ts
- node .\node_modules\typescript\bin\tsc --noEmit --pretty false 2>&1 | Select-String -Pattern '^src/(app|middleware/errorHandler|middleware/requestProtection|openapi/spec)\.ts|^src/app\.test\.ts|^tests/requestProtection\.test\.ts'

Note: full repository tsc still reports existing unrelated baseline errors, including src/config/health.ts/test.ts, missing dotenv typings, and DB pool typing issues; no touched-file TypeScript errors were emitted by the filtered check.