### PR TITLE
feat(dlq): suspend dead replay consumers

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 High-performance contract event indexer with optimized batch processing and PostgreSQL indexing for efficient historical event replay.
 
-## 🚀 Features
+## ?? Features
 
 - **Batch Insert Processing**: 50x faster than single-row inserts
 - **Optimized Database Indexes**: Composite and partial indexes for replay queries
@@ -11,13 +11,13 @@ High-performance contract event indexer with optimized batch processing and Post
 - **Security Hardened**: Parameterized queries, input validation, concurrent operation prevention
 - **Comprehensive Testing**: 80%+ code coverage with edge case handling
 
-## 📋 Requirements
+## ?? Requirements
 
 - Node.js 18+
 - PostgreSQL 12+
 - pnpm (or npm/yarn)
 
-## 🛠️ Installation
+## ??? Installation
 
 ```bash
 # Install dependencies
@@ -30,7 +30,7 @@ cp .env.example .env
 # DATABASE_URL=postgresql://user:password@localhost:5432/indexer_db
 ```
 
-## 🗄️ Database Setup
+## ??? Database Setup
 
 ```bash
 # Run migrations to create tables and indexes
@@ -42,7 +42,7 @@ This creates:
 - `contract_events` table (replay destination)
 - Optimized indexes for replay queries
 
-## 🏃 Running the Service
+## ?? Running the Service
 
 ```bash
 # Development mode
@@ -55,7 +55,7 @@ node dist/src/index.js
 
 The service will start on port 3000 (configurable via `PORT` environment variable).
 
-## 📡 API Usage
+## ?? API Usage
 
 ### Start a Replay
 
@@ -105,7 +105,7 @@ Response:
 }
 ```
 
-## 🧪 Testing
+## ?? Testing
 
 ```bash
 # Run all tests
@@ -121,18 +121,18 @@ pnpm test tests/indexer/service.replay.test.ts
 ### Test Coverage
 
 The test suite includes:
-- ✅ Input validation (invalid parameters)
-- ✅ Empty replay sets
-- ✅ Batch processing with various sizes
-- ✅ Batch boundary alignment
-- ✅ Duplicate event handling (ON CONFLICT)
-- ✅ Concurrent replay prevention
-- ✅ Transaction rollback on errors
-- ✅ Progress tracking and estimation
-- ✅ Block range filtering
-- ✅ SQL injection prevention
+- ? Input validation (invalid parameters)
+- ? Empty replay sets
+- ? Batch processing with various sizes
+- ? Batch boundary alignment
+- ? Duplicate event handling (ON CONFLICT)
+- ? Concurrent replay prevention
+- ? Transaction rollback on errors
+- ? Progress tracking and estimation
+- ? Block range filtering
+- ? SQL injection prevention
 
-## ⚙️ Configuration
+## ?? Configuration
 
 ### Environment Variables
 
@@ -145,10 +145,10 @@ The test suite includes:
 ### Batch Size Tuning
 
 - **Small (100-500)**: Lower memory, more round-trips
-- **Medium (1000-2000)**: Balanced performance ⭐ recommended
+- **Medium (1000-2000)**: Balanced performance ? recommended
 - **Large (5000+)**: Faster bulk operations, higher memory
 
-## 🔒 Security
+## ?? Security
 
 ### Implemented Protections
 
@@ -171,7 +171,7 @@ Target URLs, webhook secrets, signatures, and raw payloads are intentionally omi
 
 ### Production Recommendations
 
-⚠️ The `/internal/indexer/*` endpoints are **not authenticated** by default.
+?? The `/internal/indexer/*` endpoints are **not authenticated** by default.
 
 Before deploying to production:
 
@@ -189,7 +189,7 @@ Additional recommendations:
 - Use API keys or JWT tokens
 - Enable HTTPS/TLS
 
-## 📊 Performance
+## ?? Performance
 
 ### Batch Insert Performance
 
@@ -205,7 +205,7 @@ For a table with 10M events:
 - Unindexed query: ~30-60 seconds
 - Indexed query: ~10-50 milliseconds
 
-## 📚 Documentation
+## ?? Documentation
 
 See [docs/indexer.md](docs/indexer.md) for comprehensive documentation including:
 - Detailed API reference
@@ -214,29 +214,29 @@ See [docs/indexer.md](docs/indexer.md) for comprehensive documentation including
 - Troubleshooting guide
 - Monitoring recommendations
 
-## 🏗️ Architecture
+## ??? Architecture
 
 ```
 src/
-├── config/          # Configuration management
-├── db/              # Database client and connection pooling
-├── indexer/         # Core replay service logic
-├── routes/          # Express route handlers
-└── types/           # TypeScript type definitions
+??? config/          # Configuration management
+??? db/              # Database client and connection pooling
+??? indexer/         # Core replay service logic
+??? routes/          # Express route handlers
+??? types/           # TypeScript type definitions
 
 migrations/
-├── 000_initial_schema.ts              # Create tables
-└── 001_add_contract_events_replay_indexes.ts  # Add indexes
+??? 000_initial_schema.ts              # Create tables
+??? 001_add_contract_events_replay_indexes.ts  # Add indexes
 
 tests/
-└── indexer/
-    └── service.replay.test.ts         # Comprehensive test suite
+??? indexer/
+    ??? service.replay.test.ts         # Comprehensive test suite
 
 docs/
-└── indexer.md                         # Full documentation
+??? indexer.md                         # Full documentation
 ```
 
-## 🔄 Development Workflow
+## ?? Development Workflow
 
 ### Suggested Execution
 
@@ -245,12 +245,12 @@ docs/
    git checkout -b feature/indexer-replay-batching
    ```
 
-2. **Implement changes**: ✅ Complete
-   - ✅ Batch insert logic in `src/indexer/service.ts`
-   - ✅ Index migration in `migrations/001_add_contract_events_replay_indexes.ts`
-   - ✅ Progress API in `src/routes/indexer.ts`
-   - ✅ Comprehensive tests in `tests/indexer/service.replay.test.ts`
-   - ✅ Documentation in `docs/indexer.md`
+2. **Implement changes**: ? Complete
+   - ? Batch insert logic in `src/indexer/service.ts`
+   - ? Index migration in `migrations/001_add_contract_events_replay_indexes.ts`
+   - ? Progress API in `src/routes/indexer.ts`
+   - ? Comprehensive tests in `tests/indexer/service.replay.test.ts`
+   - ? Documentation in `docs/indexer.md`
 
 3. **Test**:
    ```bash
@@ -263,7 +263,7 @@ docs/
    git commit -m "perf: batch contract-event replay inserts and add targeted DB indexes"
    ```
 
-## 🐛 Troubleshooting
+## ?? Troubleshooting
 
 ### Replay Times Out
 - Reduce `REPLAY_BATCH_SIZE`
@@ -285,15 +285,25 @@ See [docs/indexer.md](docs/indexer.md) for detailed troubleshooting.
 Outbound webhook retries use two Redis-backed per-consumer controls:
 
 - **Rate limiting** (`src/redis/webhookRateLimit.ts`): sliding-window cap via `WEBHOOK_RETRY_RPS` (default `10`/s).
-- **Circuit breaker** (`src/redis/webhookCircuitBreakerStore.ts`): shared `closed` → `open` → `half-open` state keyed by SHA-256 hash of the consumer URL. After `circuitBreakerThreshold` consecutive failures, deliveries are deferred until `circuitBreakerResetMs`, then a single cross-instance probe is allowed.
+- **Circuit breaker** (`src/redis/webhookCircuitBreakerStore.ts`): shared `closed` ? `open` ? `half-open` state keyed by SHA-256 hash of the consumer URL. After `circuitBreakerThreshold` consecutive failures, deliveries are deferred until `circuitBreakerResetMs`, then a single cross-instance probe is allowed.
 
 `attemptWebhookDeliveryWithRateLimit` in `src/webhooks/retry.ts` applies both gates before each delivery. State transitions emit `fluxora_webhook_circuit_breaker_transitions_total`. See [docs/webhooks.md](docs/webhooks.md) for details.
 
-## 📝 License
+### DLQ replay suspension
+
+The admin DLQ API tracks consecutive replay failures per consumer endpoint URL when webhook deliveries return to the DLQ. Set `DLQ_REPLAY_SUSPEND_THRESHOLD` to control how many consecutive failures suspend a consumer; the default is `3`.
+
+- `GET /admin/dlq` and `GET /admin/dlq/:id` include a `consumerReplay` summary with `consumerUrlHash`, `consecutiveFailures`, `suspended`, and `suspendedAt` when the DLQ payload identifies an endpoint.
+- `POST /admin/dlq/:id/replay` returns `409 DLQ_CONSUMER_SUSPENDED` while the consumer is suspended.
+- `POST /admin/dlq/consumers/reenable` with `{ "consumerUrl": "https://consumer.example/webhook" }` resets the failure counter and allows operators to replay entries again.
+
+Suspension and re-enable actions emit audit events keyed by a hash of the consumer URL so operator logs do not expose third-party endpoint URLs.
+
+## ?? License
 
 MIT
 
-## 🤝 Contributing
+## ?? Contributing
 
 1. Fork the repository
 2. Create a feature branch

--- a/migrations/1774715400000_dlq-consumer-replay-state.ts
+++ b/migrations/1774715400000_dlq-consumer-replay-state.ts
@@ -1,0 +1,24 @@
+import { ColumnDefinitions, MigrationBuilder } from 'node-pg-migrate';
+
+export const shorthands: ColumnDefinitions | undefined = undefined;
+
+export async function up(pgm: MigrationBuilder): Promise<void> {
+  pgm.createTable('dlq_consumer_replay_state', {
+    consumer_url_hash: { type: 'text', primaryKey: true },
+    consumer_url: { type: 'text', notNull: true },
+    consecutive_failures: { type: 'integer', notNull: true, default: 0 },
+    suspended: { type: 'boolean', notNull: true, default: false },
+    suspended_at: { type: 'timestamp with time zone', notNull: false },
+    updated_at: {
+      type: 'timestamp with time zone',
+      notNull: true,
+      default: pgm.func('current_timestamp'),
+    },
+  });
+
+  pgm.createIndex('dlq_consumer_replay_state', 'suspended');
+}
+
+export async function down(pgm: MigrationBuilder): Promise<void> {
+  pgm.dropTable('dlq_consumer_replay_state');
+}

--- a/src/db/repositories/dlqRepository.ts
+++ b/src/db/repositories/dlqRepository.ts
@@ -1,7 +1,8 @@
 import { getPool, query } from '../pool.js';
-import type { DlqEntry } from '../../routes/dlq.js';
+import type { DlqConsumerReplayState, DlqEntry } from '../../routes/dlq.js';
+import { hashDlqConsumerUrl } from '../../lib/dlqConsumer.js';
 
-// ── Internal helpers ──────────────────────────────────────────────────────────
+// ?? Internal helpers ??????????????????????????????????????????????????????????
 
 function rowToEntry(row: Record<string, unknown>): DlqEntry {
   return {
@@ -16,7 +17,23 @@ function rowToEntry(row: Record<string, unknown>): DlqEntry {
   };
 }
 
-// ── Repository ────────────────────────────────────────────────────────────────
+function nullableDateToIso(value: unknown): string | undefined {
+  if (!value) return undefined;
+  return value instanceof Date ? value.toISOString() : new Date(String(value)).toISOString();
+}
+
+function rowToConsumerReplayState(row: Record<string, unknown>): DlqConsumerReplayState {
+  return {
+    consumerUrl: row['consumer_url'] as string,
+    consumerUrlHash: row['consumer_url_hash'] as string,
+    consecutiveFailures: Number(row['consecutive_failures'] ?? 0),
+    suspended: Boolean(row['suspended']),
+    suspendedAt: nullableDateToIso(row['suspended_at']),
+    updatedAt: nullableDateToIso(row['updated_at']) ?? new Date(0).toISOString(),
+  };
+}
+
+// ?? Repository ????????????????????????????????????????????????????????????????
 
 export const dlqRepository = {
   async insert(entry: DlqEntry): Promise<void> {
@@ -105,5 +122,86 @@ export const dlqRepository = {
     }
     const result = await query(pool, 'DELETE FROM dead_letter_queue');
     return result.rowCount ?? 0;
+  },
+
+  async deleteAllConsumerReplayStates(): Promise<number> {
+    const pool = getPool();
+    const result = await query(pool, 'DELETE FROM dlq_consumer_replay_state');
+    return result.rowCount ?? 0;
+  },
+
+  async findConsumerReplayState(consumerUrl: string): Promise<DlqConsumerReplayState | undefined> {
+    const pool = getPool();
+    const result = await query<Record<string, unknown>>(
+      pool,
+      'SELECT * FROM dlq_consumer_replay_state WHERE consumer_url_hash = $1',
+      [hashDlqConsumerUrl(consumerUrl)],
+    );
+    return result.rows[0] ? rowToConsumerReplayState(result.rows[0]) : undefined;
+  },
+
+  async findConsumerReplayStates(consumerUrls: string[]): Promise<Map<string, DlqConsumerReplayState>> {
+    const uniqueUrls = Array.from(new Set(consumerUrls));
+    if (uniqueUrls.length === 0) return new Map();
+
+    const pool = getPool();
+    const hashes = uniqueUrls.map(hashDlqConsumerUrl);
+    const result = await query<Record<string, unknown>>(
+      pool,
+      'SELECT * FROM dlq_consumer_replay_state WHERE consumer_url_hash = ANY($1::text[])',
+      [hashes],
+    );
+
+    const byUrl = new Map<string, DlqConsumerReplayState>();
+    for (const row of result.rows) {
+      const state = rowToConsumerReplayState(row);
+      byUrl.set(state.consumerUrl, state);
+    }
+    return byUrl;
+  },
+
+  async recordConsumerReplayFailure(consumerUrl: string, threshold: number): Promise<DlqConsumerReplayState> {
+    const pool = getPool();
+    const hash = hashDlqConsumerUrl(consumerUrl);
+    const result = await query<Record<string, unknown>>(
+      pool,
+      `
+        INSERT INTO dlq_consumer_replay_state
+          (consumer_url_hash, consumer_url, consecutive_failures, suspended, suspended_at, updated_at)
+        VALUES ($1, $2, 1, $3, CASE WHEN $3 THEN NOW() ELSE NULL END, NOW())
+        ON CONFLICT (consumer_url_hash) DO UPDATE SET
+          consumer_url = EXCLUDED.consumer_url,
+          consecutive_failures = dlq_consumer_replay_state.consecutive_failures + 1,
+          suspended = dlq_consumer_replay_state.suspended
+            OR (dlq_consumer_replay_state.consecutive_failures + 1 >= $4),
+          suspended_at = CASE
+            WHEN dlq_consumer_replay_state.suspended THEN dlq_consumer_replay_state.suspended_at
+            WHEN dlq_consumer_replay_state.consecutive_failures + 1 >= $4 THEN NOW()
+            ELSE NULL
+          END,
+          updated_at = NOW()
+        RETURNING *
+      `,
+      [hash, consumerUrl, 1 >= threshold, threshold],
+    );
+    return rowToConsumerReplayState(result.rows[0]!);
+  },
+
+  async reenableConsumer(consumerUrl: string): Promise<DlqConsumerReplayState | undefined> {
+    const pool = getPool();
+    const result = await query<Record<string, unknown>>(
+      pool,
+      `
+        UPDATE dlq_consumer_replay_state
+        SET consecutive_failures = 0,
+            suspended = false,
+            suspended_at = NULL,
+            updated_at = NOW()
+        WHERE consumer_url_hash = $1
+        RETURNING *
+      `,
+      [hashDlqConsumerUrl(consumerUrl)],
+    );
+    return result.rows[0] ? rowToConsumerReplayState(result.rows[0]) : undefined;
   },
 };

--- a/src/lib/auditLog.ts
+++ b/src/lib/auditLog.ts
@@ -6,13 +6,13 @@
  * in this module mutates or removes existing records.
  *
  * Three write paths:
- *  1. `recordAuditEvent`          – in-memory only; never throws; used by
+ *  1. `recordAuditEvent`          - in-memory only; never throws; used by
  *                                   non-transactional callers (admin routes, etc.)
  *  2. `buildAuditEntry` +
- *     `writeAuditEntryToDb`       – used inside DB transactions so the audit
+ *     `writeAuditEntryToDb`       - used inside DB transactions so the audit
  *                                   row is committed or rolled back atomically
  *                                   with the primary stream operation.
- *  3. `recordAuditEventToDb`       – non-transactional helper that writes to
+ *  3. `recordAuditEventToDb`       - non-transactional helper that writes to
  *                                   the shared Postgres audit table and then
  *                                   mirrors the entry into the in-memory log.
  *
@@ -30,7 +30,7 @@
 import { logger } from './logger.js';
 import { getPool, query } from '../db/pool.js';
 
-export type AuditAction = 'STREAM_CREATED' | 'STREAM_CANCELLED' | 'STREAM_STATUS_UPDATED' | 'DLQ_LISTED' | 'DLQ_REPLAYED' | 'DLQ_PURGED' | 'PAUSE_FLAGS_UPDATED' | 'REINDEX_TRIGGERED' | 'API_KEY_CREATED' | 'API_KEY_ROTATED' | 'API_KEY_REVOKED';
+export type AuditAction = 'STREAM_CREATED' | 'STREAM_CANCELLED' | 'STREAM_STATUS_UPDATED' | 'DLQ_LISTED' | 'DLQ_REPLAYED' | 'DLQ_PURGED' | 'DLQ_CONSUMER_SUSPENDED' | 'DLQ_CONSUMER_REENABLED' | 'PAUSE_FLAGS_UPDATED' | 'REINDEX_TRIGGERED' | 'API_KEY_CREATED' | 'API_KEY_ROTATED' | 'API_KEY_REVOKED';
 
 /**
  * Minimal prepare/run shape used by {@link writeAuditEntryToDb}.
@@ -77,7 +77,7 @@ function appendAuditEntry(entry: AuditEntry): void {
   });
 }
 
-// ── In-memory path (non-transactional) ───────────────────────────────────────
+// ?? In-memory path (non-transactional) ???????????????????????????????????????
 
 /**
  * Append an audit entry to the in-memory log. Never throws.
@@ -112,7 +112,7 @@ export function recordAuditEvent(
   }
 }
 
-// ── Transactional path (DB-backed) ───────────────────────────────────────────
+// ?? Transactional path (DB-backed) ???????????????????????????????????????????
 
 /**
  * Build an AuditEntry without writing it anywhere.
@@ -196,7 +196,7 @@ export async function recordAuditEventToDb(
   return entry;
 }
 
-// ── Queries ───────────────────────────────────────────────────────────────────
+// ?? Queries ???????????????????????????????????????????????????????????????????
 
 /** Return a shallow copy of all in-memory entries (oldest first). */
 export function getAuditEntries(): AuditEntry[] {
@@ -204,9 +204,9 @@ export function getAuditEntries(): AuditEntry[] {
   return [...(log ?? [])];
 }
 
-// ── Test helpers ──────────────────────────────────────────────────────────────
+// ?? Test helpers ??????????????????????????????????????????????????????????????
 
-/** Reset store — test use only. */
+/** Reset store - test use only. */
 export function _resetAuditLog(): void {
   const log = (globalThis as Record<string, unknown>)[AUDIT_LOG_KEY];
   if (Array.isArray(log)) {

--- a/src/lib/dlqConsumer.ts
+++ b/src/lib/dlqConsumer.ts
@@ -1,0 +1,62 @@
+import { createHash } from 'node:crypto';
+
+const URL_FIELDS = ['consumerUrl', 'endpointUrl', 'webhookUrl', 'url'];
+const NESTED_FIELDS = ['originalDelivery', 'delivery', 'webhook', 'endpoint'];
+
+/** Normalize a DLQ consumer endpoint to a stable http(s) URL string. */
+export function normalizeDlqConsumerUrl(value: unknown): string | undefined {
+  if (typeof value !== 'string' || value.trim() === '') return undefined;
+
+  try {
+    const parsed = new URL(value.trim());
+    if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') return undefined;
+    parsed.hash = '';
+    return parsed.toString();
+  } catch {
+    return undefined;
+  }
+}
+
+/** Hash the endpoint before storing it in audit metadata or Redis-style keys. */
+export function hashDlqConsumerUrl(consumerUrl: string): string {
+  return createHash('sha256').update(consumerUrl).digest('hex').slice(0, 16);
+}
+
+function objectRecord(value: unknown): Record<string, unknown> | undefined {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) return undefined;
+  return value as Record<string, unknown>;
+}
+
+function parsePayload(payload: unknown): unknown {
+  if (typeof payload !== 'string') return payload;
+  try {
+    return JSON.parse(payload);
+  } catch {
+    return payload;
+  }
+}
+
+/**
+ * Extract the target consumer URL from the DLQ payload shapes produced by the
+ * webhook delivery store and the durable outbox dispatcher.
+ */
+export function extractDlqConsumerUrl(payload: unknown): string | undefined {
+  const record = objectRecord(parsePayload(payload));
+  if (!record) return undefined;
+
+  for (const key of URL_FIELDS) {
+    const url = normalizeDlqConsumerUrl(record[key]);
+    if (url) return url;
+  }
+
+  for (const key of NESTED_FIELDS) {
+    const nested = objectRecord(record[key]);
+    if (!nested) continue;
+    for (const urlKey of URL_FIELDS) {
+      const url = normalizeDlqConsumerUrl(nested[urlKey]);
+      if (url) return url;
+    }
+  }
+
+  return undefined;
+}

--- a/src/openapi/spec.ts
+++ b/src/openapi/spec.ts
@@ -14,7 +14,7 @@ extendZodWithOpenApi(z);
 
 export const registry = new OpenAPIRegistry();
 
-// ── Shared schemas ────────────────────────────────────────────────────────────
+// ?? Shared schemas ????????????????????????????????????????????????????????????
 
 const DecimalString = registry.register(
   'DecimalString',
@@ -23,7 +23,7 @@ const DecimalString = registry.register(
 
 const StellarAddress = registry.register(
   'StellarAddress',
-  z.string().openapi({ example: 'GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN', description: 'Stellar public key (G…)' }),
+  z.string().openapi({ example: 'GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN', description: 'Stellar public key (G.)' }),
 );
 
 const StreamStatus = registry.register(
@@ -67,7 +67,7 @@ const ErrorEnvelope = registry.register(
   }),
 );
 
-// ── Security schemes ──────────────────────────────────────────────────────────
+// ?? Security schemes ??????????????????????????????????????????????????????????
 
 registry.registerComponent('securitySchemes', 'bearerAuth', {
   type: 'http',
@@ -83,7 +83,7 @@ registry.registerComponent('securitySchemes', 'indexerWorkerToken', {
   description: 'Static shared secret for internal indexer worker endpoints',
 });
 
-// ── Reusable response helpers ─────────────────────────────────────────────────
+// ?? Reusable response helpers ?????????????????????????????????????????????????
 
 function successSchema<T extends z.ZodTypeAny>(dataSchema: T) {
   return z.object({ success: z.literal(true), data: dataSchema, meta: ResponseMeta });
@@ -102,7 +102,7 @@ const errorResponses = {
   '503': { description: 'Service unavailable', content: { 'application/json': { schema: ErrorEnvelope } } },
 } as const;
 
-// ── GET / ─────────────────────────────────────────────────────────────────────
+// ?? GET / ?????????????????????????????????????????????????????????????????????
 
 registry.registerPath({
   method: 'get', path: '/',
@@ -116,7 +116,7 @@ registry.registerPath({
   },
 });
 
-// ── Health ────────────────────────────────────────────────────────────────────
+// ?? Health ????????????????????????????????????????????????????????????????????
 
 registry.registerPath({
   method: 'get', path: '/health',
@@ -167,7 +167,7 @@ registry.registerPath({
   },
 });
 
-// ── Streams ───────────────────────────────────────────────────────────────────
+// ?? Streams ???????????????????????????????????????????????????????????????????
 
 /**
  * Cursor semantics for GET /api/streams
@@ -176,7 +176,7 @@ registry.registerPath({
  *   Each cursor is an opaque base64url token. Internally it encodes a
  *   version-tagged JSON object `{ v: 1, lastId: "<stream-id>" }`, where
  *   `lastId` is the `id` of the last stream returned on the previous page.
- *   Clients MUST treat cursors as black boxes — the internal structure is
+ *   Clients MUST treat cursors as black boxes - the internal structure is
  *   not part of the public API and may change without notice. Do not
  *   construct or decode cursors manually.
  *
@@ -191,7 +191,7 @@ registry.registerPath({
  *   issued do not invalidate it, because the query uses a keyset condition
  *   (`id > lastId`). However, a cursor referencing a deleted or
  *   compacted stream id will simply skip to the next matching row without
- *   error — the client observes a gap, not a failure.
+ *   error - the client observes a gap, not a failure.
  *
  *   A structurally invalid cursor (wrong base64url encoding, missing version
  *   tag, or empty `lastId`) is rejected immediately with 400
@@ -208,7 +208,7 @@ registry.registerPath({
  *   2. If `has_more` is `true`, pass the returned `next_cursor` as the
  *      `cursor` parameter to fetch the next page.
  *   3. When `has_more` is `false`, `next_cursor` is `null` and you are on
- *      the last page — stop iterating.
+ *      the last page - stop iterating.
  */
 
 /** Cursor token schema with full semantics documented. */
@@ -250,6 +250,7 @@ const StreamListPage = registry.register(
 );
 
 /** 400 body specific to invalid/expired cursor. */
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 const InvalidCursorError = z.object({
   success: z.literal(false),
   error: z.object({
@@ -271,15 +272,15 @@ registry.registerPath({
   summary: 'List streams (cursor-paginated)',
   description:
     '## Cursor Pagination\n\n' +
-    '**Encoding** — `next_cursor` is an opaque base64url token (`{ v: 1, lastId }` internally). ' +
+    '**Encoding** - `next_cursor` is an opaque base64url token (`{ v: 1, lastId }` internally). ' +
     'Never construct or decode it manually; the internal format may change.\n\n' +
-    '**Security** — Cursors do not contain raw database row ids or PII. ' +
+    '**Security** - Cursors do not contain raw database row ids or PII. ' +
     'The embedded `lastId` is the same application-level id that appears in list responses. ' +
     'Server-side ownership scoping is re-applied on every request.\n\n' +
-    '**Stability** — Cursors survive concurrent inserts (keyset semantics: `id > lastId`). ' +
+    '**Stability** - Cursors survive concurrent inserts (keyset semantics: `id > lastId`). ' +
     'Deleting the row referenced by a cursor does not cause an error; the next matching row is returned.\n\n' +
-    '**Ordering** — Pages are returned in ascending `id` order (deterministic lexicographic sort).\n\n' +
-    '**Invalid cursor** — A malformed or tampered cursor returns `400 VALIDATION_ERROR` with ' +
+    '**Ordering** - Pages are returned in ascending `id` order (deterministic lexicographic sort).\n\n' +
+    '**Invalid cursor** - A malformed or tampered cursor returns `400 VALIDATION_ERROR` with ' +
     '`message: "cursor must be a valid opaque pagination token"` before any database access. ' +
     'Discard the cursor and restart from page 1.',
   tags: ['streams'],
@@ -287,13 +288,13 @@ registry.registerPath({
     query: z.object({
       limit: z.string().optional().openapi({
         example: '20',
-        description: 'Page size (1–100, default 20).',
+        description: 'Page size (1-100, default 20).',
       }),
       cursor: z.string().optional().openapi({
         description:
-          'Opaque cursor from the previous page's `next_cursor`. ' +
+          "Opaque cursor from the previous page's `next_cursor`. " +
           'Omit to request the first page. ' +
-          'Treated as a black box — do not construct manually.',
+          'Treated as a black box - do not construct manually.',
         example: 'eyJ2IjoxLCJsYXN0SWQiOiJzdHJlYW0tYWJjMTIzIn0',
       }),
       status: z.string().optional().openapi({ example: 'active' }),
@@ -372,7 +373,7 @@ registry.registerPath({
             lastPage: {
               summary: 'Last page (has_more=false, next_cursor=null)',
               description:
-                'When `has_more` is `false`, `next_cursor` is `null` — stop iterating. ' +
+                'When `has_more` is `false`, `next_cursor` is `null` - stop iterating. ' +
                 'The `streams` array may be empty if no rows remain after the cursor.',
               value: {
                 success: true,
@@ -401,7 +402,7 @@ registry.registerPath({
     },
     '400': {
       description:
-        'Validation error. Also returned for an invalid or expired cursor — ' +
+        'Validation error. Also returned for an invalid or expired cursor - ' +
         '`error.code` will be `"VALIDATION_ERROR"` and ' +
         '`error.message` will be `"cursor must be a valid opaque pagination token"`. ' +
         'Discard the cursor and restart pagination from page 1 (omit `cursor`).',
@@ -472,7 +473,7 @@ registry.registerPath({
   tags: ['streams'],
   security: [{ bearerAuth: [] }],
   request: {
-    headers: z.object({ 'Idempotency-Key': z.string().openapi({ description: 'Unique key (1–128 chars) to prevent duplicate creation', example: 'my-key-001' }) }),
+    headers: z.object({ 'Idempotency-Key': z.string().openapi({ description: 'Unique key (1-128 chars) to prevent duplicate creation', example: 'my-key-001' }) }),
     body: {
       required: true,
       content: {
@@ -551,7 +552,7 @@ registry.registerPath({
   },
 });
 
-// ── Auth ──────────────────────────────────────────────────────────────────────
+// ?? Auth ??????????????????????????????????????????????????????????????????????
 
 registry.registerPath({
   method: 'post', path: '/api/auth/session',
@@ -586,7 +587,7 @@ registry.registerPath({
   },
 });
 
-// ── Audit ─────────────────────────────────────────────────────────────────────
+// ?? Audit ?????????????????????????????????????????????????????????????????????
 
 registry.registerPath({
   method: 'get', path: '/api/audit',
@@ -610,7 +611,7 @@ registry.registerPath({
   },
 });
 
-// ── Privacy ───────────────────────────────────────────────────────────────────
+// ?? Privacy ???????????????????????????????????????????????????????????????????
 
 registry.registerPath({
   method: 'get', path: '/api/privacy/policy',
@@ -630,7 +631,7 @@ registry.registerPath({
   },
 });
 
-// ── Admin ─────────────────────────────────────────────────────────────────────
+// ?? Admin ?????????????????????????????????????????????????????????????????????
 
 registry.registerPath({
   method: 'get', path: '/api/admin/status/read-only',
@@ -765,7 +766,7 @@ registry.registerPath({
   },
 });
 
-// ── DLQ ───────────────────────────────────────────────────────────────────────
+// ?? DLQ ???????????????????????????????????????????????????????????????????????
 
 registry.registerPath({
   method: 'get', path: '/admin/dlq',
@@ -816,20 +817,44 @@ registry.registerPath({
 });
 
 registry.registerPath({
-  method: 'post', path: '/admin/dlq/{id}/retry',
-  summary: 'Retry DLQ entry',
+  method: 'post', path: '/admin/dlq/{id}/replay',
+  summary: 'Replay DLQ entry',
   tags: ['admin'],
   security: [{ bearerAuth: [] }],
   request: { params: z.object({ id: z.string() }) },
   responses: {
-    '200': { description: 'Retry queued', content: { 'application/json': { schema: z.record(z.string(), z.unknown()) } } },
+    '200': { description: 'Replay queued', content: { 'application/json': { schema: z.record(z.string(), z.unknown()) } } },
+    '401': errorResponses['401'],
+    '403': errorResponses['403'],
+    '409': { description: 'Consumer is suspended' },
+    '404': errorResponses['404'],
+  },
+});
+
+registry.registerPath({
+  method: 'post', path: '/admin/dlq/consumers/reenable',
+  summary: 'Re-enable a suspended DLQ consumer',
+  tags: ['admin'],
+  security: [{ bearerAuth: [] }],
+  request: {
+    body: {
+      content: {
+        'application/json': {
+          schema: z.object({ consumerUrl: z.string().url() }),
+        },
+      },
+    },
+  },
+  responses: {
+    '200': { description: 'Consumer re-enabled', content: { 'application/json': { schema: z.record(z.string(), z.unknown()) } } },
+    '400': errorResponses['400'],
     '401': errorResponses['401'],
     '403': errorResponses['403'],
     '404': errorResponses['404'],
   },
 });
 
-// ── Rate limits ───────────────────────────────────────────────────────────────
+// ?? Rate limits ???????????????????????????????????????????????????????????????
 
 registry.registerPath({
   method: 'get', path: '/api/rate-limits',
@@ -879,7 +904,7 @@ registry.registerPath({
   },
 });
 
-// ── Internal indexer ──────────────────────────────────────────────────────────
+// ?? Internal indexer ??????????????????????????????????????????????????????????
 
 registry.registerPath({
   method: 'post', path: '/internal/indexer/contract-events',
@@ -949,7 +974,7 @@ registry.registerPath({
   },
 });
 
-// ── Webhooks ──────────────────────────────────────────────────────────────────
+// ?? Webhooks ??????????????????????????????????????????????????????????????????
 
 registry.registerPath({
   method: 'post', path: '/internal/webhooks/receive',
@@ -983,7 +1008,7 @@ registry.registerPath({
   },
 });
 
-// ── Metrics ───────────────────────────────────────────────────────────────────
+// ?? Metrics ???????????????????????????????????????????????????????????????????
 
 registry.registerPath({
   method: 'get', path: '/metrics',
@@ -994,7 +1019,7 @@ registry.registerPath({
   },
 });
 
-// ── Generator ─────────────────────────────────────────────────────────────────
+// ?? Generator ?????????????????????????????????????????????????????????????????
 
 /**
  * Build and return the complete OpenAPI 3.1 document.

--- a/src/routes/dlq.ts
+++ b/src/routes/dlq.ts
@@ -1,22 +1,22 @@
 /**
- * Dead-Letter Queue (DLQ) Inspection API — Admin Only
+ * Dead-Letter Queue (DLQ) Inspection API - Admin Only
  *
- * Issue #43 — Dead-letter queue inspection API (admin-only)
+ * Issue #43 - Dead-letter queue inspection API (admin-only)
  *
  * Trust boundaries
  * ----------------
  * - Public internet clients:       403 Forbidden on all routes.
- * - Authenticated partners:        403 Forbidden — operator role required.
+ * - Authenticated partners:        403 Forbidden - operator role required.
  * - Administrators (operator role): Full read + delete access.
  * - Internal workers:              Call enqueueDeadLetter() directly; not exposed via HTTP.
  *
  * Failure modes
  * -------------
- * - No auth header          → 401 UNAUTHORIZED
- * - Valid token, wrong role → 403 FORBIDDEN
- * - Entry not found         → 404 NOT_FOUND
- * - Invalid pagination      → 400 VALIDATION_ERROR
- * - Dependency outage       → 503 SERVICE_UNAVAILABLE (future)
+ * - No auth header          ? 401 UNAUTHORIZED
+ * - Valid token, wrong role ? 403 FORBIDDEN
+ * - Entry not found         ? 404 NOT_FOUND
+ * - Invalid pagination      ? 400 VALIDATION_ERROR
+ * - Dependency outage       ? 503 SERVICE_UNAVAILABLE (future)
  *
  * @openapi
  * /admin/dlq:
@@ -84,6 +84,7 @@ import { info } from '../utils/logger.js';
 import { recordAuditEvent } from '../lib/auditLog.js';
 import { successResponse, errorResponse } from '../utils/response.js';
 import { dlqRepository } from '../db/repositories/dlqRepository.js';
+import { extractDlqConsumerUrl, hashDlqConsumerUrl, normalizeDlqConsumerUrl } from '../lib/dlqConsumer.js';
 
 /** Shape of a dead-letter entry */
 export interface DlqEntry {
@@ -95,6 +96,88 @@ export interface DlqEntry {
   firstFailedAt: string;
   lastFailedAt: string;
   correlationId?: string;
+}
+
+export interface DlqConsumerReplayState {
+  consumerUrl: string;
+  consumerUrlHash: string;
+  consecutiveFailures: number;
+  suspended: boolean;
+  suspendedAt?: string;
+  updatedAt: string;
+}
+
+interface DlqConsumerReplaySummary {
+  consumerUrlHash: string;
+  consecutiveFailures: number;
+  suspended: boolean;
+  suspendedAt?: string;
+}
+
+type DlqEntryResponse = DlqEntry & {
+  consumerReplay?: DlqConsumerReplaySummary;
+};
+
+function getReplaySuspendThreshold(): number {
+  const parsed = Number.parseInt(process.env.DLQ_REPLAY_SUSPEND_THRESHOLD ?? '', 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : 3;
+}
+
+function summarizeConsumerReplayState(state: DlqConsumerReplayState): DlqConsumerReplaySummary {
+  return {
+    consumerUrlHash: state.consumerUrlHash,
+    consecutiveFailures: state.consecutiveFailures,
+    suspended: state.suspended,
+    ...(state.suspendedAt ? { suspendedAt: state.suspendedAt } : {}),
+  };
+}
+
+async function annotateConsumerReplayState(entries: DlqEntry[]): Promise<DlqEntryResponse[]> {
+  const consumerUrls = entries
+    .map((entry) => extractDlqConsumerUrl(entry.payload))
+    .filter((url): url is string => url !== undefined);
+  const states = await dlqRepository.findConsumerReplayStates(consumerUrls);
+
+  return entries.map((entry) => {
+    const consumerUrl = extractDlqConsumerUrl(entry.payload);
+    if (!consumerUrl) return entry;
+
+    const state = states.get(consumerUrl);
+    return {
+      ...entry,
+      consumerReplay: state
+        ? summarizeConsumerReplayState(state)
+        : {
+            consumerUrlHash: hashDlqConsumerUrl(consumerUrl),
+            consecutiveFailures: 0,
+            suspended: false,
+          },
+    };
+  });
+}
+
+async function recordDlqReplayFailureIfConsumerKnown(entry: DlqEntry): Promise<void> {
+  const consumerUrl = extractDlqConsumerUrl(entry.payload);
+  if (!consumerUrl) return;
+
+  const threshold = getReplaySuspendThreshold();
+  const previous = await dlqRepository.findConsumerReplayState(consumerUrl);
+  const next = await dlqRepository.recordConsumerReplayFailure(consumerUrl, threshold);
+
+  if (next.suspended && !previous?.suspended) {
+    recordAuditEvent(
+      'DLQ_CONSUMER_SUSPENDED',
+      'dlq_consumer',
+      next.consumerUrlHash,
+      entry.correlationId,
+      {
+        consecutiveFailures: next.consecutiveFailures,
+        threshold,
+        dlqEntryId: entry.id,
+        topic: entry.topic,
+      },
+    );
+  }
 }
 
 /** Enqueue a dead-letter entry. Called by internal workers. */
@@ -109,7 +192,14 @@ export async function enqueueDeadLetter(
     lastFailedAt: now,
   };
   await dlqRepository.insert(full);
+  await recordDlqReplayFailureIfConsumerKnown(full);
   return full;
+}
+
+/** Reset DLQ state. Test use only. */
+export async function _resetDlq(): Promise<void> {
+  await dlqRepository.deleteAll();
+  await dlqRepository.deleteAllConsumerReplayStates();
 }
 
 export const dlqRouter = Router();
@@ -150,17 +240,18 @@ dlqRouter.get(
 
     const topic = typeof topicFilter === 'string' && topicFilter.trim() !== '' ? topicFilter.trim() : undefined;
     const { entries, total } = await dlqRepository.findAll({ limit, offset, topic });
+    const entriesWithConsumerState = await annotateConsumerReplayState(entries);
 
-    info('DLQ entries listed', { total, returned: entries.length, offset, limit, requestId });
+    info('DLQ entries listed', { total, returned: entriesWithConsumerState.length, offset, limit, requestId });
 
-    recordAuditEvent('DLQ_LISTED', 'dlq', 'list', requestId, { total, returned: entries.length, offset, limit, topicFilter });
+    recordAuditEvent('DLQ_LISTED', 'dlq', 'list', requestId, { total, returned: entriesWithConsumerState.length, offset, limit, topicFilter });
 
     res.json(successResponse({
-      entries,
+      entries: entriesWithConsumerState,
       total,
       limit,
       offset,
-      has_more: offset + entries.length < total,
+      has_more: offset + entriesWithConsumerState.length < total,
     }));
   }),
 );
@@ -178,7 +269,47 @@ dlqRouter.get(
       res.status(404).json(errorResponse('NOT_FOUND', `DLQ entry '${req.params.id}' not found`, undefined, req.id));
       return;
     }
-    res.json(successResponse({ entry }, req.id));
+    const [entryWithConsumerState] = await annotateConsumerReplayState([entry]);
+    res.json(successResponse({ entry: entryWithConsumerState }, req.id));
+  }),
+);
+
+/**
+ * POST /admin/dlq/consumers/reenable
+ * Re-enable a suspended consumer so operators can replay its DLQ entries.
+ */
+dlqRouter.post(
+  '/consumers/reenable',
+  requirePermission(Permission.DLQ_REPLAY),
+  asyncHandler(async (req: Request, res: Response) => {
+    const consumerUrl = normalizeDlqConsumerUrl((req.body as Record<string, unknown> | undefined)?.consumerUrl);
+    if (!consumerUrl) {
+      throw validationError('consumerUrl must be a valid http(s) URL');
+    }
+
+    const state = await dlqRepository.reenableConsumer(consumerUrl);
+    if (!state) {
+      res.status(404).json(errorResponse(
+        'NOT_FOUND',
+        'DLQ consumer replay state not found',
+        { consumerUrlHash: hashDlqConsumerUrl(consumerUrl) },
+        req.id,
+      ));
+      return;
+    }
+
+    recordAuditEvent(
+      'DLQ_CONSUMER_REENABLED',
+      'dlq_consumer',
+      state.consumerUrlHash,
+      req.id,
+      { consecutiveFailures: 0 },
+    );
+
+    res.json(successResponse({
+      message: 'DLQ consumer re-enabled',
+      consumerReplay: summarizeConsumerReplayState(state),
+    }, req.id));
   }),
 );
 
@@ -194,6 +325,20 @@ dlqRouter.post(
     if (!entry) {
       res.status(404).json({ error: { code: 'NOT_FOUND', message: `DLQ entry '${req.params.id}' not found`, requestId: req.id } });
       return;
+    }
+
+    const consumerUrl = extractDlqConsumerUrl(entry.payload);
+    if (consumerUrl) {
+      const consumerState = await dlqRepository.findConsumerReplayState(consumerUrl);
+      if (consumerState?.suspended) {
+        res.status(409).json(errorResponse(
+          'DLQ_CONSUMER_SUSPENDED',
+          'DLQ consumer is suspended; re-enable it before replaying entries for this endpoint',
+          summarizeConsumerReplayState(consumerState),
+          req.id,
+        ));
+        return;
+      }
     }
 
     await dlqRepository.update(entry.id, { attempts: 0, lastFailedAt: new Date().toISOString() });

--- a/src/webhooks/retry.ts
+++ b/src/webhooks/retry.ts
@@ -37,8 +37,8 @@ export interface RetrySchedule {
 }
 
 export interface WebhookOutboxRetryInput {
-  /** The actual consumer endpoint URL — used as the rate-limit key. */
-  consumerUrl?: string;
+  /** The actual consumer endpoint URL - used as the rate-limit key. */
+  consumerUrl: string;
   streamId: string;
   eventType: string;
   payload: unknown;
@@ -109,19 +109,19 @@ export function applyJitter(delayMs: number, policy: EnhancedRetryPolicy): numbe
  * Determine whether an HTTP status code should trigger a retry.
  *
  * Retryable classes (transient failures safe to retry):
- *   - `undefined`   — no status code, i.e. a network error or timeout
- *   - `408`         — Request Timeout
- *   - `425`         — Too Early
- *   - `429`         — Too Many Requests (rate-limited by consumer)
- *   - `500`         — Internal Server Error
- *   - `502`         — Bad Gateway
- *   - `503`         — Service Unavailable
- *   - `504`         — Gateway Timeout
+ *   - `undefined`   - no status code, i.e. a network error or timeout
+ *   - `408`         - Request Timeout
+ *   - `425`         - Too Early
+ *   - `429`         - Too Many Requests (rate-limited by consumer)
+ *   - `500`         - Internal Server Error
+ *   - `502`         - Bad Gateway
+ *   - `503`         - Service Unavailable
+ *   - `504`         - Gateway Timeout
  *
  * Non-retryable classes (permanent failures; retrying would waste resources
  * and could amplify load on a misconfigured or auth-rejecting consumer):
- *   - `4xx` auth/validation codes (400, 401, 403, 404, 422, …)
- *   - `2xx` / `3xx` — delivery succeeded or was redirected
+ *   - `4xx` auth/validation codes (400, 401, 403, 404, 422, .)
+ *   - `2xx` / `3xx` - delivery succeeded or was redirected
  *
  * The set is configurable via `policy.retryableStatusCodes` so operators can
  * tune it per-consumer without code changes.
@@ -132,62 +132,6 @@ export function isRetryableStatusCode(
 ): boolean {
   if (statusCode === undefined) return true;
   return policy.retryableStatusCodes.includes(statusCode);
-}
-
-/** Return the absolute timestamp for the next retry attempt. */
-export function calculateNextRetryTime(
-  attemptNumber: number,
-  policy: EnhancedRetryPolicy,
-  now: number = Date.now(),
-): number {
-  const delayMs = applyJitter(calculateBackoffDelay(attemptNumber, policy), policy);
-  return now + delayMs;
-}
-
-/** Generate retry metadata for every configured attempt. */
-export function generateRetrySchedule(
-  policy: EnhancedRetryPolicy,
-  now: number = Date.now(),
-): RetrySchedule[] {
-  return Array.from({ length: policy.maxAttempts }, (_, index) => {
-    const attemptNumber = index + 1;
-    const delayMs = applyJitter(calculateBackoffDelay(attemptNumber, policy), policy);
-
-    return {
-      attemptNumber,
-      delayMs,
-      retryAt: now + delayMs,
-    };
-  });
-}
-
-/** Attach retry metadata to an outbox payload and return the next retry time. */
-export function scheduleWebhookOutboxRetry(input: WebhookOutboxRetryInput): WebhookOutboxRetryPlan {
-  const policy = input.policy ?? DEFAULT_RETRY_POLICY;
-  const nextAttemptNumber = input.attemptNumber + 1;
-
-  if (nextAttemptNumber > policy.maxAttempts) {
-    return {
-      shouldRetry: false,
-      attemptNumber: input.attemptNumber,
-      retryAt: null,
-      payload: input.payload,
-    };
-  }
-
-  const payload =
-    typeof input.payload === 'object' && input.payload !== null && !Array.isArray(input.payload)
-      ? { ...(input.payload as Record<string, unknown>), _webhookRetry: { attemptNumber: nextAttemptNumber } }
-      : { _webhookRetry: { attemptNumber: nextAttemptNumber } };
-
-  return {
-    shouldRetry: true,
-    attemptNumber: nextAttemptNumber,
-    retryAt: new Date(calculateNextRetryTime(input.attemptNumber, policy, input.now)),
-    payload,
-  };
-  const retryable = policy.retryableStatusCodes ?? DEFAULT_RETRY_POLICY.retryableStatusCodes;
-  return retryable.includes(statusCode);
 }
 
 /**
@@ -206,7 +150,7 @@ export function calculateNextRetryTime(
 }
 
 /**
- * Generate the full retry schedule for a policy — one entry per attempt.
+ * Generate the full retry schedule for a policy - one entry per attempt.
  */
 export function generateRetrySchedule(
   policy: EnhancedRetryPolicy = DEFAULT_RETRY_POLICY,

--- a/src/webhooks/service.ts
+++ b/src/webhooks/service.ts
@@ -12,12 +12,10 @@ import type {
   WebhookEvent,
   WebhookDelivery,
   WebhookDeliveryAttempt,
-  WebhookRetryPolicy,
 } from './types.js';
 import { DEFAULT_RETRY_POLICY } from './types.js';
 import { webhookDeliveryStore } from './store.js';
 import { computeWebhookSignature } from './signature.js';
-import { calculateNextRetryTime, scheduleWebhookOutboxRetry, shouldRetry } from './retry.js';
 import { calculateNextRetryTime, shouldRetry, checkWebhookDeliveryGate, attemptWebhookDeliveryWithRateLimit, countsTowardCircuitBreaker, type EnhancedRetryPolicy } from './retry.js';
 import { webhookDeliveriesTotal, webhookDeliveryDurationSeconds } from '../metrics/businessMetrics.js';
 import type { WebhookCircuitBreakerStore, CircuitBreakerPolicy } from '../redis/webhookCircuitBreakerStore.js';

--- a/tests/routes/admin.dlq.test.ts
+++ b/tests/routes/admin.dlq.test.ts
@@ -1,37 +1,136 @@
-import { describe, it, expect, beforeEach, beforeAll, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, beforeAll, afterEach, vi } from 'vitest';
+import express from 'express';
 import request from 'supertest';
-import { app } from '../../src/app.js';
-import { _resetDlq, enqueueDeadLetter } from '../../src/routes/dlq.js';
+import type { DlqConsumerReplayState, DlqEntry } from '../../src/routes/dlq.js';
+
+const repoState = vi.hoisted(() => {
+  const entries = new Map<string, DlqEntry>();
+  const consumers = new Map<string, DlqConsumerReplayState>();
+  const hash = (consumerUrl: string): string =>
+    `test_${Buffer.from(consumerUrl).toString('hex').slice(0, 16)}`;
+
+  return { entries, consumers, hash };
+});
+
+vi.mock('../../src/db/repositories/dlqRepository.js', () => ({
+  dlqRepository: {
+    async insert(entry: DlqEntry): Promise<void> {
+      repoState.entries.set(entry.id, entry);
+    },
+    async findAll(opts: { limit: number; offset: number; topic?: string }): Promise<{ entries: DlqEntry[]; total: number }> {
+      const entries = Array.from(repoState.entries.values())
+        .filter((entry) => !opts.topic || entry.topic === opts.topic)
+        .sort((a, b) => b.firstFailedAt.localeCompare(a.firstFailedAt));
+      return {
+        entries: entries.slice(opts.offset, opts.offset + opts.limit),
+        total: entries.length,
+      };
+    },
+    async findById(id: string): Promise<DlqEntry | undefined> {
+      return repoState.entries.get(id);
+    },
+    async update(id: string, patch: Partial<Pick<DlqEntry, 'attempts' | 'lastFailedAt'>>): Promise<void> {
+      const entry = repoState.entries.get(id);
+      if (!entry) return;
+      repoState.entries.set(id, { ...entry, ...patch });
+    },
+    async deleteById(id: string): Promise<boolean> {
+      return repoState.entries.delete(id);
+    },
+    async deleteAll(topic?: string): Promise<number> {
+      const ids = Array.from(repoState.entries.values())
+        .filter((entry) => !topic || entry.topic === topic)
+        .map((entry) => entry.id);
+      ids.forEach((id) => repoState.entries.delete(id));
+      return ids.length;
+    },
+    async deleteAllConsumerReplayStates(): Promise<number> {
+      const count = repoState.consumers.size;
+      repoState.consumers.clear();
+      return count;
+    },
+    async findConsumerReplayState(consumerUrl: string): Promise<DlqConsumerReplayState | undefined> {
+      return repoState.consumers.get(consumerUrl);
+    },
+    async findConsumerReplayStates(consumerUrls: string[]): Promise<Map<string, DlqConsumerReplayState>> {
+      const states = new Map<string, DlqConsumerReplayState>();
+      consumerUrls.forEach((consumerUrl) => {
+        const state = repoState.consumers.get(consumerUrl);
+        if (state) states.set(consumerUrl, state);
+      });
+      return states;
+    },
+    async recordConsumerReplayFailure(consumerUrl: string, threshold: number): Promise<DlqConsumerReplayState> {
+      const previous = repoState.consumers.get(consumerUrl);
+      const consecutiveFailures = (previous?.consecutiveFailures ?? 0) + 1;
+      const suspended = Boolean(previous?.suspended) || consecutiveFailures >= threshold;
+      const state: DlqConsumerReplayState = {
+        consumerUrl,
+        consumerUrlHash: repoState.hash(consumerUrl),
+        consecutiveFailures,
+        suspended,
+        ...(suspended ? { suspendedAt: previous?.suspendedAt ?? new Date().toISOString() } : {}),
+        updatedAt: new Date().toISOString(),
+      };
+      repoState.consumers.set(consumerUrl, state);
+      return state;
+    },
+    async reenableConsumer(consumerUrl: string): Promise<DlqConsumerReplayState | undefined> {
+      const previous = repoState.consumers.get(consumerUrl);
+      if (!previous) return undefined;
+      const state: DlqConsumerReplayState = {
+        consumerUrl,
+        consumerUrlHash: previous.consumerUrlHash,
+        consecutiveFailures: 0,
+        suspended: false,
+        updatedAt: new Date().toISOString(),
+      };
+      repoState.consumers.set(consumerUrl, state);
+      return state;
+    },
+  },
+}));
+
+import { _resetDlq, dlqRouter, enqueueDeadLetter } from '../../src/routes/dlq.js';
 import { generateToken } from '../../src/lib/auth.js';
+import { getAuditEntries, _resetAuditLog } from '../../src/lib/auditLog.js';
 import { initializeConfig } from '../../src/config/env.js';
 
 let operatorToken: string;
 let viewerToken: string;
+const app = express();
+app.use(express.json());
+app.use('/admin/dlq', dlqRouter);
+
+const deadConsumerUrl = 'https://dead.example/webhook';
+const healthyConsumerUrl = 'https://healthy.example/webhook';
 
 beforeAll(() => {
   process.env.NODE_ENV = 'test';
   process.env.JWT_SECRET = 'a-very-long-secret-key-for-testing-only-12345';
+  process.env.DLQ_REPLAY_SUSPEND_THRESHOLD = '2';
   initializeConfig();
   operatorToken = generateToken({ address: 'GOPERATOR', role: 'operator' });
   viewerToken = generateToken({ address: 'GVIEWER', role: 'viewer' });
 });
 
 describe('admin DLQ routes', () => {
-  beforeEach(() => {
-    _resetDlq();
+  beforeEach(async () => {
+    process.env.DLQ_REPLAY_SUSPEND_THRESHOLD = '2';
+    await _resetDlq();
+    _resetAuditLog();
   });
 
-  afterEach(() => {
-    _resetDlq();
+  afterEach(async () => {
+    await _resetDlq();
+    _resetAuditLog();
   });
 
-  // 1. Unauthorized Access
   it('rejects unauthenticated GET to DLQ list with 401', async () => {
     const res = await request(app).get('/admin/dlq');
     expect(res.status).toBe(401);
   });
 
-  // 2. Invalid Credentials
   it('rejects GET with viewer role to DLQ list with 403', async () => {
     const res = await request(app)
       .get('/admin/dlq')
@@ -39,12 +138,10 @@ describe('admin DLQ routes', () => {
     expect(res.status).toBe(403);
   });
 
-  // 3. DLQ List Endpoint
   it('allows authenticated GET to DLQ list with 200 and valid shape', async () => {
-    // Seed one entry
-    enqueueDeadLetter({
+    await enqueueDeadLetter({
       topic: 'stream.created',
-      payload: { id: 'test-stream' },
+      payload: { endpointUrl: deadConsumerUrl, id: 'test-stream' },
       error: 'timeout error',
       attempts: 1,
     });
@@ -55,15 +152,148 @@ describe('admin DLQ routes', () => {
 
     expect(res.status).toBe(200);
     expect(res.body.success).toBe(true);
-    expect(res.body.data).toHaveProperty('entries');
-    expect(Array.isArray(res.body.data.entries)).toBe(true);
     expect(res.body.data.entries).toHaveLength(1);
     expect(res.body.data.entries[0].topic).toBe('stream.created');
+    expect(res.body.data.entries[0].consumerReplay).toMatchObject({
+      consecutiveFailures: 1,
+      suspended: false,
+    });
   });
 
-  // 4. Delete Existing DLQ Entry
+  it('surfaces suspended state in the DLQ list after the replay-failure threshold', async () => {
+    await enqueueDeadLetter({
+      topic: 'stream.created',
+      payload: { endpointUrl: deadConsumerUrl, id: 'first-failure' },
+      error: 'HTTP 503',
+      attempts: 5,
+    });
+    await enqueueDeadLetter({
+      topic: 'stream.created',
+      payload: { endpointUrl: deadConsumerUrl, id: 'second-failure' },
+      error: 'HTTP 503',
+      attempts: 5,
+    });
+
+    const res = await request(app)
+      .get('/admin/dlq')
+      .set('Authorization', `Bearer ${operatorToken}`)
+      .expect(200);
+
+    expect(res.body.data.entries).toHaveLength(2);
+    expect(res.body.data.entries[0].consumerReplay).toMatchObject({
+      consumerUrlHash: repoState.hash(deadConsumerUrl),
+      consecutiveFailures: 2,
+      suspended: true,
+    });
+
+    const suspensionAudit = getAuditEntries().find((entry) => entry.action === 'DLQ_CONSUMER_SUSPENDED');
+    expect(suspensionAudit).toBeDefined();
+    expect(suspensionAudit?.resourceId).toBe(repoState.hash(deadConsumerUrl));
+    expect(suspensionAudit?.meta).toMatchObject({ consecutiveFailures: 2, threshold: 2 });
+  });
+
+  it('does not suspend unrelated consumers when one endpoint reaches the threshold', async () => {
+    await enqueueDeadLetter({
+      topic: 'stream.created',
+      payload: { endpointUrl: deadConsumerUrl, id: 'dead-1' },
+      error: 'HTTP 503',
+      attempts: 5,
+    });
+    await enqueueDeadLetter({
+      topic: 'stream.created',
+      payload: { endpointUrl: deadConsumerUrl, id: 'dead-2' },
+      error: 'HTTP 503',
+      attempts: 5,
+    });
+    await enqueueDeadLetter({
+      topic: 'stream.created',
+      payload: { endpointUrl: healthyConsumerUrl, id: 'healthy-1' },
+      error: 'timeout',
+      attempts: 1,
+    });
+
+    const res = await request(app)
+      .get('/admin/dlq')
+      .set('Authorization', `Bearer ${operatorToken}`)
+      .expect(200);
+
+    const healthyEntry = res.body.data.entries.find(
+      (entry: { payload: { id: string } }) => entry.payload.id === 'healthy-1',
+    );
+    expect(healthyEntry.consumerReplay).toMatchObject({
+      consumerUrlHash: repoState.hash(healthyConsumerUrl),
+      consecutiveFailures: 1,
+      suspended: false,
+    });
+  });
+
+  it('rejects replay for a suspended consumer until an operator re-enables it', async () => {
+    const firstEntry = await enqueueDeadLetter({
+      topic: 'stream.created',
+      payload: { endpointUrl: deadConsumerUrl, id: 'dead-1' },
+      error: 'HTTP 503',
+      attempts: 5,
+    });
+    await enqueueDeadLetter({
+      topic: 'stream.created',
+      payload: { endpointUrl: deadConsumerUrl, id: 'dead-2' },
+      error: 'HTTP 503',
+      attempts: 5,
+    });
+
+    const blocked = await request(app)
+      .post(`/admin/dlq/${firstEntry.id}/replay`)
+      .set('Authorization', `Bearer ${operatorToken}`)
+      .expect(409);
+
+    expect(blocked.body.error.code).toBe('DLQ_CONSUMER_SUSPENDED');
+    expect(blocked.body.error.details).toMatchObject({
+      consumerUrlHash: repoState.hash(deadConsumerUrl),
+      consecutiveFailures: 2,
+      suspended: true,
+    });
+
+    const reenabled = await request(app)
+      .post('/admin/dlq/consumers/reenable')
+      .set('Authorization', `Bearer ${operatorToken}`)
+      .send({ consumerUrl: deadConsumerUrl })
+      .expect(200);
+
+    expect(reenabled.body.data.consumerReplay).toMatchObject({
+      consumerUrlHash: repoState.hash(deadConsumerUrl),
+      consecutiveFailures: 0,
+      suspended: false,
+    });
+
+    const replayed = await request(app)
+      .post(`/admin/dlq/${firstEntry.id}/replay`)
+      .set('Authorization', `Bearer ${operatorToken}`)
+      .expect(200);
+
+    expect(replayed.body.data.message).toBe('DLQ entry replayed');
+    expect(getAuditEntries().some((entry) => entry.action === 'DLQ_CONSUMER_REENABLED')).toBe(true);
+    expect(getAuditEntries().some((entry) => entry.action === 'DLQ_REPLAYED')).toBe(true);
+  });
+
+  it('requires operator permissions to re-enable a suspended consumer', async () => {
+    await enqueueDeadLetter({
+      topic: 'stream.created',
+      payload: { endpointUrl: deadConsumerUrl },
+      error: 'HTTP 503',
+      attempts: 5,
+    });
+
+    const res = await request(app)
+      .post('/admin/dlq/consumers/reenable')
+      .set('Authorization', `Bearer ${viewerToken}`)
+      .send({ consumerUrl: deadConsumerUrl });
+
+    expect(res.status).toBe(403);
+    expect(res.body.error.code).toBe('FORBIDDEN');
+  });
+
   it('allows authenticated operator to delete DLQ entry with 200', async () => {
-    const entry = enqueueDeadLetter({
+    const entry = await enqueueDeadLetter({
       topic: 'stream.created',
       payload: {},
       error: 'some error',
@@ -79,7 +309,6 @@ describe('admin DLQ routes', () => {
     expect(res.body.data.id).toBe(entry.id);
   });
 
-  // 5. Delete Non-Existent DLQ Entry
   it('returns 404 when deleting a non-existent DLQ entry', async () => {
     const res = await request(app)
       .delete('/admin/dlq/non-existent-id')


### PR DESCRIPTION
Fixes #349.

## Summary
- track consecutive DLQ replay failures per consumer endpoint and persist suspension state
- reject replay for suspended consumers until an operator re-enables the endpoint
- surface consumer replay state in DLQ list/get responses and audit suspension/re-enable actions
- document the DLQ replay suspension threshold and admin re-enable flow

## Verification
- 
ode .\node_modules\vitest\vitest.mjs run tests\routes\admin.dlq.test.ts --reporter=dot (9 tests passed)
- 
ode .\node_modules\vitest\vitest.mjs run src\webhooks\retry.test.ts tests\webhooks\circuitBreaker.store.test.ts tests\webhooks\retry.rateLimit.test.ts tests\webhooks\service.dispatcher.test.ts --reporter=dot (44 tests passed)
- 
ode .\node_modules\eslint\bin\eslint.js src\routes\dlq.ts src\db\repositories\dlqRepository.ts src\lib\dlqConsumer.ts src\webhooks\retry.ts src\webhooks\service.ts tests\routes\admin.dlq.test.ts src\openapi\spec.ts
- git diff --check

Full 	sc --noEmit --pretty false still reports existing repository-wide baseline errors in unrelated files such as src/config/health.ts, src/db/pool.ts, and src/db/repositories/streamRepository.ts; filtered output showed no errors for the touched DLQ/webhook/OpenAPI files after the targeted fixes.

## Security notes
- re-enable stays behind the existing dlq:replay operator permission
- replay attempts for suspended consumers return 409 DLQ_CONSUMER_SUSPENDED
- audit metadata uses a hash of the consumer URL instead of logging the raw third-party endpoint