### PR TITLE
feat(metrics): expose webhook backlog gauges

### DIFF
--- a/docs/observability.md
+++ b/docs/observability.md
@@ -31,6 +31,31 @@ scrape_configs:
 | `403` | Token present but incorrect |
 | `503` | `ADMIN_API_KEY` not configured on the server |
 
+## Webhook backlog metrics
+
+Webhook dead-letter queue and outbox backlog metrics are exported from the
+admin-protected `GET /metrics` endpoint. They are aggregate gauges with no
+consumer URL labels, so a scrape cannot leak webhook destinations or create
+unbounded label cardinality.
+
+| Metric | Type | Description | Suggested alert |
+|--------|------|-------------|-----------------|
+| `fluxora_webhook_dlq_items` | Gauge | Current number of webhook deliveries in the dead-letter queue. | Page when `> 0` for 10 minutes. |
+| `fluxora_webhook_outbox_pending_items` | Gauge | Current number of pending webhook outbox items waiting for delivery. | Warn when `> 100` for 15 minutes or increasing for 30 minutes. |
+| `fluxora_webhook_circuit_breaker_open_endpoints` | Gauge | Process-local count of webhook endpoints currently in the open circuit-breaker phase. | Warn when `> 0` for 5 minutes. |
+
+Example alert:
+
+```yaml
+- alert: FluxoraWebhookDlqBacklog
+  expr: fluxora_webhook_dlq_items > 0
+  for: 10m
+  labels:
+    severity: page
+  annotations:
+    summary: Webhook dead-letter queue is accumulating failed deliveries
+```
+
 ## Slow-query logging
 
 Every repository method in `src/db/repositories/streamRepository.ts` is instrumented with a Prometheus histogram.

--- a/src/app.ts
+++ b/src/app.ts
@@ -45,6 +45,8 @@ import { getRateLimitConfig } from './config/rateLimits.js';
 import { successResponse, errorResponse } from './utils/response.js';
 import { docsRouter } from './routes/docs.js';
 import { startVacuumCollector } from './metrics/vacuumCollector.js';
+import { registerWebhookStoreMetricsSource } from './metrics/businessMetrics.js';
+import { webhookDeliveryStore } from './webhooks/store.js';
 
 export interface AppOptions {
   /** When true, mounts a /__test/error and /__test/timeout route. */
@@ -201,6 +203,7 @@ export function createApp(options: AppOptions = {}): Express {
   const appConfig = options.config ?? loadConfig();
   void wireIdempotencyStore(appConfig);
   void wireWebhookCircuitBreakerStore(appConfig);
+  registerWebhookStoreMetricsSource(() => webhookDeliveryStore.getMetrics());
 
   app.use(requestTimeoutMiddleware(options.requestTimeoutMs ?? appConfig.requestTimeoutMs));
   app.use(privacyHeaders);

--- a/src/metrics/businessMetrics.ts
+++ b/src/metrics/businessMetrics.ts
@@ -1,6 +1,14 @@
 import { Counter, Histogram, Gauge } from 'prom-client';
 import { registry } from '../metrics.js';
 
+interface WebhookStoreMetricsSnapshot {
+  dlqItems: number;
+  outboxItems: number;
+}
+
+let webhookStoreMetricsSource: (() => WebhookStoreMetricsSnapshot) | null = null;
+let webhookCircuitBreakerOpenEndpointCount = 0;
+
 export const streamsCreatedTotal =
   (registry.getSingleMetric('fluxora_streams_created_total') as Counter<'status'>) ||
   new Counter({
@@ -45,6 +53,53 @@ export const webhookDeliveryDurationSeconds =
     registers: [registry],
   });
 
+/**
+ * Current count of webhook deliveries in the dead-letter queue.
+ *
+ * This gauge intentionally has no endpoint labels so consumer URLs, secrets, or
+ * other high-cardinality values cannot leak through Prometheus.
+ */
+export const webhookDlqItemsGauge =
+  (registry.getSingleMetric('fluxora_webhook_dlq_items') as Gauge) ||
+  new Gauge({
+    name: 'fluxora_webhook_dlq_items',
+    help: 'Current number of webhook deliveries in the dead-letter queue',
+    registers: [registry],
+    collect() {
+      refreshWebhookStoreGauges();
+    },
+  });
+
+/**
+ * Current count of pending webhook outbox items waiting for delivery.
+ *
+ * No per-URL labels are exposed; alerting should be based on aggregate backlog.
+ */
+export const webhookOutboxPendingItemsGauge =
+  (registry.getSingleMetric('fluxora_webhook_outbox_pending_items') as Gauge) ||
+  new Gauge({
+    name: 'fluxora_webhook_outbox_pending_items',
+    help: 'Current number of pending webhook outbox items waiting for delivery',
+    registers: [registry],
+    collect() {
+      refreshWebhookStoreGauges();
+    },
+  });
+
+/**
+ * Current process-local count of webhook consumer endpoints whose circuit
+ * breaker is open.
+ *
+ * The count is aggregate-only to avoid URL label cardinality and PII leakage.
+ */
+export const webhookCircuitBreakerOpenEndpointsGauge =
+  (registry.getSingleMetric('fluxora_webhook_circuit_breaker_open_endpoints') as Gauge) ||
+  new Gauge({
+    name: 'fluxora_webhook_circuit_breaker_open_endpoints',
+    help: 'Current number of webhook consumer endpoints with an open circuit breaker',
+    registers: [registry],
+  });
+
 export const indexerEventsIngestedTotal =
   (registry.getSingleMetric('fluxora_indexer_events_ingested_total') as Counter) ||
   new Counter({
@@ -61,13 +116,62 @@ export const indexerLagSeconds =
     registers: [registry],
   });
 
+function clampGaugeValue(value: number): number {
+  if (!Number.isFinite(value)) return 0;
+  return Math.max(0, value);
+}
+
+function refreshWebhookStoreGauges(): void {
+  if (!webhookStoreMetricsSource) return;
+
+  try {
+    const snapshot = webhookStoreMetricsSource();
+    webhookDlqItemsGauge.set(clampGaugeValue(snapshot.dlqItems));
+    webhookOutboxPendingItemsGauge.set(clampGaugeValue(snapshot.outboxItems));
+  } catch {
+    // Never let a transient store read failure break /metrics scraping.
+  }
+}
+
+/** Register or clear the source used to refresh webhook store gauges on scrape. */
+export function registerWebhookStoreMetricsSource(source: (() => WebhookStoreMetricsSnapshot) | null): void {
+  webhookStoreMetricsSource = source;
+  if (source) refreshWebhookStoreGauges();
+}
+
+/** Explicitly synchronize webhook DLQ/outbox gauges from a known snapshot. */
+export function syncWebhookStoreMetrics(snapshot: WebhookStoreMetricsSnapshot): void {
+  webhookDlqItemsGauge.set(clampGaugeValue(snapshot.dlqItems));
+  webhookOutboxPendingItemsGauge.set(clampGaugeValue(snapshot.outboxItems));
+}
+
+/**
+ * Update the aggregate open-circuit gauge when a webhook endpoint changes
+ * circuit-breaker phase.
+ */
+export function recordWebhookCircuitBreakerTransition(fromState: string, toState: string): void {
+  if (fromState !== 'open' && toState === 'open') {
+    webhookCircuitBreakerOpenEndpointCount += 1;
+  } else if (fromState === 'open' && toState !== 'open') {
+    webhookCircuitBreakerOpenEndpointCount = Math.max(0, webhookCircuitBreakerOpenEndpointCount - 1);
+  }
+
+  webhookCircuitBreakerOpenEndpointsGauge.set(webhookCircuitBreakerOpenEndpointCount);
+}
+
 /** Clean helper to de-register metrics between test runs. */
 export function deRegisterBusinessMetrics(): void {
+  webhookStoreMetricsSource = null;
+  webhookCircuitBreakerOpenEndpointCount = 0;
+
   registry.removeSingleMetric('fluxora_streams_created_total');
   registry.removeSingleMetric('fluxora_sse_active_connections');
   registry.removeSingleMetric('fluxora_sse_connections_rejected_total');
   registry.removeSingleMetric('fluxora_webhook_deliveries_total');
   registry.removeSingleMetric('fluxora_webhook_delivery_duration_seconds');
+  registry.removeSingleMetric('fluxora_webhook_dlq_items');
+  registry.removeSingleMetric('fluxora_webhook_outbox_pending_items');
+  registry.removeSingleMetric('fluxora_webhook_circuit_breaker_open_endpoints');
   registry.removeSingleMetric('fluxora_indexer_events_ingested_total');
   registry.removeSingleMetric('fluxora_indexer_lag_seconds');
 }

--- a/src/redis/webhookCircuitBreakerStore.ts
+++ b/src/redis/webhookCircuitBreakerStore.ts
@@ -7,6 +7,7 @@ import { createHash, randomUUID } from 'node:crypto';
 import { Counter } from 'prom-client';
 import type { RedisClient } from './client.js';
 import { registry } from '../metrics.js';
+import { recordWebhookCircuitBreakerTransition } from '../metrics/businessMetrics.js';
 
 export interface CircuitBreakerPolicy {
   circuitBreakerThreshold?: number;
@@ -79,7 +80,9 @@ function ttlSec(policy: CircuitBreakerPolicy): number {
 }
 
 function emit(from: WebhookCircuitBreakerPhase, to: WebhookCircuitBreakerPhase): void {
-  if (from !== to) transitionsTotal.inc({ from_state: from, to_state: to });
+  if (from === to) return;
+  transitionsTotal.inc({ from_state: from, to_state: to });
+  recordWebhookCircuitBreakerTransition(from, to);
 }
 
 function parse(raw: string | null): WebhookCircuitBreakerRecord {

--- a/src/routes/metrics.ts
+++ b/src/routes/metrics.ts
@@ -11,6 +11,8 @@ export const metricsRouter = express.Router();
  * Returns Prometheus-format metrics including:
  * - http_requests_total: Counter of HTTP requests by method, route, status_code
  * - http_request_duration_seconds: Histogram of request latency
+ * - fluxora_webhook_dlq_items / fluxora_webhook_outbox_pending_items
+ *   aggregate webhook backlog gauges
  * - Default Node.js metrics (process info, GC, memory, etc.)
  *
  * Content-Type: text/plain; version=0.0.4

--- a/tests/metrics/businessMetrics.test.ts
+++ b/tests/metrics/businessMetrics.test.ts
@@ -8,14 +8,21 @@ import {
   webhookDeliveryDurationSeconds,
   indexerEventsIngestedTotal,
   indexerLagSeconds,
+  syncWebhookStoreMetrics,
   deRegisterBusinessMetrics,
 } from '../../src/metrics/businessMetrics.js';
 import { WebhookService } from '../../src/webhooks/service.js';
 import { IndexerIngestionService } from '../../src/indexer/service.js';
 import { InMemoryContractEventStore } from '../../src/indexer/store.js';
 
+const ADMIN_KEY = 'business-metrics-admin-key';
+let originalAdminKey: string | undefined;
+
 // Setup fresh metrics before each test in this suite
 beforeEach(() => {
+  originalAdminKey = process.env.ADMIN_API_KEY;
+  process.env.ADMIN_API_KEY = ADMIN_KEY;
+
   // Reset existing metrics if they are still registered
   try {
     streamsCreatedTotal.reset();
@@ -25,6 +32,14 @@ beforeEach(() => {
     indexerLagSeconds.reset();
   } catch {
     // no-op if already de-registered
+  }
+});
+
+afterEach(() => {
+  if (originalAdminKey !== undefined) {
+    process.env.ADMIN_API_KEY = originalAdminKey;
+  } else {
+    delete process.env.ADMIN_API_KEY;
   }
 });
 
@@ -179,11 +194,16 @@ describe('Business Metrics Integration', () => {
   // 3. Scrape integration
   it('exposes custom business metrics in /metrics endpoint', async () => {
     streamsCreatedTotal.inc({ status: 'active' });
+    syncWebhookStoreMetrics({ dlqItems: 1, outboxItems: 2 });
 
-    const res = await request(app).get('/metrics');
+    const res = await request(app)
+      .get('/metrics')
+      .set('Authorization', `Bearer ${ADMIN_KEY}`);
     expect(res.status).toBe(200);
     expect(res.text).toContain('fluxora_streams_created_total');
     expect(res.text).toContain('status="active"');
+    expect(res.text).toMatch(/fluxora_webhook_dlq_items\{[^}]*\} 1/);
+    expect(res.text).toMatch(/fluxora_webhook_outbox_pending_items\{[^}]*\} 2/);
   });
 
   // 4. Double Registration & De-registration protection
@@ -195,5 +215,6 @@ describe('Business Metrics Integration', () => {
     // Verify calling deRegister removes them
     deRegisterBusinessMetrics();
     expect(registry.getSingleMetric('fluxora_streams_created_total')).toBeUndefined();
+    expect(registry.getSingleMetric('fluxora_webhook_dlq_items')).toBeUndefined();
   });
 });

--- a/tests/metrics/webhookBacklogMetrics.test.ts
+++ b/tests/metrics/webhookBacklogMetrics.test.ts
@@ -1,0 +1,84 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { registry } from '../../src/metrics.js';
+import {
+  deRegisterBusinessMetrics,
+  recordWebhookCircuitBreakerTransition,
+  registerWebhookStoreMetricsSource,
+  syncWebhookStoreMetrics,
+  webhookCircuitBreakerOpenEndpointsGauge,
+  webhookDlqItemsGauge,
+  webhookOutboxPendingItemsGauge,
+} from '../../src/metrics/businessMetrics.js';
+
+async function gaugeValue(gauge: typeof webhookDlqItemsGauge): Promise<number> {
+  const metric = await gauge.get();
+  return metric.values[0]?.value ?? 0;
+}
+
+describe('webhook backlog business metrics', () => {
+  beforeEach(() => {
+    registerWebhookStoreMetricsSource(null);
+    webhookDlqItemsGauge.reset();
+    webhookOutboxPendingItemsGauge.reset();
+    webhookCircuitBreakerOpenEndpointsGauge.reset();
+  });
+
+  afterEach(() => {
+    registerWebhookStoreMetricsSource(null);
+  });
+
+  it('syncs DLQ and outbox gauges without labels', async () => {
+    syncWebhookStoreMetrics({ dlqItems: 3, outboxItems: 7 });
+
+    expect(await gaugeValue(webhookDlqItemsGauge)).toBe(3);
+    expect(await gaugeValue(webhookOutboxPendingItemsGauge)).toBe(7);
+
+    const dlqMetric = await webhookDlqItemsGauge.get();
+    expect(dlqMetric.values[0]?.labels).toEqual({});
+  });
+
+  it('refreshes DLQ and outbox gauges on Prometheus scrape', async () => {
+    let snapshot = { dlqItems: 0, outboxItems: 1 };
+    registerWebhookStoreMetricsSource(() => snapshot);
+
+    expect(await registry.metrics()).toMatch(/fluxora_webhook_outbox_pending_items\{[^}]*\} 1/);
+
+    snapshot = { dlqItems: 2, outboxItems: 5 };
+    const scrape = await registry.metrics();
+
+    expect(scrape).toMatch(/fluxora_webhook_dlq_items\{[^}]*\} 2/);
+    expect(scrape).toMatch(/fluxora_webhook_outbox_pending_items\{[^}]*\} 5/);
+  });
+
+  it('keeps metrics scraping healthy if the store metrics source throws', async () => {
+    syncWebhookStoreMetrics({ dlqItems: 4, outboxItems: 6 });
+    registerWebhookStoreMetricsSource(() => {
+      throw new Error('store unavailable');
+    });
+
+    const scrape = await registry.metrics();
+
+    expect(scrape).toMatch(/fluxora_webhook_dlq_items\{[^}]*\} 4/);
+    expect(scrape).toMatch(/fluxora_webhook_outbox_pending_items\{[^}]*\} 6/);
+  });
+
+  it('tracks open circuit-breaker endpoints as an aggregate count', async () => {
+    recordWebhookCircuitBreakerTransition('closed', 'open');
+    recordWebhookCircuitBreakerTransition('closed', 'open');
+    recordWebhookCircuitBreakerTransition('open', 'half-open');
+
+    expect(await gaugeValue(webhookCircuitBreakerOpenEndpointsGauge)).toBe(1);
+
+    const metric = await webhookCircuitBreakerOpenEndpointsGauge.get();
+    expect(metric.values[0]?.labels).toEqual({});
+  });
+
+  it('de-registers the webhook gauges with the rest of the business metrics', () => {
+    deRegisterBusinessMetrics();
+
+    expect(registry.getSingleMetric('fluxora_webhook_dlq_items')).toBeUndefined();
+    expect(registry.getSingleMetric('fluxora_webhook_outbox_pending_items')).toBeUndefined();
+    expect(registry.getSingleMetric('fluxora_webhook_circuit_breaker_open_endpoints')).toBeUndefined();
+  });
+});

--- a/tests/routes/metrics.auth.test.ts
+++ b/tests/routes/metrics.auth.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import request from 'supertest';
 import { app } from '../../src/app.js';
+import { syncWebhookStoreMetrics } from '../../src/metrics/businessMetrics.js';
 
 const ADMIN_KEY = 'test-metrics-admin-key';
 
@@ -41,6 +42,18 @@ describe('GET /metrics auth', () => {
       .set('Authorization', `Bearer ${ADMIN_KEY}`);
     expect(res.status).toBe(200);
     expect(res.text).toContain('# HELP');
+  });
+
+  it('exposes webhook backlog gauges only through the admin-protected metrics route', async () => {
+    syncWebhookStoreMetrics({ dlqItems: 2, outboxItems: 4 });
+
+    const res = await request(app)
+      .get('/metrics')
+      .set('Authorization', `Bearer ${ADMIN_KEY}`);
+
+    expect(res.status).toBe(200);
+    expect(res.text).toMatch(/fluxora_webhook_dlq_items\{[^}]*\} 2/);
+    expect(res.text).toMatch(/fluxora_webhook_outbox_pending_items\{[^}]*\} 4/);
   });
 
   it('returns 503 when ADMIN_API_KEY is not configured', async () => {


### PR DESCRIPTION
Closes #347.

## Summary
- exposes aggregate Prometheus gauges for webhook DLQ depth, outbox backlog, and open circuit-breaker endpoints
- registers the webhook delivery store metrics source with the app and syncs the gauges before `/metrics` output
- records aggregate circuit-breaker open endpoint transitions without URL labels to avoid PII/high-cardinality metrics
- documents alert thresholds and adds focused metric/auth coverage

## Validation
- `node .\node_modules\vitest\vitest.mjs run tests\metrics\webhookBacklogMetrics.test.ts` passed 5 tests
- App/service/circuit-breaker route focused suites are currently blocked before collection by existing duplicate exports in `src/webhooks/retry.ts` (`calculateNextRetryTime`, `generateRetrySchedule`, `scheduleWebhookOutboxRetry`)
- Full `tsc --noEmit --pretty false` is blocked by existing `src/openapi/spec.ts` parse errors; touched-file filtering produced no matching errors for this change

## Security / Ops
- keeps metrics aggregate-only and avoids per-webhook URL labels
- metrics stay behind the existing admin `/metrics` route