### PR TITLE
perf(db): bound read-replica pool waits

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -25,6 +25,10 @@ POOL_QUEUE_LIMIT=50
 # Read-replica URL (optional — omit to use primary for all queries)
 # When set, SELECT queries on streams are routed through a dedicated replica pool.
 # DATABASE_REPLICA_URL=postgresql://readonly_user:password@replica-host:5432/fluxora
+# Optional read-replica overrides. Defaults inherit STATEMENT_TIMEOUT_MS and
+# POOL_QUEUE_LIMIT so replica reads remain bounded when these are omitted.
+# DATABASE_REPLICA_STATEMENT_TIMEOUT_MS=15000
+# DATABASE_REPLICA_POOL_QUEUE_LIMIT=50
 
 # Full DATABASE_URL (auto-generated in docker-compose, override if needed)
 DATABASE_URL=postgresql://fluxora:fluxora_secure_password@localhost:5432/fluxora

--- a/docs/database/read-replica-routing.md
+++ b/docs/database/read-replica-routing.md
@@ -41,15 +41,20 @@ and is integrated into the stream repository's read methods.
 
 ### Environment variable
 
-| Variable               | Required | Default           | Description                              |
-| ---------------------- | -------- | ----------------- | ---------------------------------------- |
-| `DATABASE_REPLICA_URL` | No       | *(falls back to primary)* | PostgreSQL connection string for the read-replica |
+| Variable | Required | Default | Description |
+| --- | --- | --- | --- |
+| `DATABASE_REPLICA_URL` | No | *(falls back to primary)* | PostgreSQL connection string for the read-replica |
+| `DATABASE_REPLICA_STATEMENT_TIMEOUT_MS` | No | `STATEMENT_TIMEOUT_MS` | Replica session-level `statement_timeout`; use a higher value for reporting reads when needed |
+| `DATABASE_REPLICA_POOL_QUEUE_LIMIT` | No | `POOL_QUEUE_LIMIT` | Max replica queries allowed to wait for a connection before fast-failing |
 
 Add it to your `.env` file:
 
 ```env
 # Read-replica (optional — omit to use primary for all queries)
 DATABASE_REPLICA_URL=postgresql://readonly_user:password@replica-host:5432/fluxora
+# Optional replica-specific overrides
+DATABASE_REPLICA_STATEMENT_TIMEOUT_MS=15000
+DATABASE_REPLICA_POOL_QUEUE_LIMIT=50
 ```
 
 ### Pool sizing
@@ -63,8 +68,12 @@ configuration:
 - `POOL_QUEUE_LIMIT`
 - `STATEMENT_TIMEOUT_MS`
 
-If you need different sizing for the replica, this can be extended with
-dedicated env vars in a future iteration.
+The replica pool applies `STATEMENT_TIMEOUT_MS` and `POOL_QUEUE_LIMIT` by
+default so slow reads cannot run forever or build an unbounded wait queue.
+Use `DATABASE_REPLICA_STATEMENT_TIMEOUT_MS` when replica/reporting reads need
+a different timeout from primary writes, and
+`DATABASE_REPLICA_POOL_QUEUE_LIMIT` when replica saturation should trip at a
+different queue depth.
 
 ## Initialisation & Fallback
 
@@ -82,6 +91,25 @@ first read query executes. On the first call:
 
 The decision is cached after the first call — there is no per-query
 overhead.
+
+## Timeout and Queue Protection
+
+`createReplicaPool()` uses the same pool factory as the primary database pool,
+with the stable metrics label `pool="read-replica"`. On each new physical
+connection it applies:
+
+```sql
+SET statement_timeout = DATABASE_REPLICA_STATEMENT_TIMEOUT_MS
+SET default_transaction_read_only = on
+```
+
+If the replica waiting queue reaches `DATABASE_REPLICA_POOL_QUEUE_LIMIT`, the
+shared query helper rejects the call with `PoolExhaustedError` before it enters
+the `pg.Pool` queue. PostgreSQL statement-timeout cancellations (`57014`) are
+mapped to `QueryTimeoutError`.
+
+Both timeout values are read from trusted environment configuration only; HTTP
+request parameters never control `SET statement_timeout`.
 
 ## Security
 
@@ -123,17 +151,26 @@ Connection strings are **never** logged. Only the hostname is extracted
 
 ### Logs to watch
 
-| Log message                                              | Level | Meaning                                    |
-| -------------------------------------------------------- | ----- | ------------------------------------------ |
+| Log message | Level | Meaning |
+| --- | --- | --- |
 | `DATABASE_REPLICA_URL not set — reads will use the primary pool` | info  | No replica configured; using primary       |
 | `Read-replica pool initialised`                          | info  | Replica connected and healthy              |
 | `Replica health-check failed — falling back to primary`  | warn  | Replica unreachable; using primary         |
 | `Replica pool error`                                     | error | Runtime error on an existing replica conn  |
 
-### Health endpoint
+### Metrics
 
-The existing `/health/ready` endpoint reports primary pool metrics. To
-add replica pool metrics, extend the health check in a future iteration.
+The labeled pool gauges distinguish primary and replica saturation:
+
+| Metric | Label | Meaning |
+| --- | --- | --- |
+| `db_pool_active` | `pool="default"` / `pool="read-replica"` | Connections currently checked out |
+| `db_pool_idle` | `pool="default"` / `pool="read-replica"` | Idle connections |
+| `db_pool_waiting` | `pool="default"` / `pool="read-replica"` | Requests queued for a connection |
+
+The legacy unlabeled `fluxora_db_pool_*` gauges remain for backward
+compatibility, while the labeled gauges should be used when alerting on
+replica-specific saturation.
 
 ## Testing
 
@@ -145,9 +182,11 @@ pnpm test -- tests/db/replicaPool.test.ts
 
 The tests cover:
 - Config resolution (with and without `DATABASE_REPLICA_URL`)
+- Replica-specific statement-timeout and queue-limit overrides
 - Health-check success and failure paths
 - Fallback to primary pool
-- Read-only enforcement on connect
+- Read-only enforcement and `statement_timeout` on connect
+- Queue-limit fast-fail and statement-timeout error mapping
 - Singleton caching behaviour
 - Reset / re-initialisation
 

--- a/src/db/replicaPool.ts
+++ b/src/db/replicaPool.ts
@@ -25,7 +25,7 @@ import { logger } from '../lib/logger.js';
 import { getPool, createPool, resolvePoolConfig } from './pool.js';
 import type { PoolConfig } from './pool.js';
 
-const { Pool } = pg;
+const READ_REPLICA_POOL_NAME = 'read-replica';
 
 // ── Internal state ────────────────────────────────────────────────────────────
 
@@ -46,6 +46,13 @@ function safeHostname(connectionString: string): string {
   }
 }
 
+function envInt(name: string, fallback: number): number {
+  const value = process.env[name];
+  if (!value) return fallback;
+  const parsed = parseInt(value, 10);
+  return Number.isFinite(parsed) ? parsed : fallback;
+}
+
 // ── Pool creation ─────────────────────────────────────────────────────────────
 
 /**
@@ -63,22 +70,29 @@ export function resolveReplicaPoolConfig(): PoolConfig | null {
   return {
     ...primaryCfg,
     connectionString: replicaUrl,
+    queueLimit: envInt('DATABASE_REPLICA_POOL_QUEUE_LIMIT', primaryCfg.queueLimit),
+    statementTimeoutMs: envInt(
+      'DATABASE_REPLICA_STATEMENT_TIMEOUT_MS',
+      primaryCfg.statementTimeoutMs,
+    ),
+    poolName: READ_REPLICA_POOL_NAME,
   };
 }
 
 /**
  * Create a pg.Pool for the read replica.
- * Sets `default_transaction_read_only = on` on every new connection so that
- * accidental INSERT/UPDATE/DELETE statements are rejected by PostgreSQL.
+ *
+ * Reuses the primary pool factory so replica reads get the same queue-limit,
+ * statement_timeout, slow-query, and labeled pool telemetry protections as the
+ * primary pool. It then adds `default_transaction_read_only = on` on every new
+ * connection so accidental INSERT/UPDATE/DELETE statements are rejected by
+ * PostgreSQL.
  */
 export function createReplicaPool(config?: PoolConfig): pg.Pool {
   const cfg = config ?? resolveReplicaPoolConfig()!;
-  const pool = new Pool({
-    connectionString: cfg.connectionString,
-    min: cfg.min,
-    max: cfg.max,
-    connectionTimeoutMillis: cfg.connectionTimeoutMillis,
-    idleTimeoutMillis: cfg.idleTimeoutMillis,
+  const pool = createPool({
+    ...cfg,
+    poolName: cfg.poolName ?? READ_REPLICA_POOL_NAME,
   });
 
   // Enforce read-only mode on every physical connection to prevent

--- a/tests/db/replicaPool.test.ts
+++ b/tests/db/replicaPool.test.ts
@@ -53,19 +53,22 @@ const mockPrimaryPool = {
   waitingCount: 0,
 } as unknown as pg.Pool;
 
-vi.mock('../../src/db/pool.js', () => ({
-  getPool: vi.fn(() => mockPrimaryPool),
-  createPool: vi.fn(),
-  resolvePoolConfig: vi.fn(() => ({
-    connectionString: 'postgresql://primary:5432/fluxora',
-    min: 2,
-    max: 10,
-    connectionTimeoutMillis: 5000,
-    idleTimeoutMillis: 30000,
-    queueLimit: 50,
-    statementTimeoutMs: 5000,
-  })),
-}));
+vi.mock('../../src/db/pool.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../src/db/pool.js')>();
+  return {
+    ...actual,
+    getPool: vi.fn(() => mockPrimaryPool),
+    resolvePoolConfig: vi.fn(() => ({
+      connectionString: 'postgresql://primary:5432/fluxora',
+      min: 2,
+      max: 10,
+      connectionTimeoutMillis: 5000,
+      idleTimeoutMillis: 30000,
+      queueLimit: 50,
+      statementTimeoutMs: 5000,
+    })),
+  };
+});
 
 // ── Import SUT (after mocks are registered) ───────────────────────────────────
 
@@ -76,6 +79,7 @@ import {
   checkReplicaHealth,
   createReplicaPool,
 } from '../../src/db/replicaPool.js';
+import { query, PoolExhaustedError, QueryTimeoutError } from '../../src/db/pool.js';
 
 // ── Tests ─────────────────────────────────────────────────────────────────────
 
@@ -108,6 +112,21 @@ describe('replicaPool', () => {
       // Pool sizing should inherit from primary
       expect(config!.min).toBe(2);
       expect(config!.max).toBe(10);
+      expect(config!.queueLimit).toBe(50);
+      expect(config!.statementTimeoutMs).toBe(5000);
+      expect(config!.poolName).toBe('read-replica');
+    });
+
+    it('supports replica-specific timeout and queue-limit overrides', () => {
+      process.env['DATABASE_REPLICA_URL'] = 'postgresql://replica:5432/fluxora';
+      process.env['DATABASE_REPLICA_STATEMENT_TIMEOUT_MS'] = '15000';
+      process.env['DATABASE_REPLICA_POOL_QUEUE_LIMIT'] = '12';
+
+      const config = resolveReplicaPoolConfig();
+
+      expect(config).not.toBeNull();
+      expect(config!.statementTimeoutMs).toBe(15000);
+      expect(config!.queueLimit).toBe(12);
     });
   });
 
@@ -134,7 +153,7 @@ describe('replicaPool', () => {
 
   describe('createReplicaPool', () => {
     it('creates a pool and registers a connect handler for read-only mode', () => {
-      const pool = createReplicaPool({
+      createReplicaPool({
         connectionString: 'postgresql://replica:5432/fluxora',
         min: 1,
         max: 5,
@@ -161,18 +180,96 @@ describe('replicaPool', () => {
         statementTimeoutMs: 3000,
       });
 
-      // Find the 'connect' handler
-      const connectCall = mockOn.mock.calls.find(
+      // Simulate both connect hooks: shared pool protections and read-only mode.
+      const connectCalls = mockOn.mock.calls.filter(
         (call: [string, (...args: unknown[]) => void]) => call[0] === 'connect'
       );
-      expect(connectCall).toBeDefined();
+      expect(connectCalls.length).toBeGreaterThanOrEqual(2);
 
-      // Simulate a new connection
       const mockClient = {
         query: vi.fn().mockResolvedValue(undefined),
       };
-      connectCall![1](mockClient);
+      for (const connectCall of connectCalls) {
+        connectCall[1](mockClient);
+      }
+      expect(mockClient.query).toHaveBeenCalledWith('SET statement_timeout = $1', [3000]);
       expect(mockClient.query).toHaveBeenCalledWith('SET default_transaction_read_only = on');
+    });
+
+    it('keeps read-only mode when replica statement_timeout is disabled', () => {
+      createReplicaPool({
+        connectionString: 'postgresql://replica:5432/fluxora',
+        min: 1,
+        max: 5,
+        connectionTimeoutMillis: 3000,
+        idleTimeoutMillis: 10000,
+        queueLimit: 20,
+        statementTimeoutMs: 0,
+      });
+
+      const connectCalls = mockOn.mock.calls.filter(
+        (call: [string, (...args: unknown[]) => void]) => call[0] === 'connect'
+      );
+      const mockClient = {
+        query: vi.fn().mockResolvedValue(undefined),
+      };
+
+      for (const connectCall of connectCalls) {
+        connectCall[1](mockClient);
+      }
+
+      expect(mockClient.query).toHaveBeenCalledTimes(1);
+      expect(mockClient.query).toHaveBeenCalledWith('SET default_transaction_read_only = on');
+    });
+
+    it('attaches the replica queue limit for the shared query helper', () => {
+      const pool = createReplicaPool({
+        connectionString: 'postgresql://replica:5432/fluxora',
+        min: 1,
+        max: 5,
+        connectionTimeoutMillis: 3000,
+        idleTimeoutMillis: 10000,
+        queueLimit: 7,
+        statementTimeoutMs: 3000,
+      });
+
+      expect((pool as pg.Pool & { _queueLimit?: number })._queueLimit).toBe(7);
+    });
+
+    it('fast-fails replica queries when the queue limit is reached', async () => {
+      const pool = createReplicaPool({
+        connectionString: 'postgresql://replica:5432/fluxora',
+        min: 1,
+        max: 5,
+        connectionTimeoutMillis: 3000,
+        idleTimeoutMillis: 10000,
+        queueLimit: 2,
+        statementTimeoutMs: 3000,
+      });
+      (pool as pg.Pool & { waitingCount: number }).waitingCount = 2;
+      mockQuery.mockClear();
+
+      await expect(query(pool, 'SELECT * FROM streams')).rejects.toBeInstanceOf(PoolExhaustedError);
+      expect(mockQuery).not.toHaveBeenCalled();
+    });
+
+    it('maps replica statement_timeout cancellations to QueryTimeoutError', async () => {
+      const pool = createReplicaPool({
+        connectionString: 'postgresql://replica:5432/fluxora',
+        min: 1,
+        max: 5,
+        connectionTimeoutMillis: 3000,
+        idleTimeoutMillis: 10000,
+        queueLimit: 20,
+        statementTimeoutMs: 3000,
+      });
+      const pgError = Object.assign(
+        new Error('canceling statement due to statement timeout'),
+        { code: '57014' },
+      );
+      mockQuery.mockRejectedValueOnce(pgError);
+
+      await expect(query(pool, 'SELECT pg_sleep(10)')).rejects.toBeInstanceOf(QueryTimeoutError);
     });
   });
 


### PR DESCRIPTION
## Summary
- reuse the primary database pool factory for the read-replica pool so replica reads get the same queue-limit, statement_timeout, slow-query handling, and labeled pool telemetry protections
- add replica-specific `DATABASE_REPLICA_STATEMENT_TIMEOUT_MS` and `DATABASE_REPLICA_POOL_QUEUE_LIMIT` overrides that default to the primary pool settings
- document the replica timeout/queue knobs and the `pool="read-replica"` saturation metrics label

Fixes #354.

## Tests
- `node .\node_modules\eslint\bin\eslint.js src\db\replicaPool.ts tests\db\replicaPool.test.ts`
- `node .\node_modules\vitest\vitest.mjs run tests\db\replicaPool.test.ts tests\db\pool.statementTimeout.test.ts tests\db\pool.exhaustion.test.ts` (55 tests passed)
- `git diff --check`

## Type-check note
- `node .\node_modules\typescript\bin\tsc --noEmit --pretty false` is still blocked by existing `src/openapi/spec.ts` parse errors on current `main`; no touched-file matches were reported for this PR.

## Security notes
- statement timeout values are read only from trusted environment configuration, not request input
- replica metrics use the fixed application-controlled `read-replica` label, not user-supplied data
- read-only enforcement remains applied on every replica connection via `SET default_transaction_read_only = on`