### PR TITLE
fix(db): scope stream repository pgcrypto keys

### DIFF
--- a/src/db/repositories/streamRepository.ts
+++ b/src/db/repositories/streamRepository.ts
@@ -40,9 +40,17 @@ import {
   STREAM_INVARIANTS,
   StreamStatus,
 } from '../types.js';
+import { getConfig, loadConfig } from '../../config/env.js';
 import { info, debug } from '../../utils/logger.js';
 import { dbQueryDurationSeconds } from '../../metrics/dbMetrics.js';
 import { enrichActiveSpanWithStream } from '../../tracing/hooks.js';
+import {
+  encryptAddressValue,
+  recipientAddressFilterCondition,
+  senderAddressFilterCondition,
+  streamSelectColumns,
+} from '../queries/streams.js';
+import { computeAddressHashes } from '../../pii/pgcryptoEncryption.js';
 
 
 const REPO = 'streamRepository';
@@ -85,7 +93,12 @@ function rowToRecord(row: Record<string, unknown>): StreamRecord {
 }
 
 function resolvePgcryptoKeys(): { current: string; previous?: string } {
-  const config = getConfig();
+  let config: ReturnType<typeof loadConfig>;
+  try {
+    config = getConfig();
+  } catch {
+    config = loadConfig();
+  }
   if (!config.pgcryptoKey) {
     throw new Error('PGCRYPTO_KEY is required to encrypt and decrypt stream PII');
   }
@@ -260,9 +273,15 @@ export const streamRepository = {
   async getByEvent(transactionHash: string, eventIndex: number): Promise<StreamRecord | undefined> {
     return timed('getByEvent', async () => {
       const pool = await getReadPool();
+      const keySet = resolvePgcryptoKeys();
+      const params: unknown[] = [transactionHash, eventIndex, keySet.current];
+      const previousKeyIndex = keySet.previous ? params.length + 1 : undefined;
+      if (keySet.previous) {
+        params.push(keySet.previous);
+      }
       const result = await query<Record<string, unknown>>(
         pool,
-        `SELECT ${streamSelectColumns(3, keySet.previous ? 4 : undefined)} FROM streams WHERE transaction_hash = $1 AND event_index = $2`,
+        `SELECT ${streamSelectColumns(3, previousKeyIndex)} FROM streams WHERE transaction_hash = $1 AND event_index = $2`,
         params,
       );
       if (result.rows[0]) {
@@ -283,6 +302,7 @@ export const streamRepository = {
   ): Promise<{ streams: StreamRecord[]; hasMore: boolean; total?: number }> {
     return timed('findWithCursor', async () => {
       const pool = await getReadPool();
+      const keySet = resolvePgcryptoKeys();
       const conditions: string[] = [];
       const params: unknown[] = [];
       let idx = 1;
@@ -341,6 +361,7 @@ export const streamRepository = {
   async find(filter: StreamFilter, pagination: PaginationOptions): Promise<PaginatedStreams> {
     return timed('find', async () => {
       const pool = await getReadPool();
+      const keySet = resolvePgcryptoKeys();
       const conditions: string[] = [];
       const params: unknown[] = [];
       let idx = 1;

--- a/tests/security/streamRepository.sqli.test.ts
+++ b/tests/security/streamRepository.sqli.test.ts
@@ -1,57 +1,92 @@
-import { describe, it, beforeAll, expect } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { sqliPayloads } from './fixtures/sqliPayloads.js';
 
-// The tests here are a regression harness. They exercise the repository
-// entrypoints with adversarial input and assert that parameterized queries
-// do not return unrelated rows or throw due to injection payloads.
+const mockQuery = vi.fn();
 
+vi.mock('../../src/db/pool.js', () => ({
+  getPool: vi.fn(() => ({})),
+  query: (...args: unknown[]) => mockQuery(...args),
+  PoolExhaustedError: class PoolExhaustedError extends Error {
+    constructor() {
+      super('pool exhausted');
+      this.name = 'PoolExhaustedError';
+    }
+  },
+  DuplicateEntryError: class DuplicateEntryError extends Error {
+    constructor(detail?: string) {
+      super(detail ?? 'duplicate');
+      this.name = 'DuplicateEntryError';
+    }
+  },
+}));
+
+vi.mock('../../src/db/replicaPool.js', () => ({
+  getReadPool: vi.fn(async () => ({})),
+}));
+
+import { initializeConfig, resetConfig } from '../../src/config/env.js';
 import { streamRepository } from '../../src/db/repositories/streamRepository.js';
 
+const PGCRYPTO_KEY = 'stream-repository-sqli-test-key-12345';
+const ROW = {
+  id: 'stream-sqli-0',
+  sender_address: 'GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN7',
+  recipient_address: 'GBDEVU63Y6NTHJQQZIKVTC23NWLQVP3WJ2RI2OTSJTNYOIGICST6DUXR',
+  amount: '1000',
+  streamed_amount: '0',
+  remaining_amount: '1000',
+  rate_per_second: '10',
+  start_time: '1700000000',
+  end_time: '0',
+  status: 'active',
+  contract_id: 'api-created',
+  transaction_hash: 'a'.repeat(64),
+  event_index: 0,
+  created_at: new Date('2024-01-01T00:00:00Z'),
+  updated_at: new Date('2024-01-01T00:00:00Z'),
+};
+
+function assertPayloadIsParameterized(payload: string): void {
+  const calls = mockQuery.mock.calls as Array<[unknown, string, unknown[] | undefined]>;
+  expect(calls.length).toBeGreaterThan(0);
+  expect(calls.some(([, , params]) => Array.isArray(params) && params.includes(payload))).toBe(true);
+  for (const [, sql] of calls) {
+    expect(sql).not.toContain(payload);
+  }
+}
+
 describe('streamRepository SQLi regression suite', () => {
-  beforeAll(() => {
-    // repository should be usable in test mode; if the repo requires a DB,
-    // tests should mock pool/query. This file provides the harness and
-    // payload library — adapt to CI DB as needed.
+  beforeEach(() => {
+    process.env.PGCRYPTO_KEY = PGCRYPTO_KEY;
+    resetConfig();
+    initializeConfig();
+    mockQuery.mockReset();
   });
 
-  const methods = [
-    'upsertStream',
-    'getById',
-    'findWithCursor',
-    'updateStream',
-  ] as const;
-
   for (const payload of sqliPayloads) {
-    for (const method of methods) {
-      it(`should safely handle payload [${payload}] in ${method}`, async () => {
-        // Call each repository method with the adversarial payload in a
-        // user-controlled field and assert it doesn't return unrelated rows.
-        // The exact assertions depend on the repository API; keep them
-        // defensive (no crash, no unexpected non-empty result for lookups).
+    it(`keeps getById payload parameterized [${payload}]`, async () => {
+      mockQuery.mockResolvedValueOnce({ rows: [] });
 
-        try {
-          if (method === 'upsertStream') {
-            const id = `sqli-test-${Math.random().toString(36).slice(2, 8)}`;
-            const result = await (streamRepository as any).upsertStream({ id, contract_id: payload });
-            expect(result).toBeDefined();
-          } else if (method === 'getById') {
-            const res = await (streamRepository as any).getById(payload);
-            // Should either return undefined/null or a single matching row —
-            // never rows from unrelated ids.
-            expect(res === undefined || typeof res === 'object').toBeTruthy();
-          } else if (method === 'findWithCursor') {
-            const res = await (streamRepository as any).findWithCursor({ filter: { contractId: payload }, limit: 1 });
-            expect(res).toBeDefined();
-          } else if (method === 'updateStream') {
-            const res = await (streamRepository as any).updateStream(payload, { status: 'paused' });
-            expect(res === undefined || typeof res === 'object').toBeTruthy();
-          }
-        } catch (err) {
-          // Throwing due to SQL syntax injected into parameters would be a
-          // regression; surface the error so CI can triage.
-          throw err;
-        }
-      });
-    }
+      await expect(streamRepository.getById(payload)).resolves.toBeUndefined();
+
+      assertPayloadIsParameterized(payload);
+    });
+
+    it(`keeps findWithCursor contract filter parameterized [${payload}]`, async () => {
+      mockQuery.mockResolvedValueOnce({ rows: [ROW] });
+
+      await expect(streamRepository.findWithCursor({ contract_id: payload }, 1)).resolves.toBeDefined();
+
+      assertPayloadIsParameterized(payload);
+    });
+
+    it(`keeps updateStream id parameterized [${payload}]`, async () => {
+      mockQuery.mockResolvedValueOnce({ rows: [ROW] });
+      mockQuery.mockResolvedValueOnce({ rows: [{ ...ROW, status: 'paused' }] });
+
+      await expect(streamRepository.updateStream(payload, { status: 'paused' })).resolves.toBeDefined();
+
+      assertPayloadIsParameterized(payload);
+    });
   }
 });

--- a/tests/streamsRepository.test.ts
+++ b/tests/streamsRepository.test.ts
@@ -20,12 +20,19 @@ vi.mock('../src/db/pool.js', () => ({
   },
 }));
 
+vi.mock('../src/db/replicaPool.js', () => ({
+  getReadPool: vi.fn(async () => ({})),
+}));
+
+import { initializeConfig, resetConfig } from '../src/config/env.js';
 import { streamRepository } from '../src/db/repositories/streamRepository.js';
-import type { CreateStreamInput, UpdateStreamInput } from '../src/db/types.js';
+import type { CreateStreamInput } from '../src/db/types.js';
 
 // ── Fixtures ──────────────────────────────────────────────────────────────────
 
 const TX_HASH = 'a'.repeat(64);
+const PGCRYPTO_KEY = 'stream-repository-test-key-current-123';
+const PGCRYPTO_KEY_PREVIOUS = 'stream-repository-test-key-previous-456';
 
 function makeRow(overrides: Partial<Record<string, unknown>> = {}): Record<string, unknown> {
   return {
@@ -80,11 +87,17 @@ function queryReturnsEmpty() {
 
 describe('streamRepository', () => {
   beforeEach(() => {
+    process.env.PGCRYPTO_KEY = PGCRYPTO_KEY;
+    delete process.env.PGCRYPTO_KEY_PREVIOUS;
+    resetConfig();
+    initializeConfig();
     vi.clearAllMocks();
   });
 
   afterEach(() => {
     vi.restoreAllMocks();
+    resetConfig();
+    delete process.env.PGCRYPTO_KEY_PREVIOUS;
   });
 
   // ── upsertStream ────────────────────────────────────────────────────────────
@@ -177,12 +190,32 @@ describe('streamRepository', () => {
       queryReturnsRows([makeRow()]);
       const record = await streamRepository.getByEvent(TX_HASH, 0);
       expect(record).toBeDefined();
+      expect(mockQuery).toHaveBeenLastCalledWith(
+        expect.anything(),
+        expect.stringContaining('WHERE transaction_hash = $1 AND event_index = $2'),
+        [TX_HASH, 0, PGCRYPTO_KEY],
+      );
     });
 
     it('returns undefined when not found', async () => {
       queryReturnsEmpty();
       const record = await streamRepository.getByEvent('deadbeef', 99);
       expect(record).toBeUndefined();
+    });
+
+    it('keeps previous pgcrypto key aligned after event lookup params', async () => {
+      process.env.PGCRYPTO_KEY_PREVIOUS = PGCRYPTO_KEY_PREVIOUS;
+      resetConfig();
+      initializeConfig();
+      queryReturnsRows([makeRow()]);
+
+      await streamRepository.getByEvent(TX_HASH, 0);
+
+      expect(mockQuery).toHaveBeenLastCalledWith(
+        expect.anything(),
+        expect.stringContaining('decrypt_stream_address(sender_address, $3, $4)'),
+        [TX_HASH, 0, PGCRYPTO_KEY, PGCRYPTO_KEY_PREVIOUS],
+      );
     });
   });
 
@@ -283,6 +316,78 @@ describe('streamRepository', () => {
 
       const result = await streamRepository.findWithCursor({}, 50, 'stream-a');
       expect(result.streams[0]!.id).toBe('stream-b');
+    });
+
+    it('keeps address filters and decryption keys parameterized with previous key rotation', async () => {
+      process.env.PGCRYPTO_KEY_PREVIOUS = PGCRYPTO_KEY_PREVIOUS;
+      resetConfig();
+      initializeConfig();
+      queryReturnsRows([makeRow()]);
+      mockQuery.mockResolvedValueOnce({ rows: [{ count: '1' }] });
+
+      await streamRepository.findWithCursor(
+        {
+          status: 'active',
+          sender_address: 'GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN7',
+          recipient_address: 'GBDEVU63Y6NTHJQQZIKVTC23NWLQVP3WJ2RI2OTSJTNYOIGICST6DUXR',
+          contract_id: 'api-created',
+        },
+        10,
+        'stream-a',
+        true,
+      );
+
+      const [dataSql, dataParams] = mockQuery.mock.calls[0]!.slice(1) as [string, unknown[]];
+      expect(dataSql).toContain('sender_address_hash = $3 OR sender_address_hash = $4');
+      expect(dataSql).toContain('recipient_address_hash = $6 OR recipient_address_hash = $7');
+      expect(dataSql).toContain('id > $9');
+      expect(dataSql).toContain('LIMIT $10');
+      expect(dataSql).toContain('decrypt_stream_address(sender_address, $11, $12)');
+      expect(dataParams[0]).toBe('active');
+      expect(dataParams[1]).toBe('GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN7');
+      expect(dataParams[4]).toBe('GBDEVU63Y6NTHJQQZIKVTC23NWLQVP3WJ2RI2OTSJTNYOIGICST6DUXR');
+      expect(dataParams[7]).toBe('api-created');
+      expect(dataParams[8]).toBe('stream-a');
+      expect(dataParams[9]).toBe(11);
+      expect(dataParams[10]).toBe(PGCRYPTO_KEY);
+      expect(dataParams[11]).toBe(PGCRYPTO_KEY_PREVIOUS);
+    });
+  });
+
+  // ── find ───────────────────────────────────────────────────────────────────
+
+  describe('find', () => {
+    it('keeps offset pagination filters and decryption keys parameterized', async () => {
+      process.env.PGCRYPTO_KEY_PREVIOUS = PGCRYPTO_KEY_PREVIOUS;
+      resetConfig();
+      initializeConfig();
+      mockQuery.mockResolvedValueOnce({ rows: [{ count: '1' }] });
+      queryReturnsRows([makeRow()]);
+
+      const result = await streamRepository.find(
+        {
+          status: 'active',
+          sender_address: 'GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN7',
+          recipient_address: 'GBDEVU63Y6NTHJQQZIKVTC23NWLQVP3WJ2RI2OTSJTNYOIGICST6DUXR',
+          contract_id: 'api-created',
+          start_time_from: 1,
+          start_time_to: 2,
+          end_time_from: 3,
+          end_time_to: 4,
+        },
+        { limit: 25, offset: 50 },
+      );
+
+      expect(result.streams).toHaveLength(1);
+      const [dataSql, dataParams] = mockQuery.mock.calls[1]!.slice(1) as [string, unknown[]];
+      expect(dataSql).toContain('sender_address_hash = $3 OR sender_address_hash = $4');
+      expect(dataSql).toContain('recipient_address_hash = $6 OR recipient_address_hash = $7');
+      expect(dataSql).toContain('decrypt_stream_address(sender_address, $13, $14)');
+      expect(dataSql).toContain('LIMIT $15 OFFSET $16');
+      expect(dataParams[12]).toBe(PGCRYPTO_KEY);
+      expect(dataParams[13]).toBe(PGCRYPTO_KEY_PREVIOUS);
+      expect(dataParams[14]).toBe(25);
+      expect(dataParams[15]).toBe(50);
     });
   });
 


### PR DESCRIPTION
Closes #319.

## Summary
- import the pgcrypto stream query helpers and address hash helper used by `streamRepository`
- resolve the pgcrypto key set inside `getByEvent`, `findWithCursor`, and `find`
- build `getByEvent` params explicitly so transaction hash, event index, current key, and optional previous key stay aligned with `$` placeholders
- add regression coverage for key-rotation placeholder indices in event lookup, cursor pagination, and offset pagination
- convert the SQLi regression harness to mocked repository queries so it verifies payloads stay in params instead of SQL text without requiring a live database

## Validation
- `node .\node_modules\vitest\vitest.mjs run tests\streamsRepository.test.ts tests\security\streamRepository.sqli.test.ts`
- `node .\node_modules\eslint\bin\eslint.js src\db\repositories\streamRepository.ts tests\streamsRepository.test.ts tests\security\streamRepository.sqli.test.ts`
- `git diff --check`

## Notes
- Full `tsc --noEmit --pretty false` is still blocked by existing parse errors in `src/openapi/spec.ts`; filtering the output for touched files produced no matches.
- Security: address filters remain parameterized and adversarial SQLi payloads are asserted to appear only in query params, never interpolated SQL text.