### PR TITLE
feat(ws): add heartbeat reaping

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -64,6 +64,10 @@ SSE_MAX_GLOBAL_CONNECTIONS=1000
 SSE_MAX_CONNECTION_DURATION_MS=1800000
 SSE_RETRY_AFTER_SECONDS=15
 WS_AUTH_REQUIRED=false
+# WebSocket heartbeat. The hub sends ping control frames on this interval and
+# terminates sockets that do not answer before the timeout window.
+WS_HEARTBEAT_INTERVAL_MS=30000
+WS_HEARTBEAT_TIMEOUT_MS=60000
 
 # =============================================================================
 # Request Handling

--- a/docs/security/websocket-rate-limiting.md
+++ b/docs/security/websocket-rate-limiting.md
@@ -15,6 +15,29 @@ The following environment variables control the connection limiting behavior:
 | `WS_MAX_CONNECTIONS_PER_IP` | `10` | Maximum number of concurrent WebSocket connections allowed from a single IP. |
 | `WS_ABUSE_THRESHOLD` | `5` | Number of rejected connection attempts allowed within a sliding window before an IP is banned. |
 | `WS_BAN_TTL_S` | `3600` | Duration (in seconds) for which an IP is banned after triggering the abuse threshold. |
+| `WS_HEARTBEAT_INTERVAL_MS` | `30000` | Interval between server ping control frames sent to connected clients. |
+| `WS_HEARTBEAT_TIMEOUT_MS` | `60000` | Time a socket may wait for a pong response before the hub terminates it. |
+
+## Heartbeat Reaping
+
+The WebSocket hub sends periodic ping control frames to every connected client.
+Each connection is marked alive when it is accepted and again whenever the
+server receives a `pong` frame. If a socket does not answer the latest ping
+within `WS_HEARTBEAT_TIMEOUT_MS`, the hub terminates it and runs the normal
+disconnect cleanup path.
+
+This cleanup path removes stream and recipient subscriptions and decrements the
+per-IP connection count maintained by the limiter. As a result, half-open
+connections behind proxies or firewalls cannot keep occupying an IP's
+connection slots forever.
+
+Heartbeat pongs are only liveness signals. They do not reset abuse-ban state,
+increase rate limits, or let a banned IP bypass `WS_MAX_CONNECTIONS_PER_IP`.
+
+```env
+WS_HEARTBEAT_INTERVAL_MS=30000
+WS_HEARTBEAT_TIMEOUT_MS=60000
+```
 
 ## Connection Rejection
 

--- a/src/ws/hub.ts
+++ b/src/ws/hub.ts
@@ -66,6 +66,8 @@ export const RATE_LIMIT_WINDOW_MS = 10_000;
 export const BACKPRESSURE_DROP_BYTES = 1 * 1024 * 1024;
 export const BACKPRESSURE_TERMINATE_BYTES = 4 * 1024 * 1024;
 export const FANOUT_YIELD_BATCH = 256;
+export const DEFAULT_HEARTBEAT_INTERVAL_MS = 30_000;
+export const DEFAULT_HEARTBEAT_TIMEOUT_MS = 60_000;
 
 // ── Types ─────────────────────────────────────────────────────────────────────
 
@@ -112,6 +114,10 @@ interface ClientState {
   metrics: ConnectionMetrics;
   subscriptionFilters: Map<string, SubscriptionFilter>;
   messageTimestamps: number[];
+  isAlive: boolean;
+  awaitingPong: boolean;
+  lastPongAt: number;
+  lastPingAt?: number;
 }
 
 // ── Hub options ───────────────────────────────────────────────────────────────
@@ -133,6 +139,16 @@ export interface StreamHubOptions {
    * When absent, replayFromCursor sends an empty result.
    */
   eventStore?: ContractEventStore;
+  /**
+   * Milliseconds between server ping frames. Defaults to
+   * WS_HEARTBEAT_INTERVAL_MS or 30 seconds.
+   */
+  heartbeatIntervalMs?: number;
+  /**
+   * Milliseconds a socket may go without answering the latest ping before the
+   * hub terminates it. Defaults to WS_HEARTBEAT_TIMEOUT_MS or 60 seconds.
+   */
+  heartbeatTimeoutMs?: number;
 }
 
 // ── Hub ───────────────────────────────────────────────────────────────────────
@@ -146,6 +162,9 @@ export class StreamHub extends EventEmitter {
   private readonly ownsDedup: boolean;
   private readonly wsAuthRequired: boolean;
   private readonly jwtSecret: string | undefined;
+  private readonly heartbeatIntervalMs: number;
+  private readonly heartbeatTimeoutMs: number;
+  private heartbeatInterval: NodeJS.Timeout | undefined;
   private eventStore: ContractEventStore | undefined;
 
   public getEventStore(): ContractEventStore | undefined {
@@ -177,6 +196,17 @@ export class StreamHub extends EventEmitter {
     this.jwtSecret = options?.jwtSecret ?? process.env.JWT_SECRET;
 
     this.eventStore = options?.eventStore;
+
+    this.heartbeatIntervalMs = this.resolvePositiveInteger(
+      options?.heartbeatIntervalMs,
+      'WS_HEARTBEAT_INTERVAL_MS',
+      DEFAULT_HEARTBEAT_INTERVAL_MS,
+    );
+    this.heartbeatTimeoutMs = this.resolvePositiveInteger(
+      options?.heartbeatTimeoutMs,
+      'WS_HEARTBEAT_TIMEOUT_MS',
+      DEFAULT_HEARTBEAT_TIMEOUT_MS,
+    );
 
     // Use noServer mode so we fully control the upgrade handshake.
     this.wss = new WebSocketServer({ noServer: true });
@@ -219,6 +249,8 @@ export class StreamHub extends EventEmitter {
     this.wss.on('connection', (ws: WebSocket, req: IncomingMessage) => {
       this.onConnect(ws, req);
     });
+
+    this.startHeartbeat();
   }
 
   // ── Connection lifecycle ───────────────────────────────────────────────────
@@ -238,6 +270,9 @@ export class StreamHub extends EventEmitter {
       metrics: { messagesReceived: 0, messagesSent: 0, bytesReceived: 0, bytesSent: 0 },
       subscriptionFilters: new Map(),
       messageTimestamps: [],
+      isAlive: true,
+      awaitingPong: false,
+      lastPongAt: connectedAt,
     };
     if (correlationId !== undefined) {
       state.correlationId = correlationId;
@@ -285,6 +320,7 @@ export class StreamHub extends EventEmitter {
       this.handleMessage(ws, raw);
     });
 
+    ws.on('pong', () => this.markAlive(ws));
     ws.on('close', (code, reason) => this.onDisconnect(ws, code, reason));
     ws.on('error', () => ws.close(1011, 'Internal Error'));
   }
@@ -310,6 +346,74 @@ export class StreamHub extends EventEmitter {
     });
 
     this.clients.delete(ws);
+  }
+
+  /**
+   * Send periodic WebSocket ping control frames and reap half-open sockets that
+   * stop answering. Reaping routes through onDisconnect so connection-limiter
+   * counters and subscription indexes are released exactly once.
+   */
+  private startHeartbeat(): void {
+    if (this.heartbeatInterval !== undefined) return;
+    this.heartbeatInterval = setInterval(() => this.runHeartbeat(), this.heartbeatIntervalMs);
+    this.heartbeatInterval.unref?.();
+  }
+
+  private stopHeartbeat(): void {
+    if (this.heartbeatInterval === undefined) return;
+    clearInterval(this.heartbeatInterval);
+    this.heartbeatInterval = undefined;
+  }
+
+  private runHeartbeat(now = Date.now()): void {
+    for (const [ws, state] of this.clients) {
+      if (ws.readyState !== WebSocket.OPEN) continue;
+
+      if (
+        state.awaitingPong &&
+        state.lastPingAt !== undefined &&
+        now - state.lastPingAt >= this.heartbeatTimeoutMs
+      ) {
+        this.reapDeadConnection(ws, state, now - state.lastPingAt);
+        continue;
+      }
+
+      if (state.awaitingPong) continue;
+
+      state.isAlive = false;
+      state.awaitingPong = true;
+      state.lastPingAt = now;
+      try {
+        ws.ping();
+      } catch {
+        this.reapDeadConnection(ws, state, 0);
+      }
+    }
+  }
+
+  private markAlive(ws: WebSocket): void {
+    const state = this.clients.get(ws);
+    if (!state) return;
+    state.isAlive = true;
+    state.awaitingPong = false;
+    state.lastPongAt = Date.now();
+    delete state.lastPingAt;
+  }
+
+  private reapDeadConnection(ws: WebSocket, state: ClientState, missedMs: number): void {
+    logger.warn('WebSocket heartbeat missed; terminating stale connection', state.correlationId, {
+      event: 'ws_heartbeat_reap',
+      connectionId: state.id,
+      ip: state.ip,
+      missedMs,
+    });
+
+    try {
+      ws.terminate();
+    } catch {
+      // no-op
+    }
+    this.onDisconnect(ws, 4000, Buffer.from('heartbeat-timeout'));
   }
 
   // ── Rate limiting ──────────────────────────────────────────────────────────
@@ -723,6 +827,15 @@ export class StreamHub extends EventEmitter {
     if (ws.readyState === WebSocket.OPEN) ws.send(JSON.stringify({ type: 'error', code, message }));
   }
 
+  private resolvePositiveInteger(
+    optionValue: number | undefined,
+    envName: string,
+    fallback: number,
+  ): number {
+    const raw = optionValue ?? Number.parseInt(process.env[envName] ?? '', 10);
+    return Number.isSafeInteger(raw) && raw > 0 ? raw : fallback;
+  }
+
   get clientCount(): number {
     return this.clients.size;
   }
@@ -821,6 +934,7 @@ export class StreamHub extends EventEmitter {
   }
 
   async close(cb?: () => void): Promise<void> {
+    this.stopHeartbeat();
     if (this.ownsDedup) await this.dedup.close();
     this.wss.close(cb);
   }

--- a/tests/ws.test.ts
+++ b/tests/ws.test.ts
@@ -19,26 +19,29 @@ import {
   StreamHubOptions,
   MAX_MESSAGE_BYTES,
   RATE_LIMIT_MAX,
-  RATE_LIMIT_WINDOW_MS,
 } from '../src/ws/hub.js';
-import { InMemoryDedupCache } from '../src/redis/dedup.js';
+import { _resetLimiter } from '../src/ws/connectionLimiter.js';
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
-function createTestServer(): { server: http.Server; hub: StreamHub; port: number } {
+async function setup(): Promise<{ server: http.Server; hub: StreamHub; port: number }> {
+  _resetLimiter();
   const server = http.createServer();
   const hub = new StreamHub(server);
-  return new Promise<{ server: http.Server; hub: StreamHub; port: number }>((resolve) => {
+  return new Promise((resolve) => {
     server.listen(0, '127.0.0.1', () => {
       const addr = server.address() as { port: number };
       resolve({ server, hub, port: addr.port });
     });
-  }) as unknown as { server: http.Server; hub: StreamHub; port: number };
+  });
 }
 
-async function setup(): Promise<{ server: http.Server; hub: StreamHub; port: number }> {
+async function setupWithOptions(
+  options: StreamHubOptions,
+): Promise<{ server: http.Server; hub: StreamHub; port: number }> {
+  _resetLimiter();
   const server = http.createServer();
-  const hub = new StreamHub(server);
+  const hub = new StreamHub(server, options);
   return new Promise((resolve) => {
     server.listen(0, '127.0.0.1', () => {
       const addr = server.address() as { port: number };
@@ -439,11 +442,13 @@ describe('WebSocket hub — RPC dependency failure modes', () => {
 });
 
 describe('WebSocket hub — backpressure strategy', () => {
+  const originalEnv = { ...process.env };
   let server: http.Server;
   let hub: StreamHub;
   let port: number;
 
   beforeEach(async () => {
+    process.env = { ...originalEnv, WS_MAX_CONNECTIONS_PER_IP: '512' };
     ({ server, hub, port } = await setup());
     hub._resetDedup();
     hub._resetMetrics();
@@ -451,6 +456,8 @@ describe('WebSocket hub — backpressure strategy', () => {
 
   afterEach(async () => {
     await teardown(server, hub);
+    _resetLimiter();
+    process.env = originalEnv;
   });
 
   it('preserves decimal-string payload fields verbatim (no Number coercion)', async () => {
@@ -691,6 +698,83 @@ describe('WebSocket hub — backpressure strategy', () => {
   });
 });
 
+describe('WebSocket hub — heartbeat reaping', () => {
+  const originalEnv = { ...process.env };
+  let server: http.Server;
+  let hub: StreamHub;
+  let port: number;
+
+  beforeEach(async () => {
+    process.env = { ...originalEnv, WS_MAX_CONNECTIONS_PER_IP: '1' };
+    _resetLimiter();
+    ({ server, hub, port } = await setupWithOptions({
+      heartbeatIntervalMs: 10_000,
+      heartbeatTimeoutMs: 5,
+    }));
+  });
+
+  afterEach(async () => {
+    await teardown(server, hub);
+    _resetLimiter();
+    process.env = originalEnv;
+  });
+
+  it('pings connected sockets and marks them alive on pong', async () => {
+    const ws = await connect(port);
+    const serverSocket = Array.from((hub as any).clients.keys())[0] as WebSocket;
+    const pingSpy = vi.spyOn(serverSocket, 'ping').mockImplementation(() => undefined);
+
+    (hub as any).runHeartbeat(1_000);
+
+    const state = (hub as any).clients.get(serverSocket) as any;
+    expect(pingSpy).toHaveBeenCalledTimes(1);
+    expect(state.awaitingPong).toBe(true);
+    expect(state.isAlive).toBe(false);
+
+    serverSocket.emit('pong', Buffer.alloc(0));
+
+    expect(state.awaitingPong).toBe(false);
+    expect(state.isAlive).toBe(true);
+    expect(state.lastPingAt).toBeUndefined();
+
+    ws.close();
+  });
+
+  it('terminates half-open sockets and releases the per-IP connection slot', async () => {
+    const staleClient = await connect(port);
+    const serverSocket = Array.from((hub as any).clients.keys())[0] as WebSocket;
+    vi.spyOn(serverSocket, 'ping').mockImplementation(() => undefined);
+    const terminateSpy = vi.spyOn(serverSocket, 'terminate').mockImplementation(() => undefined);
+
+    (hub as any).runHeartbeat(2_000);
+    (hub as any).runHeartbeat(2_006);
+
+    expect(terminateSpy).toHaveBeenCalledTimes(1);
+    expect(hub.clientCount).toBe(0);
+
+    const replacement = await connect(port);
+    await sleep(30);
+    expect(hub.clientCount).toBe(1);
+
+    staleClient.close();
+    replacement.close();
+  });
+
+  it('clears the heartbeat interval on close', async () => {
+    expect((hub as any).heartbeatInterval).toBeDefined();
+
+    await teardown(server, hub);
+
+    expect((hub as any).heartbeatInterval).toBeUndefined();
+
+    // afterEach should not close it again.
+    server = http.createServer();
+    hub = new StreamHub(server, { heartbeatIntervalMs: 10_000, heartbeatTimeoutMs: 5 });
+    await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+    port = (server.address() as { port: number }).port;
+  });
+});
+
 describe('WebSocket hub — observability and metrics', () => {
   let server: http.Server;
   let hub: StreamHub;
@@ -781,6 +865,7 @@ function makeToken(payload: object = { sub: 'user-1' }, secret = TEST_JWT_SECRET
 }
 
 async function setupWithAuth(opts: { wsAuthRequired: boolean; jwtSecret?: string } = { wsAuthRequired: true }): Promise<{ server: http.Server; hub: StreamHub; port: number }> {
+  _resetLimiter();
   const server = http.createServer();
   const hub = new StreamHub(server, {
     wsAuthRequired: opts.wsAuthRequired,
@@ -936,6 +1021,7 @@ function makeStoreRecord(eventId: string, ledger: number, topic = 'stream.create
 }
 
 async function setupWithStore(store: InMemoryContractEventStore): Promise<{ server: http.Server; hub: StreamHub; port: number }> {
+  _resetLimiter();
   const server = http.createServer();
   const hub = new StreamHub(server, { eventStore: store });
   return new Promise((resolve) => {


### PR DESCRIPTION
## Summary
- add configurable WebSocket ping/pong heartbeat settings (`WS_HEARTBEAT_INTERVAL_MS`, `WS_HEARTBEAT_TIMEOUT_MS`)
- mark sockets alive on connect/pong and terminate sockets that miss the heartbeat timeout
- route heartbeat reaping through the normal disconnect cleanup so subscriptions and per-IP limiter counters are released
- document heartbeat behavior and isolate WebSocket limiter state in the ws test fixture

Fixes #356.

## Tests
- `node .\node_modules\vitest\vitest.mjs run tests\ws.test.ts -t heartbeat` (3 heartbeat tests passed)
- `node .\node_modules\vitest\vitest.mjs run tests\ws.test.ts` (47 tests passed)
- `node .\node_modules\eslint\bin\eslint.js src\ws\hub.ts tests\ws.test.ts` (0 errors; existing `no-explicit-any` warnings remain in the legacy ws test file)
- `git diff --check`

## Type-check note
- `node .\node_modules\typescript\bin\tsc --noEmit --pretty false` is still blocked by existing `src/openapi/spec.ts` parse errors on current `main`; no touched-file matches were reported for this PR.

## Security notes
- pong frames only refresh liveness and do not reset abuse-ban state or bypass per-IP connection caps
- reaped sockets call the same disconnect cleanup path as normal closes, which decrements limiter counts exactly once
- heartbeat intervals are trusted server-side config/options, not client-controlled input