### PR TITLE
fix(validation): bound decimal string amounts

### DIFF
--- a/src/validation/schemas.ts
+++ b/src/validation/schemas.ts
@@ -10,18 +10,54 @@
  * @module validation/schemas
  */
 import { z } from 'zod';
+import {
+  MAX_DECIMAL_INTEGER_PART,
+  STELLAR_DECIMALS,
+} from '../serialization/decimal.js';
 
 /** Regex for valid decimal strings: optional sign, digits, optional fraction */
 export const DECIMAL_STRING_REGEX = /^[+-]?\d+(\.\d+)?$/;
+const MAX_DECIMAL_INTEGER_PART_STRING = MAX_DECIMAL_INTEGER_PART.toString();
 
 /** Regex for valid Stellar public keys: G followed by 55 base32 characters */
 export const STELLAR_PUBLIC_KEY_REGEX = /^G[A-Z2-7]{55}$/;
 
-/** Reusable decimal-string field schema */
+/** Returns true when the integer part is within the serializer's max magnitude. */
+function hasSupportedIntegerMagnitude(value: string): boolean {
+  if (!DECIMAL_STRING_REGEX.test(value)) return true;
+
+  const integerPart = value.split('.')[0]!.replace(/^[+-]/, '').replace(/^0+/, '') || '0';
+  if (integerPart.length !== MAX_DECIMAL_INTEGER_PART_STRING.length) {
+    return integerPart.length < MAX_DECIMAL_INTEGER_PART_STRING.length;
+  }
+
+  return integerPart <= MAX_DECIMAL_INTEGER_PART_STRING;
+}
+
+/** Returns true when the fractional precision fits Stellar's stroop scale. */
+function hasStellarFractionalPrecision(value: string): boolean {
+  if (!DECIMAL_STRING_REGEX.test(value)) return true;
+  return (value.split('.')[1]?.length ?? 0) <= STELLAR_DECIMALS;
+}
+
+/**
+ * Reusable decimal-string field schema for Stellar amount inputs.
+ *
+ * The regex keeps the public API strict about JSON string shape. The bounds
+ * refinements align accepted values with the decimal serializer's maximum
+ * integer magnitude and Stellar's seven-decimal stroop precision before values
+ * reach route or database code.
+ */
 function decimalStringField(fieldName: string) {
   return z
     .string({ error: `${fieldName} must be a decimal string, not a number` })
-    .regex(DECIMAL_STRING_REGEX, `${fieldName} must be a valid decimal string (e.g. "100", "0.0000116")`);
+    .regex(DECIMAL_STRING_REGEX, `${fieldName} must be a valid decimal string (e.g. "100", "0.0000116")`)
+    .refine(hasSupportedIntegerMagnitude, {
+      message: `${fieldName} exceeds maximum supported integer value ${MAX_DECIMAL_INTEGER_PART_STRING}`,
+    })
+    .refine(hasStellarFractionalPrecision, {
+      message: `${fieldName} must have at most ${STELLAR_DECIMALS} decimal places`,
+    });
 }
 
 /** Reusable Stellar public key field schema */

--- a/tests/routes/streams.test.ts
+++ b/tests/routes/streams.test.ts
@@ -559,33 +559,20 @@ describe('streams routes', () => {
       expect(res.body.data.ratePerSecond).toBe('0.0000116');
     });
 
-    it('accepts large and high-precision decimal strings without numeric coercion', async () => {
-      const preciseBody = {
+    it('rejects decimal strings outside schema bounds before persistence', async () => {
+      const outOfBoundsBody = {
         ...validBody,
         depositAmount: '9007199254740993.000000000000000001',
         ratePerSecond: '+0.000000000000000001',
       };
-      mockUpsertStream.mockResolvedValue({
-        created: true,
-        stream: makeDbRecord({
-          amount: '9007199254740993.000000000000000001',
-          rate_per_second: '+0.000000000000000001',
-        }),
-      });
 
-      const res = await post(preciseBody, uniqueKey());
+      const res = await post(outOfBoundsBody, uniqueKey());
 
-      expect(res.status).toBe(201);
-      expect(mockUpsertStream).toHaveBeenCalledTimes(1);
-      expect(mockUpsertStream.mock.calls[0]?.[0]).toEqual(
-        expect.objectContaining({
-          amount: '9007199254740993.000000000000000001',
-          remaining_amount: '9007199254740993.000000000000000001',
-          rate_per_second: '+0.000000000000000001',
-        }),
-      );
-      expect(res.body.data.depositAmount).toBe('9007199254740993.000000000000000001');
-      expect(res.body.data.ratePerSecond).toBe('+0.000000000000000001');
+      expect(res.status).toBe(400);
+      expect(res.body.error.code).toBe('VALIDATION_ERROR');
+      expect(res.body.error.details).toContain('depositAmount must have at most 7 decimal places');
+      expect(res.body.error.details).toContain('ratePerSecond must have at most 7 decimal places');
+      expect(mockUpsertStream).not.toHaveBeenCalled();
     });
   });
 

--- a/tests/validation/schemas.test.ts
+++ b/tests/validation/schemas.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from 'vitest';
+
+import { MAX_DECIMAL_INTEGER_PART, STELLAR_DECIMALS } from '../../src/serialization/decimal.js';
+import { CreateStreamSchema, StreamBatchCreateSchema } from '../../src/validation/schemas.js';
+
+const VALID_SENDER = 'GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN7';
+const VALID_RECIPIENT = 'GBDEVU63Y6NTHJQQZIKVTC23NWLQVP3WJ2RI2OTSJTNYOIGICST6DUXR';
+
+const validCreateStreamBody = {
+  sender: VALID_SENDER,
+  recipient: VALID_RECIPIENT,
+  depositAmount: '1000.0000000',
+  ratePerSecond: '0.0000116',
+};
+
+function makeBatchStream(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'stream-tx-0-0',
+    sender_address: VALID_SENDER,
+    recipient_address: VALID_RECIPIENT,
+    amount: '1000.0000000',
+    streamed_amount: '0',
+    remaining_amount: '1000.0000000',
+    rate_per_second: '0.0000116',
+    start_time: 1700000000,
+    end_time: 0,
+    contract_id: 'api-created',
+    transaction_hash: 'tx-0',
+    event_index: 0,
+    ...overrides,
+  };
+}
+
+function issueMessages(result: ReturnType<typeof CreateStreamSchema.safeParse>): string[] {
+  if (result.success) return [];
+  return result.error.issues.map((issue) => issue.message);
+}
+
+describe('validation schemas', () => {
+  describe('decimal string amount bounds', () => {
+    it('accepts the maximum supported integer magnitude with Stellar precision', () => {
+      const result = CreateStreamSchema.safeParse({
+        ...validCreateStreamBody,
+        depositAmount: `${MAX_DECIMAL_INTEGER_PART.toString()}.${'0'.repeat(STELLAR_DECIMALS)}`,
+      });
+
+      expect(result.success).toBe(true);
+    });
+
+    it('rejects create-stream values above the supported integer magnitude', () => {
+      const result = CreateStreamSchema.safeParse({
+        ...validCreateStreamBody,
+        depositAmount: `${(MAX_DECIMAL_INTEGER_PART + 1n).toString()}.0000000`,
+      });
+
+      expect(result.success).toBe(false);
+      expect(issueMessages(result)).toContain(
+        `depositAmount exceeds maximum supported integer value ${MAX_DECIMAL_INTEGER_PART.toString()}`,
+      );
+    });
+
+    it('rejects create-stream fractional precision beyond Stellar stroops', () => {
+      const result = CreateStreamSchema.safeParse({
+        ...validCreateStreamBody,
+        ratePerSecond: '0.00000001',
+      });
+
+      expect(result.success).toBe(false);
+      expect(issueMessages(result)).toContain(`ratePerSecond must have at most ${STELLAR_DECIMALS} decimal places`);
+    });
+
+    it('applies the same decimal bounds to indexed stream batches', () => {
+      const result = StreamBatchCreateSchema.safeParse({
+        streams: [
+          makeBatchStream({
+            amount: `${(MAX_DECIMAL_INTEGER_PART + 1n).toString()}`,
+            remaining_amount: '100.00000001',
+          }),
+        ],
+      });
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.issues).toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({
+              path: ['streams', 0, 'amount'],
+              message: `amount exceeds maximum supported integer value ${MAX_DECIMAL_INTEGER_PART.toString()}`,
+            }),
+            expect.objectContaining({
+              path: ['streams', 0, 'remaining_amount'],
+              message: `remaining_amount must have at most ${STELLAR_DECIMALS} decimal places`,
+            }),
+          ]),
+        );
+      }
+    });
+  });
+});


### PR DESCRIPTION
Closes #366.

## Summary
- adds decimal string schema refinements for the serializer maximum integer magnitude and Stellar 7-decimal stroop precision
- applies the same bounds to create-stream requests and indexed stream batch amount fields
- updates the route regression expectation so out-of-bounds high-precision values fail before persistence

## Validation
- `node .\node_modules\vitest\vitest.mjs run tests\validation\schemas.test.ts tests\validation-edge-cases.test.ts -t "validation schemas|Duplicate Submission Detection|batch"` passed 10 tests
- `node .\node_modules\vitest\vitest.mjs run tests\decimal.test.ts -t "validateDecimalString|parseToStroops|compareDecimalStringToZero"` passed 38 focused tests
- `git diff --check` passed
- `tsc --noEmit --pretty false` still hits existing main-branch parse errors in `src/openapi/spec.ts`; no touched-file TypeScript errors matched `src/validation/schemas.ts`, `tests/validation/schemas.test.ts`, or `tests/routes/streams.test.ts`
- `tests/routes/streams.test.ts -t "rejects decimal strings outside schema bounds"` is currently blocked by existing duplicate exports in `src/webhooks/retry.ts` before tests are collected

## Security
- rejects out-of-range public amount strings at the Zod trust boundary before route normalization or persistence
- avoids numeric coercion for magnitude checks so oversized decimal strings cannot trigger precision loss