### PR TITLE
Fix poison webhook payload DLQ handling

### DIFF
--- a/docs/webhooks.md
+++ b/docs/webhooks.md
@@ -34,6 +34,19 @@ FOR UPDATE SKIP LOCKED
 
 Failed retryable deliveries are delegated to `src/webhooks/retry.ts`. The original row is marked processed and a new unprocessed row is inserted with `created_at` set to the next retry time. The dispatcher only claims rows whose `created_at` is due, so retries remain durable in PostgreSQL without holding process memory.
 
+## Poison delivery handling
+
+The dispatcher fast-tracks rows that cannot be repaired by retrying to the dead-letter queue. Operators can distinguish these from exhausted transient failures with the `failureCode` returned by `GET /api/webhooks/dlq`.
+
+| `failureCode` | Meaning |
+|---------------|---------|
+| `poison_payload` | The stored outbox payload is not valid JSON, is not a JSON object, uses an unsupported `event_type`, or has a payload `event` marker that does not match `event_type`. |
+| `poison_endpoint` | The configured or per-row consumer URL is malformed or violates endpoint safety rules. |
+| `poison_status` | The consumer returned a non-retryable HTTP status, such as `400`, `401`, `403`, `404`, or `422`. |
+| `exhausted_retry` | A transient failure reached `maxAttempts` and no further retry row will be enqueued. |
+
+Poison rows are marked processed before being added to the DLQ so a single bad payload or endpoint cannot roll back the whole batch and block later outbox rows.
+
 ## Retry rate limiting
 
 To prevent a slow or error-prone consumer from being bombarded with retries, `attemptWebhookDeliveryWithRateLimit` in `src/webhooks/retry.ts` enforces a per-consumer-URL sliding-window rate limit before each outbound attempt.
@@ -54,7 +67,7 @@ Per-consumer circuit breaker state is persisted in Redis (`src/redis/webhookCirc
 
 1. Before firing a retry, the dispatcher calls `checkWebhookDeliveryGate` / `attemptWebhookDeliveryWithRateLimit` with the consumer endpoint URL.
 2. The circuit breaker store reads/writes JSON state at `webhook_cb:{sha256(url)}`. Half-open probe ownership is tracked with `webhook_cb_probe:{sha256(url)}` via Redis `SET NX`.
-3. When the circuit is open, the outbox row is re-enqueued with `created_at = resetAt` — no HTTP call is made.
+3. When the circuit is open, the outbox row is re-enqueued with `created_at = resetAt` - no HTTP call is made.
 4. Successful deliveries reset the breaker; retryable failures increment the shared failure counter.
 5. State transitions increment `fluxora_webhook_circuit_breaker_transitions_total{from_state,to_state}`.
 

--- a/src/routes/webhooks.ts
+++ b/src/routes/webhooks.ts
@@ -29,7 +29,7 @@ webhooksRouter.post(
   (req, res): void => {
     const rawBody = req.body as Buffer;
     const headers = req.headers as Record<string, string | undefined>;
-    // `verifyWebhookSignature` uses exact-optional types — only forward
+    // `verifyWebhookSignature` uses exact-optional types - only forward
     // properties when they are actually set.
     const verifyInput: Parameters<typeof verifyWebhookSignature>[0] = {
       rawBody,
@@ -262,6 +262,7 @@ webhooksRouter.get('/dlq', (req, res) => {
       eventType: item.eventType,
       endpointUrl: item.endpointUrl,
       failureReason: item.failureReason,
+      failureCode: item.failureCode,
       attemptCount: item.originalDelivery.attempts.length,
       createdAt: new Date(item.createdAt).toISOString(),
       processedAt: item.processedAt ? new Date(item.processedAt).toISOString() : null,

--- a/src/webhooks/retry.ts
+++ b/src/webhooks/retry.ts
@@ -37,8 +37,8 @@ export interface RetrySchedule {
 }
 
 export interface WebhookOutboxRetryInput {
-  /** The actual consumer endpoint URL — used as the rate-limit key. */
-  consumerUrl?: string;
+  /** The actual consumer endpoint URL used as the rate-limit key. */
+  consumerUrl: string;
   streamId: string;
   eventType: string;
   payload: unknown;
@@ -109,19 +109,19 @@ export function applyJitter(delayMs: number, policy: EnhancedRetryPolicy): numbe
  * Determine whether an HTTP status code should trigger a retry.
  *
  * Retryable classes (transient failures safe to retry):
- *   - `undefined`   — no status code, i.e. a network error or timeout
- *   - `408`         — Request Timeout
- *   - `425`         — Too Early
- *   - `429`         — Too Many Requests (rate-limited by consumer)
- *   - `500`         — Internal Server Error
- *   - `502`         — Bad Gateway
- *   - `503`         — Service Unavailable
- *   - `504`         — Gateway Timeout
+ *   - `undefined`   no status code, i.e. a network error or timeout
+ *   - `408`         Request Timeout
+ *   - `425`         Too Early
+ *   - `429`         Too Many Requests (rate-limited by consumer)
+ *   - `500`         Internal Server Error
+ *   - `502`         Bad Gateway
+ *   - `503`         Service Unavailable
+ *   - `504`         Gateway Timeout
  *
  * Non-retryable classes (permanent failures; retrying would waste resources
  * and could amplify load on a misconfigured or auth-rejecting consumer):
- *   - `4xx` auth/validation codes (400, 401, 403, 404, 422, …)
- *   - `2xx` / `3xx` — delivery succeeded or was redirected
+ *   - `4xx` auth/validation codes (400, 401, 403, 404, 422, ...)
+ *   - `2xx` / `3xx` delivery succeeded or was redirected
  *
  * The set is configurable via `policy.retryableStatusCodes` so operators can
  * tune it per-consumer without code changes.
@@ -140,8 +140,9 @@ export function calculateNextRetryTime(
   policy: EnhancedRetryPolicy,
   now: number = Date.now(),
 ): number {
+  if (attemptNumber >= policy.maxAttempts) return 0;
   const delayMs = applyJitter(calculateBackoffDelay(attemptNumber, policy), policy);
-  return now + delayMs;
+  return now + Math.round(delayMs);
 }
 
 /** Generate retry metadata for every configured attempt. */
@@ -158,63 +159,6 @@ export function generateRetrySchedule(
       delayMs,
       retryAt: now + delayMs,
     };
-  });
-}
-
-/** Attach retry metadata to an outbox payload and return the next retry time. */
-export function scheduleWebhookOutboxRetry(input: WebhookOutboxRetryInput): WebhookOutboxRetryPlan {
-  const policy = input.policy ?? DEFAULT_RETRY_POLICY;
-  const nextAttemptNumber = input.attemptNumber + 1;
-
-  if (nextAttemptNumber > policy.maxAttempts) {
-    return {
-      shouldRetry: false,
-      attemptNumber: input.attemptNumber,
-      retryAt: null,
-      payload: input.payload,
-    };
-  }
-
-  const payload =
-    typeof input.payload === 'object' && input.payload !== null && !Array.isArray(input.payload)
-      ? { ...(input.payload as Record<string, unknown>), _webhookRetry: { attemptNumber: nextAttemptNumber } }
-      : { _webhookRetry: { attemptNumber: nextAttemptNumber } };
-
-  return {
-    shouldRetry: true,
-    attemptNumber: nextAttemptNumber,
-    retryAt: new Date(calculateNextRetryTime(input.attemptNumber, policy, input.now)),
-    payload,
-  };
-  const retryable = policy.retryableStatusCodes ?? DEFAULT_RETRY_POLICY.retryableStatusCodes;
-  return retryable.includes(statusCode);
-}
-
-/**
- * Calculate the absolute timestamp (ms since epoch) at which the next retry
- * should be attempted, or 0 if the attempt number has reached maxAttempts.
- */
-export function calculateNextRetryTime(
-  attemptNumber: number,
-  policy: EnhancedRetryPolicy = DEFAULT_RETRY_POLICY,
-  now: number = Date.now(),
-): number {
-  if (attemptNumber >= policy.maxAttempts) return 0;
-  const raw = calculateBackoffDelay(attemptNumber, policy);
-  const withJitter = applyJitter(raw, policy);
-  return now + Math.round(withJitter);
-}
-
-/**
- * Generate the full retry schedule for a policy — one entry per attempt.
- */
-export function generateRetrySchedule(
-  policy: EnhancedRetryPolicy = DEFAULT_RETRY_POLICY,
-  now: number = Date.now(),
-): RetrySchedule[] {
-  return Array.from({ length: policy.maxAttempts }, (_, i) => {
-    const delayMs = Math.round(applyJitter(calculateBackoffDelay(i, policy), policy));
-    return { attemptNumber: i + 1, delayMs, retryAt: now + delayMs };
   });
 }
 

--- a/src/webhooks/service.ts
+++ b/src/webhooks/service.ts
@@ -10,15 +10,15 @@ import { getCorrelationId } from '../tracing/middleware.js';
 import { getPool } from '../db/pool.js';
 import type {
   WebhookEvent,
+  WebhookEventType,
   WebhookDelivery,
   WebhookDeliveryAttempt,
-  WebhookRetryPolicy,
 } from './types.js';
 import { DEFAULT_RETRY_POLICY } from './types.js';
 import { webhookDeliveryStore } from './store.js';
+import type { DeadLetterQueueReasonCode } from './store.js';
 import { computeWebhookSignature } from './signature.js';
-import { calculateNextRetryTime, scheduleWebhookOutboxRetry, shouldRetry } from './retry.js';
-import { calculateNextRetryTime, shouldRetry, checkWebhookDeliveryGate, attemptWebhookDeliveryWithRateLimit, countsTowardCircuitBreaker, type EnhancedRetryPolicy } from './retry.js';
+import { calculateNextRetryTime, shouldRetry, isRetryableStatusCode, checkWebhookDeliveryGate, attemptWebhookDeliveryWithRateLimit, countsTowardCircuitBreaker, type EnhancedRetryPolicy } from './retry.js';
 import { webhookDeliveriesTotal, webhookDeliveryDurationSeconds } from '../metrics/businessMetrics.js';
 import type { WebhookCircuitBreakerStore, CircuitBreakerPolicy } from '../redis/webhookCircuitBreakerStore.js';
 import { getWebhookCircuitBreakerStore } from '../redis/webhookCircuitBreakerStore.js';
@@ -58,6 +58,26 @@ interface ResolvedEndpoint {
   endpointUrl: string;
   secret: string;
 }
+
+const WEBHOOK_EVENT_TYPES = new Set<WebhookEventType>([
+  'stream.created',
+  'stream.updated',
+  'stream.cancelled',
+]);
+
+interface PoisonClassification {
+  code: DeadLetterQueueReasonCode;
+  reason: string;
+}
+
+type PayloadValidationResult =
+  | { ok: true; payload: Record<string, unknown> }
+  | { ok: false; poison: PoisonClassification };
+
+type EndpointResolutionResult =
+  | { ok: true; endpoint: ResolvedEndpoint }
+  | { ok: false; poison: PoisonClassification }
+  | { ok: false; missing: true };
 
 function parsePositiveInteger(value: string | undefined, fallback: number): number {
   if (!value) return fallback;
@@ -101,16 +121,69 @@ function assertSafeWebhookEndpoint(endpointUrl: string): void {
   }
 }
 
-function normalizePayload(payload: unknown): unknown {
+function validateWebhookOutboxPayload(payload: unknown): PayloadValidationResult {
   if (typeof payload === 'string') {
     try {
-      return JSON.parse(payload);
+      const parsed = JSON.parse(payload);
+      return validateWebhookOutboxPayload(parsed);
     } catch {
-      return payload;
+      return {
+        ok: false,
+        poison: {
+          code: 'poison_payload',
+          reason: 'Webhook outbox payload is not valid JSON',
+        },
+      };
     }
   }
 
-  return payload;
+  if (typeof payload !== 'object' || payload === null || Array.isArray(payload)) {
+    return {
+      ok: false,
+      poison: {
+        code: 'poison_payload',
+        reason: 'Webhook outbox payload must be a JSON object',
+      },
+    };
+  }
+
+  return { ok: true, payload: payload as Record<string, unknown> };
+}
+
+function validateWebhookOutboxEvent(row: OutboxRow, payload: Record<string, unknown>): PoisonClassification | null {
+  if (!WEBHOOK_EVENT_TYPES.has(row.event_type as WebhookEventType)) {
+    return {
+      code: 'poison_payload',
+      reason: `Webhook outbox event_type is not supported: ${row.event_type}`,
+    };
+  }
+
+  const payloadEvent = payload['event'];
+  if (payloadEvent !== undefined && payloadEvent !== row.event_type) {
+    return {
+      code: 'poison_payload',
+      reason: 'Webhook outbox payload event does not match event_type',
+    };
+  }
+
+  return null;
+}
+
+function isSuccessfulAttempt(attempt: WebhookDeliveryAttempt): boolean {
+  return (
+    attempt.statusCode !== undefined &&
+    attempt.statusCode >= 200 &&
+    attempt.statusCode < 300 &&
+    !attempt.error
+  );
+}
+
+function describePermanentFailure(
+  attempt: WebhookDeliveryAttempt,
+  attemptNumber: number,
+): string {
+  const attempts = `after ${attemptNumber} attempt${attemptNumber === 1 ? '' : 's'}`;
+  return attempt.error ? `${attempt.error} ${attempts}` : `HTTP ${attempt.statusCode} ${attempts}`;
 }
 
 function extractAttemptNumber(payload: unknown): number {
@@ -126,6 +199,7 @@ function extractAttemptNumber(payload: unknown): number {
 function enqueuePermanentFailureToDlq(
   delivery: WebhookDelivery,
   failureReason: string,
+  failureCode: DeadLetterQueueReasonCode = 'exhausted_retry',
 ): string | undefined {
   const alreadyQueued = webhookDeliveryStore
     .getDeadLetterQueueItems()
@@ -138,7 +212,7 @@ function enqueuePermanentFailureToDlq(
     return undefined;
   }
 
-  return webhookDeliveryStore.addToDeadLetterQueue(delivery, failureReason);
+  return webhookDeliveryStore.addToDeadLetterQueue(delivery, failureReason, failureCode);
 }
 
 export class WebhookService {
@@ -581,20 +655,27 @@ export class WebhookDispatcher {
     return this.inFlight;
   }
 
-  private resolveEndpoint(row: OutboxRow): ResolvedEndpoint | null {
-    if (!this.endpointUrl || !this.secret) return null;
+  private resolveEndpoint(payloadObject: Record<string, unknown>): EndpointResolutionResult {
+    if (!this.endpointUrl || !this.secret) return { ok: false, missing: true };
 
-    const payload = normalizePayload(row.payload);
-    const payloadObject = typeof payload === 'object' && payload !== null
-      ? payload as Record<string, unknown>
-      : {};
     const endpointUrl =
       typeof payloadObject['endpointUrl'] === 'string' ? payloadObject['endpointUrl'] : this.endpointUrl;
     const secret =
       typeof payloadObject['secret'] === 'string' ? payloadObject['secret'] : this.secret;
 
-    assertSafeWebhookEndpoint(endpointUrl);
-    return { endpointUrl, secret };
+    try {
+      assertSafeWebhookEndpoint(endpointUrl);
+    } catch (error) {
+      return {
+        ok: false,
+        poison: {
+          code: 'poison_endpoint',
+          reason: error instanceof Error ? error.message : 'Webhook endpoint URL is invalid',
+        },
+      };
+    }
+
+    return { ok: true, endpoint: { endpointUrl, secret } };
   }
 
   private async processBatch(): Promise<void> {
@@ -638,22 +719,18 @@ export class WebhookDispatcher {
     }
   }
 
-  private async deliverRow(client: DbClient, row: OutboxRow): Promise<void> {
-    const endpoint = this.resolveEndpoint(row);
-    if (!endpoint) {
-      logger.warn('Webhook outbox row skipped; no endpoint configured', undefined, { outboxId: row.id });
-      return;
-    }
-
-    const payload = normalizePayload(row.payload);
-    const payloadString = JSON.stringify(payload);
-    const attemptNumber = extractAttemptNumber(payload);
-    const delivery: WebhookDelivery = {
+  private buildDelivery(
+    row: OutboxRow,
+    endpointUrl: string,
+    payload: Record<string, unknown>,
+    attemptNumber: number,
+  ): WebhookDelivery {
+    return {
       id: `outbox_${row.id}`,
       deliveryId: `outbox_${row.id}`,
       eventId: row.stream_id,
       eventType: row.event_type as WebhookEvent['type'],
-      endpointUrl: endpoint.endpointUrl,
+      endpointUrl,
       status: 'pending',
       attempts: Array.from({ length: Math.max(0, attemptNumber - 1) }, (_, index) => ({
         attemptNumber: index + 1,
@@ -661,8 +738,70 @@ export class WebhookDispatcher {
       })),
       createdAt: new Date(row.created_at).getTime(),
       updatedAt: Date.now(),
-      payload: payloadString,
+      payload: JSON.stringify(payload),
     };
+  }
+
+  private async moveRowToDlq(
+    client: DbClient,
+    row: OutboxRow,
+    payload: Record<string, unknown>,
+    endpointUrl: string,
+    poison: PoisonClassification,
+    attemptNumber = extractAttemptNumber(payload),
+  ): Promise<void> {
+    const delivery = this.buildDelivery(row, endpointUrl, payload, attemptNumber);
+    delivery.status = 'permanent_failure';
+    await client.query('UPDATE webhook_outbox SET processed = true WHERE id = $1', [row.id]);
+    enqueuePermanentFailureToDlq(delivery, poison.reason, poison.code);
+  }
+
+  private async deliverRow(client: DbClient, row: OutboxRow): Promise<void> {
+    const payloadValidation = validateWebhookOutboxPayload(row.payload);
+    if (payloadValidation.ok === false) {
+      await this.moveRowToDlq(
+        client,
+        row,
+        { rawPayload: typeof row.payload === 'string' ? row.payload : JSON.stringify(row.payload) },
+        this.endpointUrl ?? 'invalid://webhook-endpoint',
+        payloadValidation.poison,
+      );
+      return;
+    }
+
+    const payload = payloadValidation.payload;
+    const eventPoison = validateWebhookOutboxEvent(row, payload);
+    if (eventPoison) {
+      await this.moveRowToDlq(
+        client,
+        row,
+        payload,
+        this.endpointUrl ?? 'invalid://webhook-endpoint',
+        eventPoison,
+      );
+      return;
+    }
+
+    const endpointResolution = this.resolveEndpoint(payload);
+    if (endpointResolution.ok === false && 'missing' in endpointResolution) {
+      logger.warn('Webhook outbox row skipped; no endpoint configured', undefined, { outboxId: row.id });
+      return;
+    }
+
+    if (endpointResolution.ok === false) {
+      await this.moveRowToDlq(
+        client,
+        row,
+        payload,
+        typeof payload['endpointUrl'] === 'string' ? payload['endpointUrl'] : this.endpointUrl ?? 'invalid://webhook-endpoint',
+        endpointResolution.poison,
+      );
+      return;
+    }
+
+    const endpoint = endpointResolution.endpoint;
+    const attemptNumber = extractAttemptNumber(payload);
+    const delivery = this.buildDelivery(row, endpoint.endpointUrl, payload, attemptNumber);
 
     const result = await attemptWebhookDeliveryWithRateLimit(
       {
@@ -701,17 +840,26 @@ export class WebhookDispatcher {
       attempt.nextRetryAt = result.retryAt?.getTime() ?? calculateNextRetryTime(attemptNumber, this.policy);
       delivery.status = 'pending';
     } else if (
-      attempt.statusCode !== undefined &&
-      attempt.statusCode >= 200 &&
-      attempt.statusCode < 300 &&
-      !attempt.error
+      isSuccessfulAttempt(attempt)
     ) {
       delivery.status = 'delivered';
     } else {
       delivery.status = 'permanent_failure';
     }
 
-    if (delivery.status === 'delivered' || delivery.status === 'permanent_failure') {
+    if (delivery.status === 'permanent_failure') {
+      const failureCode = attempt.statusCode !== undefined && !isRetryableStatusCode(attempt.statusCode, this.policy)
+        ? 'poison_status'
+        : 'exhausted_retry';
+      enqueuePermanentFailureToDlq(
+        delivery,
+        describePermanentFailure(attempt, attemptNumber),
+        failureCode,
+      );
+      return;
+    }
+
+    if (delivery.status === 'delivered') {
       return;
     }
 

--- a/src/webhooks/store.ts
+++ b/src/webhooks/store.ts
@@ -6,6 +6,12 @@
 import type { WebhookDelivery, WebhookDeliveryStatus } from './types.js';
 import { logger } from '../lib/logger.js';
 
+export type DeadLetterQueueReasonCode =
+  | 'poison_payload'
+  | 'poison_endpoint'
+  | 'poison_status'
+  | 'exhausted_retry';
+
 export interface DeadLetterQueueItem {
   id: string;
   deliveryId: string;
@@ -15,6 +21,7 @@ export interface DeadLetterQueueItem {
   payload: string;
   originalDelivery: WebhookDelivery;
   failureReason: string;
+  failureCode: DeadLetterQueueReasonCode;
   createdAt: number;
   processedAt?: number;
 }
@@ -193,7 +200,11 @@ export class WebhookDeliveryStore {
   /**
    * Add failed delivery to dead-letter queue
    */
-  addToDeadLetterQueue(delivery: WebhookDelivery, failureReason: string): string {
+  addToDeadLetterQueue(
+    delivery: WebhookDelivery,
+    failureReason: string,
+    failureCode: DeadLetterQueueReasonCode = 'exhausted_retry',
+  ): string {
     const id = `dlq_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`;
     
     const dlqItem: DeadLetterQueueItem = {
@@ -205,6 +216,7 @@ export class WebhookDeliveryStore {
       payload: delivery.payload,
       originalDelivery: delivery,
       failureReason,
+      failureCode,
       createdAt: Date.now(),
     };
     
@@ -215,6 +227,7 @@ export class WebhookDeliveryStore {
       dlqId: id,
       deliveryId: delivery.deliveryId,
       failureReason,
+      failureCode,
       attemptCount: delivery.attempts.length,
     });
     

--- a/tests/webhooks/service.dispatcher.test.ts
+++ b/tests/webhooks/service.dispatcher.test.ts
@@ -3,6 +3,7 @@ import { WebhookDispatcher } from '../../src/webhooks/service.js';
 import type { EnhancedRetryPolicy } from '../../src/webhooks/retry.js';
 import { FakeRedisClient } from '../../src/redis/__test__/fakeRedisClient.js';
 import { RedisWebhookCircuitBreakerStore } from '../../src/redis/webhookCircuitBreakerStore.js';
+import { webhookDeliveryStore } from '../../src/webhooks/store.js';
 
 interface MockClient {
   queries: Array<{ sql: string; params: unknown[] | undefined }>;
@@ -61,12 +62,14 @@ describe('WebhookDispatcher outbox polling', () => {
   beforeEach(() => {
     redis = new FakeRedisClient();
     breaker = new RedisWebhookCircuitBreakerStore(redis);
+    webhookDeliveryStore.clear();
     vi.spyOn(Math, 'random').mockReturnValue(0.5);
   });
 
   afterEach(async () => {
     await breaker.close();
     redis.reset();
+    webhookDeliveryStore.clear();
     vi.restoreAllMocks();
   });
 
@@ -162,6 +165,122 @@ describe('WebhookDispatcher outbox polling', () => {
     await createDispatcher(client, breaker).pollOnce();
 
     expect(client.queries.some(q => q.sql.includes('INSERT INTO webhook_outbox'))).toBe(false);
+    expect(webhookDeliveryStore.getDeadLetterQueueItems()).toEqual([
+      expect.objectContaining({
+        deliveryId: 'outbox_44',
+        failureCode: 'exhausted_retry',
+        failureReason: 'HTTP 500 after 3 attempts',
+      }),
+    ]);
+  });
+
+  it('fast-tracks invalid JSON payloads to the dead-letter queue without delivery', async () => {
+    const client = createClient([
+      {
+        id: '48',
+        stream_id: 'stream-7',
+        event_type: 'stream.created',
+        payload: '{"id":',
+        created_at: new Date(),
+      },
+    ]);
+    global.fetch = vi.fn() as unknown as typeof fetch;
+
+    await createDispatcher(client, breaker).pollOnce();
+
+    expect(global.fetch).not.toHaveBeenCalled();
+    expect(client.queries).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          sql: 'UPDATE webhook_outbox SET processed = true WHERE id = $1',
+          params: ['48'],
+        }),
+      ]),
+    );
+    expect(client.queries.some(q => q.sql.includes('INSERT INTO webhook_outbox'))).toBe(false);
+    expect(webhookDeliveryStore.getDeadLetterQueueItems()).toEqual([
+      expect.objectContaining({
+        deliveryId: 'outbox_48',
+        failureCode: 'poison_payload',
+        failureReason: 'Webhook outbox payload is not valid JSON',
+      }),
+    ]);
+  });
+
+  it('fast-tracks malformed consumer URLs to the dead-letter queue without retrying', async () => {
+    const client = createClient([
+      {
+        id: '49',
+        stream_id: 'stream-8',
+        event_type: 'stream.created',
+        payload: { id: 'evt-8', endpointUrl: 'ftp://consumer.example/webhooks' },
+        created_at: new Date(),
+      },
+    ]);
+    global.fetch = vi.fn() as unknown as typeof fetch;
+
+    await createDispatcher(client, breaker).pollOnce();
+
+    expect(global.fetch).not.toHaveBeenCalled();
+    expect(client.queries.some(q => q.sql.includes('INSERT INTO webhook_outbox'))).toBe(false);
+    expect(webhookDeliveryStore.getDeadLetterQueueItems()).toEqual([
+      expect.objectContaining({
+        deliveryId: 'outbox_49',
+        endpointUrl: 'ftp://consumer.example/webhooks',
+        failureCode: 'poison_endpoint',
+        failureReason: 'Webhook endpoint must use http or https',
+      }),
+    ]);
+  });
+
+  it('fast-tracks payloads whose event marker disagrees with event_type', async () => {
+    const client = createClient([
+      {
+        id: '51',
+        stream_id: 'stream-10',
+        event_type: 'stream.updated',
+        payload: { id: 'evt-10', event: 'stream.cancelled' },
+        created_at: new Date(),
+      },
+    ]);
+    global.fetch = vi.fn() as unknown as typeof fetch;
+
+    await createDispatcher(client, breaker).pollOnce();
+
+    expect(global.fetch).not.toHaveBeenCalled();
+    expect(client.queries.some(q => q.sql.includes('INSERT INTO webhook_outbox'))).toBe(false);
+    expect(webhookDeliveryStore.getDeadLetterQueueItems()).toEqual([
+      expect.objectContaining({
+        deliveryId: 'outbox_51',
+        failureCode: 'poison_payload',
+        failureReason: 'Webhook outbox payload event does not match event_type',
+      }),
+    ]);
+  });
+
+  it('moves non-retryable HTTP responses to the dead-letter queue with a poison status code', async () => {
+    const client = createClient([
+      {
+        id: '50',
+        stream_id: 'stream-9',
+        event_type: 'stream.created',
+        payload: { id: 'evt-9' },
+        created_at: new Date(),
+      },
+    ]);
+    global.fetch = vi.fn(async () => new Response(null, { status: 400, statusText: 'Bad Request' })) as unknown as typeof fetch;
+
+    await createDispatcher(client, breaker).pollOnce();
+
+    expect(global.fetch).toHaveBeenCalledOnce();
+    expect(client.queries.some(q => q.sql.includes('INSERT INTO webhook_outbox'))).toBe(false);
+    expect(webhookDeliveryStore.getDeadLetterQueueItems()).toEqual([
+      expect.objectContaining({
+        deliveryId: 'outbox_50',
+        failureCode: 'poison_status',
+        failureReason: 'HTTP 400 after 1 attempt',
+      }),
+    ]);
   });
 
   it('defers delivery when the shared Redis circuit breaker is open', async () => {


### PR DESCRIPTION
Fixes #345.

## Summary
- validate durable webhook outbox rows before attempting delivery so invalid JSON, non-object payloads, unsupported/mismatched event markers, and unsafe endpoint URLs are fast-tracked to DLQ
- move non-retryable HTTP responses to DLQ with `poison_status`, while retryable max-attempt failures use `exhausted_retry`
- expose `failureCode` on the webhook DLQ API and document poison vs exhausted failure modes
- clean up duplicate retry exports/imports currently blocking related webhook test collection

## Validation
- `node .\node_modules\vitest\vitest.mjs run tests\webhooks\service.dispatcher.test.ts src\webhooks\retry.test.ts tests\webhooks\retry.rateLimit.test.ts tests\webhooks\circuitBreaker.store.test.ts src\webhooks\store.test.ts --reporter=dot` (57 passed)
- `node .\node_modules\eslint\bin\eslint.js src\webhooks\service.ts src\webhooks\store.ts src\webhooks\retry.ts src\routes\webhooks.ts tests\webhooks\service.dispatcher.test.ts`
- `git diff --check`

## Notes
- Full `tsc --noEmit --pretty false` is still blocked by existing repository baseline errors in `src/openapi/spec.ts` before it reaches these changes.