### PR TITLE
fix(db): stabilize stream offset pagination ordering

### DIFF
--- a/migrations/20260621_streams_offset_order_tiebreaker.ts
+++ b/migrations/20260621_streams_offset_order_tiebreaker.ts
@@ -1,0 +1,27 @@
+import { PoolClient } from 'pg';
+
+/**
+ * Supports deterministic offset pagination by matching the repository's
+ * fixed ORDER BY created_at DESC, id DESC clause.
+ */
+export async function up(client: PoolClient): Promise<void> {
+  await client.query(`
+    DROP INDEX IF EXISTS idx_streams_created_at;
+  `);
+
+  await client.query(`
+    CREATE INDEX IF NOT EXISTS idx_streams_created_at_id
+      ON streams (created_at DESC, id DESC);
+  `);
+}
+
+export async function down(client: PoolClient): Promise<void> {
+  await client.query(`
+    DROP INDEX IF EXISTS idx_streams_created_at_id;
+  `);
+
+  await client.query(`
+    CREATE INDEX IF NOT EXISTS idx_streams_created_at
+      ON streams (created_at);
+  `);
+}

--- a/src/db/repositories/streamRepository.ts
+++ b/src/db/repositories/streamRepository.ts
@@ -46,6 +46,7 @@ import { enrichActiveSpanWithStream } from '../../tracing/hooks.js';
 
 
 const REPO = 'streamRepository';
+export const STREAM_OFFSET_ORDER_BY = 'created_at DESC, id DESC';
 
 // ── Types ─────────────────────────────────────────────────────────────────────
 
@@ -337,7 +338,13 @@ export const streamRepository = {
     });
   },
 
-  /** Offset-based paginated list. */
+  /**
+   * Offset-based paginated list.
+   *
+   * Ordering is fixed to (created_at DESC, id DESC) so rows sharing the same
+   * created_at still page deterministically. Do not interpolate client input
+   * into ORDER BY; filters remain parameterized below.
+   */
   async find(filter: StreamFilter, pagination: PaginationOptions): Promise<PaginatedStreams> {
     return timed('find', async () => {
       const pool = await getReadPool();
@@ -381,7 +388,7 @@ export const streamRepository = {
         query<{ count: string }>(pool, `SELECT COUNT(*) AS count FROM streams ${where}`, countParams),
         query<Record<string, unknown>>(
           pool,
-          `SELECT ${streamSelectColumns(keyIndex, previousKeyIndex)} FROM streams ${where} ORDER BY created_at DESC LIMIT $${params.length + 1} OFFSET $${params.length + 2}`,
+          `SELECT ${streamSelectColumns(keyIndex, previousKeyIndex)} FROM streams ${where} ORDER BY ${STREAM_OFFSET_ORDER_BY} LIMIT $${params.length + 1} OFFSET $${params.length + 2}`,
           [...params, pagination.limit, pagination.offset],
         ),
       ]);

--- a/tests/db/streamRepository.offsetOrdering.test.ts
+++ b/tests/db/streamRepository.offsetOrdering.test.ts
@@ -1,0 +1,17 @@
+import fs from 'fs';
+import path from 'path';
+import { describe, expect, it } from 'vitest';
+
+const repositoryPath = path.join(process.cwd(), 'src/db/repositories/streamRepository.ts');
+const source = fs.readFileSync(repositoryPath, 'utf8');
+
+describe('streamRepository offset ordering', () => {
+  it('uses a unique deterministic tiebreaker for offset pages', () => {
+    expect(source).toContain("export const STREAM_OFFSET_ORDER_BY = 'created_at DESC, id DESC'");
+  });
+
+  it('keeps the offset query ordered by fixed columns before LIMIT/OFFSET', () => {
+    expect(source).toContain('ORDER BY ${STREAM_OFFSET_ORDER_BY} LIMIT');
+    expect(source).not.toContain('ORDER BY created_at DESC LIMIT');
+  });
+});

--- a/tests/db/streamsOffsetOrderMigration.test.ts
+++ b/tests/db/streamsOffsetOrderMigration.test.ts
@@ -1,0 +1,20 @@
+import fs from 'fs';
+import path from 'path';
+import { describe, expect, it } from 'vitest';
+
+const migrationPath = path.join(process.cwd(), 'migrations/20260621_streams_offset_order_tiebreaker.ts');
+const source = fs.readFileSync(migrationPath, 'utf8');
+
+describe('streams offset ordering migration', () => {
+  it('creates a composite index matching offset pagination order', () => {
+    expect(source).toContain('CREATE INDEX IF NOT EXISTS idx_streams_created_at_id');
+    expect(source).toContain('ON streams (created_at DESC, id DESC)');
+  });
+
+  it('replaces and restores the legacy created_at index deterministically', () => {
+    expect(source).toContain('DROP INDEX IF EXISTS idx_streams_created_at;');
+    expect(source).toContain('DROP INDEX IF EXISTS idx_streams_created_at_id;');
+    expect(source).toContain('CREATE INDEX IF NOT EXISTS idx_streams_created_at');
+    expect(source).toContain('ON streams (created_at)');
+  });
+});


### PR DESCRIPTION
Closes #339.

## Summary
- adds a fixed unique tiebreaker to `streamRepository.find` offset ordering: `created_at DESC, id DESC`
- adds a migration replacing the legacy single-column `idx_streams_created_at` with a composite `(created_at DESC, id DESC)` index
- adds focused regression tests that lock the repository ORDER BY clause and migration index shape

## Validation
- `node .\node_modules\vitest\vitest.mjs run tests\db\streamRepository.offsetOrdering.test.ts tests\db\streamsOffsetOrderMigration.test.ts` passed 4 tests across 2 files
- `git diff --check` passed for touched files
- Full `tsc --noEmit --pretty false` is still blocked by existing `src/openapi/spec.ts` parse errors; touched-file filtering produced no matching errors

## Security notes
- `ORDER BY` uses fixed column names only, with no client-controlled interpolation
- existing `LIMIT` and `OFFSET` remain parameterized

## Notes
- The public `GET /api/streams` route currently uses cursor pagination ordered by `id ASC`; this PR fixes the repository offset path requested in the issue without changing public cursor semantics.