### PR TITLE
feat(metrics): add auth latency histograms

### DIFF
--- a/docs/observability.md
+++ b/docs/observability.md
@@ -140,6 +140,33 @@ scrape_configs:
 | `403` | Token present but incorrect |
 | `503` | `ADMIN_API_KEY` not configured on the server |
 
+## Authentication latency metrics
+
+Authentication is on the request path for protected routes. Fluxora exports bounded Prometheus histograms so operators can spot slow JWT verification or API-key lookup without exposing credential material.
+
+### Metrics
+
+| Metric Name | Type | Labels | Description |
+|-------------|------|--------|-------------|
+| `fluxora_auth_jwt_verify_duration_seconds` | Histogram | `outcome` (`success` or `failure`) | Wall-clock duration of JWT signature/expiry verification. |
+| `fluxora_auth_apikey_lookup_duration_seconds` | Histogram | `outcome` (`success` or `failure`) | Wall-clock duration of API-key hash lookup. |
+
+**Buckets (seconds):** 0.001, 0.0025, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1
+
+Only the low-cardinality `outcome` label is emitted. API key ids, prefixes, raw keys, JWT subjects, `jti` values, addresses, and roles are never metric labels.
+
+### Example PromQL
+
+```promql
+histogram_quantile(0.95, sum by (le, outcome) (rate(fluxora_auth_jwt_verify_duration_seconds_bucket[5m])))
+```
+
+```promql
+histogram_quantile(0.95, sum by (le, outcome) (rate(fluxora_auth_apikey_lookup_duration_seconds_bucket[5m])))
+```
+
+Alert if p95 authentication latency stays above `100ms` for 10 minutes, or if failure-labeled latency diverges from success-labeled latency during a credential-store incident.
+
 ## Runtime Performance Metrics
 
 The application exposes fine-grained Node.js runtime health indicators to differentiate garbage collection pressure from event loop starvation during load spikes.

--- a/src/lib/apiKey.ts
+++ b/src/lib/apiKey.ts
@@ -1,6 +1,7 @@
 import { createId } from '@paralleldrive/cuid2';
 import { createHash, timingSafeEqual } from 'crypto';
 import type { ApiKeyRecord, ApiKeyCreated } from '../db/types.js';
+import { recordApiKeyLookupDuration } from '../metrics/businessMetrics.js';
 
 // ---------------------------------------------------------------------------
 // In-memory store (replace with DB-backed store when persistence is needed)
@@ -97,7 +98,15 @@ export function listApiKeys(): ApiKeyRecord[] {
  * Validates a raw API key against the stored hashes using constant-time comparison.
  */
 export function isValidApiKey(rawKey: string): boolean {
-  if (!rawKey) return false;
+  const lookupStart = process.hrtime.bigint();
+  const observeLookup = (outcome: 'success' | 'failure'): void => {
+    recordApiKeyLookupDuration(Number(process.hrtime.bigint() - lookupStart) / 1_000_000_000, outcome);
+  };
+
+  if (!rawKey) {
+    observeLookup('failure');
+    return false;
+  }
 
   const hash = sha256hex(rawKey);
   const hashBuf = Buffer.from(hash, 'hex');
@@ -107,6 +116,7 @@ export function isValidApiKey(rawKey: string): boolean {
     try {
       const storedBuf = Buffer.from(record.keyHash, 'hex');
       if (storedBuf.length === hashBuf.length && timingSafeEqual(storedBuf, hashBuf)) {
+        observeLookup('success');
         return true;
       }
     } catch {
@@ -114,6 +124,7 @@ export function isValidApiKey(rawKey: string): boolean {
     }
   }
 
+  observeLookup('failure');
   return false;
 }
 

--- a/src/metrics/businessMetrics.ts
+++ b/src/metrics/businessMetrics.ts
@@ -45,6 +45,44 @@ export const webhookDeliveryDurationSeconds =
     registers: [registry],
   });
 
+/**
+ * JWT verification latency in seconds, labeled only by aggregate outcome.
+ * Never add token, subject, jti, or role labels here.
+ */
+export const authJwtVerifyDurationSeconds =
+  (registry.getSingleMetric('fluxora_auth_jwt_verify_duration_seconds') as Histogram<'outcome'>) ||
+  new Histogram({
+    name: 'fluxora_auth_jwt_verify_duration_seconds',
+    help: 'Duration of JWT verification in seconds',
+    labelNames: ['outcome'] as const,
+    buckets: [0.001, 0.0025, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1],
+    registers: [registry],
+  });
+
+/**
+ * API-key lookup latency in seconds, labeled only by aggregate outcome.
+ * Never add key id, prefix, raw key material, or caller labels here.
+ */
+export const authApiKeyLookupDurationSeconds =
+  (registry.getSingleMetric('fluxora_auth_apikey_lookup_duration_seconds') as Histogram<'outcome'>) ||
+  new Histogram({
+    name: 'fluxora_auth_apikey_lookup_duration_seconds',
+    help: 'Duration of API-key lookup in seconds',
+    labelNames: ['outcome'] as const,
+    buckets: [0.001, 0.0025, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1],
+    registers: [registry],
+  });
+
+export type AuthLatencyOutcome = 'success' | 'failure';
+
+export function recordJwtVerifyDuration(durationSeconds: number, outcome: AuthLatencyOutcome): void {
+  authJwtVerifyDurationSeconds.observe({ outcome }, durationSeconds);
+}
+
+export function recordApiKeyLookupDuration(durationSeconds: number, outcome: AuthLatencyOutcome): void {
+  authApiKeyLookupDurationSeconds.observe({ outcome }, durationSeconds);
+}
+
 export const indexerEventsIngestedTotal =
   (registry.getSingleMetric('fluxora_indexer_events_ingested_total') as Counter) ||
   new Counter({
@@ -68,6 +106,8 @@ export function deRegisterBusinessMetrics(): void {
   registry.removeSingleMetric('fluxora_sse_connections_rejected_total');
   registry.removeSingleMetric('fluxora_webhook_deliveries_total');
   registry.removeSingleMetric('fluxora_webhook_delivery_duration_seconds');
+  registry.removeSingleMetric('fluxora_auth_jwt_verify_duration_seconds');
+  registry.removeSingleMetric('fluxora_auth_apikey_lookup_duration_seconds');
   registry.removeSingleMetric('fluxora_indexer_events_ingested_total');
   registry.removeSingleMetric('fluxora_indexer_lag_seconds');
 }

--- a/src/middleware/auth.ts
+++ b/src/middleware/auth.ts
@@ -4,6 +4,7 @@ import { ApiErrorCode } from './errorHandler.js';
 import { warn, info, debug } from '../utils/logger.js';
 import { z } from 'zod';
 import { isRevoked } from '../redis/jwtRevocationStore.js';
+import { recordJwtVerifyDuration } from '../metrics/businessMetrics.js';
 
 export enum Permission {
   STREAMS_READ = 'streams:read',
@@ -71,7 +72,15 @@ export async function authenticate(req: Request, res: Response, next: NextFuncti
 
   try {
     // 1. Verify signature and expiry (cryptographic check)
-    const payload = verifyToken(token) as unknown;
+    const verifyStart = process.hrtime.bigint();
+    let payload: unknown;
+    try {
+      payload = verifyToken(token) as unknown;
+      recordJwtVerifyDuration(Number(process.hrtime.bigint() - verifyStart) / 1_000_000_000, 'success');
+    } catch (error) {
+      recordJwtVerifyDuration(Number(process.hrtime.bigint() - verifyStart) / 1_000_000_000, 'failure');
+      throw error;
+    }
 
     // 2. Check revocation list (immediate invalidation check)
     const jti = (payload as any)?.jti;

--- a/tests/lib/auth.test.ts
+++ b/tests/lib/auth.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach, beforeAll } from 'vitest';
 import { generateToken, verifyToken, UserPayload } from '../../src/lib/auth.js';
 import { initializeConfig } from '../../src/config/env.js';
+import { authApiKeyLookupDurationSeconds } from '../../src/metrics/businessMetrics.js';
 import {
   createApiKey,
   rotateApiKey,
@@ -55,6 +56,7 @@ describe('Auth Module', () => {
 describe('API Key Management', () => {
   beforeEach(() => {
     _resetApiKeyStoreForTest();
+    authApiKeyLookupDurationSeconds.reset();
   });
 
   describe('createApiKey', () => {
@@ -95,6 +97,33 @@ describe('API Key Management', () => {
     it('rejects an unknown key', () => {
       createApiKey('svc');
       expect(isValidApiKey('flx_notakey')).toBe(false);
+    });
+
+    it('records lookup latency without key-specific labels', async () => {
+      const { key } = createApiKey('svc');
+      expect(isValidApiKey(key)).toBe(true);
+      expect(isValidApiKey('flx_notakey')).toBe(false);
+
+      const value = await authApiKeyLookupDurationSeconds.get();
+      const successCount = value.values.find(
+        (metric) =>
+          metric.metricName === 'fluxora_auth_apikey_lookup_duration_seconds_count' &&
+          metric.labels.outcome === 'success',
+      );
+      const failureCount = value.values.find(
+        (metric) =>
+          metric.metricName === 'fluxora_auth_apikey_lookup_duration_seconds_count' &&
+          metric.labels.outcome === 'failure',
+      );
+
+      expect(successCount?.value).toBe(1);
+      expect(failureCount?.value).toBe(1);
+      for (const metric of value.values) {
+        expect(metric.labels).toHaveProperty('outcome');
+        expect(metric.labels).not.toHaveProperty('key');
+        expect(metric.labels).not.toHaveProperty('keyId');
+        expect(metric.labels).not.toHaveProperty('prefix');
+      }
     });
 
     it('rejects empty string', () => {

--- a/tests/metrics/authLatencyMetrics.test.ts
+++ b/tests/metrics/authLatencyMetrics.test.ts
@@ -1,0 +1,67 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { registry } from '../../src/metrics.js';
+import {
+  authApiKeyLookupDurationSeconds,
+  authJwtVerifyDurationSeconds,
+  recordApiKeyLookupDuration,
+  recordJwtVerifyDuration,
+} from '../../src/metrics/businessMetrics.js';
+
+beforeEach(() => {
+  authJwtVerifyDurationSeconds.reset();
+  authApiKeyLookupDurationSeconds.reset();
+});
+
+describe('auth latency metrics', () => {
+  it('registers bounded histograms with outcome-only application labels', () => {
+    const jwtMetric = registry.getSingleMetric('fluxora_auth_jwt_verify_duration_seconds');
+    const apiKeyMetric = registry.getSingleMetric('fluxora_auth_apikey_lookup_duration_seconds');
+
+    expect(jwtMetric).toBe(authJwtVerifyDurationSeconds);
+    expect(apiKeyMetric).toBe(authApiKeyLookupDurationSeconds);
+    // @ts-expect-error prom-client exposes labelNames on the metric instance.
+    expect(jwtMetric?.labelNames).toEqual(['outcome']);
+    // @ts-expect-error prom-client exposes labelNames on the metric instance.
+    expect(apiKeyMetric?.labelNames).toEqual(['outcome']);
+  });
+
+  it('records JWT verification success and failure observations', async () => {
+    recordJwtVerifyDuration(0.004, 'success');
+    recordJwtVerifyDuration(0.012, 'failure');
+
+    const value = await authJwtVerifyDurationSeconds.get();
+    const successCount = value.values.find(
+      (metric) =>
+        metric.metricName === 'fluxora_auth_jwt_verify_duration_seconds_count' &&
+        metric.labels.outcome === 'success',
+    );
+    const failureCount = value.values.find(
+      (metric) =>
+        metric.metricName === 'fluxora_auth_jwt_verify_duration_seconds_count' &&
+        metric.labels.outcome === 'failure',
+    );
+
+    expect(successCount?.value).toBe(1);
+    expect(failureCount?.value).toBe(1);
+  });
+
+  it('records API-key lookup success and failure observations', async () => {
+    recordApiKeyLookupDuration(0.003, 'success');
+    recordApiKeyLookupDuration(0.009, 'failure');
+
+    const value = await authApiKeyLookupDurationSeconds.get();
+    const successCount = value.values.find(
+      (metric) =>
+        metric.metricName === 'fluxora_auth_apikey_lookup_duration_seconds_count' &&
+        metric.labels.outcome === 'success',
+    );
+    const failureCount = value.values.find(
+      (metric) =>
+        metric.metricName === 'fluxora_auth_apikey_lookup_duration_seconds_count' &&
+        metric.labels.outcome === 'failure',
+    );
+
+    expect(successCount?.value).toBe(1);
+    expect(failureCount?.value).toBe(1);
+  });
+});

--- a/tests/unit/middleware/auth.test.ts
+++ b/tests/unit/middleware/auth.test.ts
@@ -3,6 +3,7 @@ import { Request, Response, NextFunction } from 'express';
 import { authenticate, requireAuth, requirePermission, Permission } from '../../../src/middleware/auth.js';
 import { verifyToken } from '../../../src/lib/auth.js';
 import { isRevoked } from '../../../src/redis/jwtRevocationStore.js';
+import { authJwtVerifyDurationSeconds } from '../../../src/metrics/businessMetrics.js';
 
 // ── Mocks ──
 
@@ -55,6 +56,7 @@ function mockNext(): NextFunction {
 describe('authenticate', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    authJwtVerifyDurationSeconds.reset();
   });
 
   // ── Happy path ──
@@ -78,6 +80,13 @@ describe('authenticate', () => {
     expect(next).toHaveBeenCalled();
     expect(req.user).toEqual(expect.objectContaining(payload));
     expect(isRevoked).toHaveBeenCalledWith('jti-valid');
+    const value = await authJwtVerifyDurationSeconds.get();
+    const successCount = value.values.find(
+      (metric) =>
+        metric.metricName === 'fluxora_auth_jwt_verify_duration_seconds_count' &&
+        metric.labels.outcome === 'success',
+    );
+    expect(successCount?.value).toBe(1);
   });
 
   it('proceeds without user when no auth header', async () => {
@@ -170,6 +179,13 @@ describe('authenticate', () => {
 
     expect(res.statusCode).toBe(401);
     expect((res as any).jsonBody.error.message).toContain('Invalid or expired');
+    const value = await authJwtVerifyDurationSeconds.get();
+    const failureCount = value.values.find(
+      (metric) =>
+        metric.metricName === 'fluxora_auth_jwt_verify_duration_seconds_count' &&
+        metric.labels.outcome === 'failure',
+    );
+    expect(failureCount?.value).toBe(1);
   });
 
   it('returns 401 for expired token', async () => {


### PR DESCRIPTION
Closes #361.

## Summary
- adds bounded Prometheus histograms for JWT verification and API-key lookup latency
- records JWT verify outcomes in `authenticate` and API-key hash lookup outcomes in `isValidApiKey`
- keeps labels limited to `outcome` so no token, subject, jti, key id, prefix, or raw key material is exported
- documents buckets plus p95 PromQL examples

## Validation
- `node .\node_modules\vitest\vitest.mjs run tests\metrics\authLatencyMetrics.test.ts tests\unit\middleware\auth.test.ts tests\lib\auth.test.ts` passed 36 tests across 3 files
- `git diff --check` passed for touched files
- Full `tsc --noEmit --pretty false` is still blocked by existing `src/openapi/spec.ts` parse errors; touched-file filtering produced no matching errors
- `tests\metrics\businessMetrics.test.ts` remains blocked before collection by existing duplicate exports in `src/webhooks/retry.ts`, so the new auth metric checks live in an isolated metrics test file

## Security notes
- metrics expose aggregate latency only
- labels are low-cardinality and do not include credential material or authenticated identity values