### PR TITLE
fix(openapi): align stream schema with API response

### DIFF
--- a/src/openapi/spec.ts
+++ b/src/openapi/spec.ts
@@ -14,35 +14,47 @@ extendZodWithOpenApi(z);
 
 export const registry = new OpenAPIRegistry();
 
+const EXAMPLE_SENDER = 'GBBD47UZQ5CYVVEUVRYNQZX3G5KRZTAYF5XSVS2UKMCCWW5LJJLXNVQX';
+const EXAMPLE_RECIPIENT = 'GBRPYHIL2CI3WHZDTOOQFC6EB4KJJGUJJBBX7XNLG5DBNVQWDADUZSQX';
+const NEXT_CURSOR_DESCRIPTION =
+  'Cursor to pass as `cursor` on the next request. Null on the last page (has_more=false).';
+
 // ── Shared schemas ────────────────────────────────────────────────────────────
 
 const DecimalString = registry.register(
   'DecimalString',
-  z.string().openapi({ example: '1000000.0000000', description: 'Decimal string amount' }),
+  z.string().openapi({ example: '1000000.0000000', description: 'Decimal string amount' })
 );
 
 const StellarAddress = registry.register(
   'StellarAddress',
-  z.string().openapi({ example: 'GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN', description: 'Stellar public key (G…)' }),
+  z
+    .string()
+    .openapi({ example: EXAMPLE_SENDER, description: 'Stellar public key beginning with G' })
 );
 
+/** Source of truth: matches StreamStatus in src/db/types.ts and the DB CHECK constraint. */
 const StreamStatus = registry.register(
   'StreamStatus',
-  z.enum(['scheduled', 'active', 'paused', 'completed', 'cancelled']).openapi({ example: 'active' }),
+  z.enum(['active', 'paused', 'completed', 'cancelled']).openapi({ example: 'active' })
 );
 
 const StreamObject = registry.register(
   'Stream',
-  z.object({
-    id: z.string().openapi({ example: 'stream-abc123' }),
-    sender: StellarAddress,
-    recipient: StellarAddress,
-    depositAmount: DecimalString,
-    ratePerSecond: DecimalString,
-    startTime: z.number().int().openapi({ example: 1700000000 }),
-    endTime: z.number().int().openapi({ example: 0 }),
-    status: StreamStatus,
-  }).openapi({ description: 'A treasury stream record' }),
+  z
+    .object({
+      id: z.string().openapi({ example: 'stream-abc123' }),
+      sender: StellarAddress,
+      recipient: StellarAddress,
+      depositAmount: DecimalString,
+      streamedAmount: DecimalString,
+      remainingAmount: DecimalString,
+      ratePerSecond: DecimalString,
+      startTime: z.number().int().openapi({ example: 1700000000 }),
+      endTime: z.number().int().openapi({ example: 0 }),
+      status: StreamStatus,
+    })
+    .openapi({ description: 'A treasury stream record' })
 );
 
 const ResponseMeta = registry.register(
@@ -51,7 +63,7 @@ const ResponseMeta = registry.register(
     timestamp: z.string().openapi({ example: '2026-01-01T00:00:00.000Z' }),
     requestId: z.string().optional().openapi({ example: 'req_abc123' }),
     idempotencyReplayed: z.boolean().optional(),
-  }),
+  })
 );
 
 const ErrorEnvelope = registry.register(
@@ -64,7 +76,7 @@ const ErrorEnvelope = registry.register(
       details: z.unknown().optional(),
       requestId: z.string().optional(),
     }),
-  }),
+  })
 );
 
 // ── Security schemes ──────────────────────────────────────────────────────────
@@ -90,28 +102,56 @@ function successSchema<T extends z.ZodTypeAny>(dataSchema: T) {
 }
 
 const errorResponses = {
-  '400': { description: 'Validation error', content: { 'application/json': { schema: ErrorEnvelope } } },
-  '401': { description: 'Unauthorized', content: { 'application/json': { schema: ErrorEnvelope } } },
+  '400': {
+    description: 'Validation error',
+    content: { 'application/json': { schema: ErrorEnvelope } },
+  },
+  '401': {
+    description: 'Unauthorized',
+    content: { 'application/json': { schema: ErrorEnvelope } },
+  },
   '403': { description: 'Forbidden', content: { 'application/json': { schema: ErrorEnvelope } } },
   '404': { description: 'Not found', content: { 'application/json': { schema: ErrorEnvelope } } },
-  '408': { description: 'Request timeout', content: { 'application/json': { schema: ErrorEnvelope } } },
+  '408': {
+    description: 'Request timeout',
+    content: { 'application/json': { schema: ErrorEnvelope } },
+  },
   '409': { description: 'Conflict', content: { 'application/json': { schema: ErrorEnvelope } } },
-  '422': { description: 'Unprocessable entity', content: { 'application/json': { schema: ErrorEnvelope } } },
-  '429': { description: 'Too many requests', content: { 'application/json': { schema: ErrorEnvelope } } },
-  '500': { description: 'Internal server error', content: { 'application/json': { schema: ErrorEnvelope } } },
-  '503': { description: 'Service unavailable', content: { 'application/json': { schema: ErrorEnvelope } } },
+  '422': {
+    description: 'Unprocessable entity',
+    content: { 'application/json': { schema: ErrorEnvelope } },
+  },
+  '429': {
+    description: 'Too many requests',
+    content: { 'application/json': { schema: ErrorEnvelope } },
+  },
+  '500': {
+    description: 'Internal server error',
+    content: { 'application/json': { schema: ErrorEnvelope } },
+  },
+  '503': {
+    description: 'Service unavailable',
+    content: { 'application/json': { schema: ErrorEnvelope } },
+  },
 } as const;
 
 // ── GET / ─────────────────────────────────────────────────────────────────────
 
 registry.registerPath({
-  method: 'get', path: '/',
+  method: 'get',
+  path: '/',
   summary: 'API info',
   tags: ['meta'],
   responses: {
     '200': {
       description: 'API metadata',
-      content: { 'application/json': { schema: successSchema(z.object({ name: z.string(), version: z.string(), docs: z.string() })) } },
+      content: {
+        'application/json': {
+          schema: successSchema(
+            z.object({ name: z.string(), version: z.string(), docs: z.string() })
+          ),
+        },
+      },
     },
   },
 });
@@ -119,7 +159,8 @@ registry.registerPath({
 // ── Health ────────────────────────────────────────────────────────────────────
 
 registry.registerPath({
-  method: 'get', path: '/health',
+  method: 'get',
+  path: '/health',
   summary: 'Liveness probe',
   tags: ['health'],
   responses: {
@@ -133,7 +174,12 @@ registry.registerPath({
             network: z.string(),
             timestamp: z.string(),
           }),
-          example: { status: 'ok', service: 'fluxora-backend', network: 'testnet', timestamp: '2026-01-01T00:00:00.000Z' },
+          example: {
+            status: 'ok',
+            service: 'fluxora-backend',
+            network: 'testnet',
+            timestamp: '2026-01-01T00:00:00.000Z',
+          },
         },
       },
     },
@@ -142,26 +188,43 @@ registry.registerPath({
 });
 
 registry.registerPath({
-  method: 'get', path: '/health/ready',
+  method: 'get',
+  path: '/health/ready',
   summary: 'Readiness probe',
   tags: ['health'],
   responses: {
     '200': {
       description: 'All dependencies healthy or degraded',
-      content: { 'application/json': { schema: z.object({ status: z.enum(['healthy', 'degraded']), version: z.string(), dependencies: z.record(z.string(), z.string()) }) } },
+      content: {
+        'application/json': {
+          schema: z.object({
+            status: z.enum(['healthy', 'degraded']),
+            version: z.string(),
+            dependencies: z.record(z.string(), z.string()),
+          }),
+        },
+      },
     },
-    '503': { description: 'One or more dependencies unhealthy', content: { 'application/json': { schema: ErrorEnvelope } } },
+    '503': {
+      description: 'One or more dependencies unhealthy',
+      content: { 'application/json': { schema: ErrorEnvelope } },
+    },
   },
 });
 
 registry.registerPath({
-  method: 'get', path: '/health/live',
+  method: 'get',
+  path: '/health/live',
   summary: 'Detailed health report',
   tags: ['health'],
   responses: {
     '200': {
       description: 'Full health report',
-      content: { 'application/json': { schema: successSchema(z.object({ report: z.record(z.string(), z.unknown()) })) } },
+      content: {
+        'application/json': {
+          schema: successSchema(z.object({ report: z.record(z.string(), z.unknown()) })),
+        },
+      },
     },
     '500': errorResponses['500'],
   },
@@ -222,7 +285,7 @@ const StreamCursorToken = registry.register(
       'Cursors do not expose internal row ids or PII. ' +
       'Stable across inserts; invalid/expired cursors return 400 INVALID_CURSOR.',
     example: 'eyJ2IjoxLCJsYXN0SWQiOiJzdHJlYW0tYWJjMTIzIn0',
-  }),
+  })
 );
 
 /** Reusable list-page response schema. */
@@ -237,37 +300,38 @@ const StreamListPage = registry.register(
       example: true,
     }),
     next_cursor: StreamCursorToken.nullable().openapi({
-      description:
-        'Cursor to pass as `cursor` on the next request. ' +
-        'Null on the last page (has_more=false).',
+      description: NEXT_CURSOR_DESCRIPTION,
       example: 'eyJ2IjoxLCJsYXN0SWQiOiJzdHJlYW0tYWJjMTIzIn0',
     }),
     total: z.number().int().optional().openapi({
       description: 'Total matching rows. Only present when include_total=true.',
       example: 42,
     }),
-  }),
+  })
 );
 
 /** 400 body specific to invalid/expired cursor. */
-const InvalidCursorError = z.object({
-  success: z.literal(false),
-  error: z.object({
-    code: z.literal('VALIDATION_ERROR').openapi({ example: 'VALIDATION_ERROR' }),
-    message: z.string().openapi({
-      example: 'cursor must be a valid opaque pagination token',
+const InvalidCursorError = z
+  .object({
+    success: z.literal(false),
+    error: z.object({
+      code: z.literal('VALIDATION_ERROR').openapi({ example: 'VALIDATION_ERROR' }),
+      message: z.string().openapi({
+        example: 'cursor must be a valid opaque pagination token',
+      }),
     }),
-  }),
-}).openapi({
-  description:
-    'Returned when the `cursor` parameter is present but cannot be decoded ' +
-    '(bad base64url, wrong JSON shape, missing version tag, or empty lastId). ' +
-    'The client must discard the cursor and restart pagination from the first page ' +
-    'by omitting the `cursor` parameter.',
-});
+  })
+  .openapi({
+    description:
+      'Returned when the `cursor` parameter is present but cannot be decoded ' +
+      '(bad base64url, wrong JSON shape, missing version tag, or empty lastId). ' +
+      'The client must discard the cursor and restart pagination from the first page ' +
+      'by omitting the `cursor` parameter.',
+  });
 
 registry.registerPath({
-  method: 'get', path: '/api/streams',
+  method: 'get',
+  path: '/api/streams',
   summary: 'List streams (cursor-paginated)',
   description:
     '## Cursor Pagination\n\n' +
@@ -289,21 +353,24 @@ registry.registerPath({
         example: '20',
         description: 'Page size (1–100, default 20).',
       }),
-      cursor: z.string().optional().openapi({
-        description:
-          'Opaque cursor from the previous page's `next_cursor`. ' +
-          'Omit to request the first page. ' +
-          'Treated as a black box — do not construct manually.',
-        example: 'eyJ2IjoxLCJsYXN0SWQiOiJzdHJlYW0tYWJjMTIzIn0',
-      }),
+      cursor: z
+        .string()
+        .optional()
+        .openapi({
+          description:
+            "Opaque cursor from the previous page's `next_cursor`. " +
+            'Omit to request the first page. ' +
+            'Treated as a black box — do not construct manually.',
+          example: 'eyJ2IjoxLCJsYXN0SWQiOiJzdHJlYW0tYWJjMTIzIn0',
+        }),
       status: z.string().optional().openapi({ example: 'active' }),
       sender: z.string().optional().openapi({
         description: 'Filter by sender Stellar address.',
-        example: 'GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN',
+        example: EXAMPLE_SENDER,
       }),
       recipient: z.string().optional().openapi({
         description: 'Filter by recipient Stellar address.',
-        example: 'GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGZCP2J7F1NRQKQOHP3OGN',
+        example: EXAMPLE_RECIPIENT,
       }),
       include_total: z.enum(['true', 'false']).optional().openapi({
         description: 'When "true", include total count of matching rows in the response.',
@@ -321,16 +388,19 @@ registry.registerPath({
           examples: {
             firstPage: {
               summary: 'First page (no cursor supplied)',
-              description: 'Omit `cursor` to request the first page. `has_more: true` means more pages follow.',
+              description:
+                'Omit `cursor` to request the first page. `has_more: true` means more pages follow.',
               value: {
                 success: true,
                 data: {
                   streams: [
                     {
                       id: 'stream-aaa111',
-                      sender: 'GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN',
-                      recipient: 'GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGZCP2J7F1NRQKQOHP3OGN',
+                      sender: EXAMPLE_SENDER,
+                      recipient: EXAMPLE_RECIPIENT,
                       depositAmount: '1000000.0000000',
+                      streamedAmount: '0',
+                      remainingAmount: '1000000.0000000',
                       ratePerSecond: '0.0000116',
                       startTime: 1700000000,
                       endTime: 0,
@@ -354,9 +424,11 @@ registry.registerPath({
                   streams: [
                     {
                       id: 'stream-bbb222',
-                      sender: 'GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN',
-                      recipient: 'GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGZCP2J7F1NRQKQOHP3OGN',
+                      sender: EXAMPLE_SENDER,
+                      recipient: EXAMPLE_RECIPIENT,
                       depositAmount: '500000.0000000',
+                      streamedAmount: '1000.0000000',
+                      remainingAmount: '499000.0000000',
                       ratePerSecond: '0.0000058',
                       startTime: 1700001000,
                       endTime: 0,
@@ -380,9 +452,11 @@ registry.registerPath({
                   streams: [
                     {
                       id: 'stream-zzz999',
-                      sender: 'GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN',
-                      recipient: 'GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGZCP2J7F1NRQKQOHP3OGN',
+                      sender: EXAMPLE_SENDER,
+                      recipient: EXAMPLE_RECIPIENT,
                       depositAmount: '250000.0000000',
+                      streamedAmount: '250000.0000000',
+                      remainingAmount: '0',
                       ratePerSecond: '0.0000029',
                       startTime: 1700002000,
                       endTime: 1800000000,
@@ -407,7 +481,7 @@ registry.registerPath({
         'Discard the cursor and restart pagination from page 1 (omit `cursor`).',
       content: {
         'application/json': {
-          schema: ErrorEnvelope,
+          schema: InvalidCursorError,
           examples: {
             invalidCursor: {
               summary: 'Invalid or expired cursor',
@@ -438,14 +512,17 @@ registry.registerPath({
 });
 
 registry.registerPath({
-  method: 'get', path: '/api/streams/{id}',
+  method: 'get',
+  path: '/api/streams/{id}',
   summary: 'Get stream by ID',
   tags: ['streams'],
   request: { params: z.object({ id: z.string().openapi({ example: 'stream-abc123' }) }) },
   responses: {
     '200': {
       description: 'Stream record',
-      content: { 'application/json': { schema: successSchema(z.object({ stream: StreamObject })) } },
+      content: {
+        'application/json': { schema: successSchema(z.object({ stream: StreamObject })) },
+      },
     },
     '404': errorResponses['404'],
     '503': errorResponses['503'],
@@ -453,7 +530,8 @@ registry.registerPath({
 });
 
 registry.registerPath({
-  method: 'head', path: '/api/streams/{id}',
+  method: 'head',
+  path: '/api/streams/{id}',
   summary: 'Check whether a stream exists',
   tags: ['streams'],
   request: { params: z.object({ id: z.string().openapi({ example: 'stream-abc123' }) }) },
@@ -467,12 +545,20 @@ registry.registerPath({
 });
 
 registry.registerPath({
-  method: 'post', path: '/api/streams',
+  method: 'post',
+  path: '/api/streams',
   summary: 'Create stream',
   tags: ['streams'],
   security: [{ bearerAuth: [] }],
   request: {
-    headers: z.object({ 'Idempotency-Key': z.string().openapi({ description: 'Unique key (1–128 chars) to prevent duplicate creation', example: 'my-key-001' }) }),
+    headers: z.object({
+      'Idempotency-Key': z
+        .string()
+        .openapi({
+          description: 'Unique key (1–128 chars) to prevent duplicate creation',
+          example: 'my-key-001',
+        }),
+    }),
     body: {
       required: true,
       content: {
@@ -486,8 +572,8 @@ registry.registerPath({
             endTime: z.number().int().optional().openapi({ example: 0 }),
           }),
           example: {
-            sender: 'GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN',
-            recipient: 'GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGZCP2J7F1NRQKQOHP3OGN',
+            sender: EXAMPLE_SENDER,
+            recipient: EXAMPLE_RECIPIENT,
             depositAmount: '1000000.0000000',
             ratePerSecond: '0.0000116',
             startTime: 1700000000,
@@ -509,7 +595,8 @@ registry.registerPath({
 });
 
 registry.registerPath({
-  method: 'delete', path: '/api/streams/{id}',
+  method: 'delete',
+  path: '/api/streams/{id}',
   summary: 'Cancel stream',
   tags: ['streams'],
   security: [{ bearerAuth: [] }],
@@ -517,7 +604,11 @@ registry.registerPath({
   responses: {
     '200': {
       description: 'Stream cancelled',
-      content: { 'application/json': { schema: successSchema(z.object({ message: z.string(), id: z.string() })) } },
+      content: {
+        'application/json': {
+          schema: successSchema(z.object({ message: z.string(), id: z.string() })),
+        },
+      },
     },
     '401': errorResponses['401'],
     '404': errorResponses['404'],
@@ -527,7 +618,8 @@ registry.registerPath({
 });
 
 registry.registerPath({
-  method: 'patch', path: '/api/streams/{id}/status',
+  method: 'patch',
+  path: '/api/streams/{id}/status',
   summary: 'Transition stream status',
   tags: ['streams'],
   request: {
@@ -543,7 +635,10 @@ registry.registerPath({
     },
   },
   responses: {
-    '200': { description: 'Updated stream', content: { 'application/json': { schema: successSchema(StreamObject) } } },
+    '200': {
+      description: 'Updated stream',
+      content: { 'application/json': { schema: successSchema(StreamObject) } },
+    },
     '400': errorResponses['400'],
     '404': errorResponses['404'],
     '409': errorResponses['409'],
@@ -554,7 +649,8 @@ registry.registerPath({
 // ── Auth ──────────────────────────────────────────────────────────────────────
 
 registry.registerPath({
-  method: 'post', path: '/api/auth/session',
+  method: 'post',
+  path: '/api/auth/session',
   summary: 'Create session (get JWT)',
   tags: ['auth'],
   request: {
@@ -563,7 +659,7 @@ registry.registerPath({
       content: {
         'application/json': {
           schema: z.object({
-            address: z.string().optional().openapi({ example: 'GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN' }),
+            address: z.string().optional().openapi({ example: EXAMPLE_SENDER }),
             role: z.enum(['operator', 'viewer']).optional().openapi({ example: 'viewer' }),
             idToken: z.string().optional().openapi({ description: 'External OIDC ID token' }),
           }),
@@ -576,7 +672,10 @@ registry.registerPath({
       description: 'JWT issued',
       content: {
         'application/json': {
-          schema: z.object({ token: z.string(), user: z.object({ address: z.string(), role: z.string() }) }),
+          schema: z.object({
+            token: z.string(),
+            user: z.object({ address: z.string(), role: z.string() }),
+          }),
           example: { token: 'eyJ...', user: { address: 'GAAZI4...', role: 'viewer' } },
         },
       },
@@ -589,7 +688,8 @@ registry.registerPath({
 // ── Audit ─────────────────────────────────────────────────────────────────────
 
 registry.registerPath({
-  method: 'get', path: '/api/audit',
+  method: 'get',
+  path: '/api/audit',
   summary: 'List audit log entries',
   tags: ['audit'],
   security: [{ bearerAuth: [] }],
@@ -598,10 +698,12 @@ registry.registerPath({
       description: 'Audit entries',
       content: {
         'application/json': {
-          schema: successSchema(z.object({
-            entries: z.array(z.record(z.string(), z.unknown())),
-            total: z.number().int(),
-          })),
+          schema: successSchema(
+            z.object({
+              entries: z.array(z.record(z.string(), z.unknown())),
+              total: z.number().int(),
+            })
+          ),
         },
       },
     },
@@ -613,58 +715,88 @@ registry.registerPath({
 // ── Privacy ───────────────────────────────────────────────────────────────────
 
 registry.registerPath({
-  method: 'get', path: '/api/privacy/policy',
+  method: 'get',
+  path: '/api/privacy/policy',
   summary: 'PII policy document',
   tags: ['privacy'],
   responses: {
-    '200': { description: 'Full PII policy', content: { 'application/json': { schema: z.record(z.string(), z.unknown()) } } },
+    '200': {
+      description: 'Full PII policy',
+      content: { 'application/json': { schema: z.record(z.string(), z.unknown()) } },
+    },
   },
 });
 
 registry.registerPath({
-  method: 'get', path: '/api/privacy/retention',
+  method: 'get',
+  path: '/api/privacy/retention',
   summary: 'Data retention schedule',
   tags: ['privacy'],
   responses: {
-    '200': { description: 'Retention schedule', content: { 'application/json': { schema: z.record(z.string(), z.unknown()) } } },
+    '200': {
+      description: 'Retention schedule',
+      content: { 'application/json': { schema: z.record(z.string(), z.unknown()) } },
+    },
   },
 });
 
 // ── Admin ─────────────────────────────────────────────────────────────────────
 
 registry.registerPath({
-  method: 'get', path: '/api/admin/status/read-only',
+  method: 'get',
+  path: '/api/admin/status/read-only',
   summary: 'Read pause flags (no auth)',
   tags: ['admin'],
   responses: {
-    '200': { description: 'Pause flags', content: { 'application/json': { schema: z.object({ pauseFlags: z.record(z.string(), z.boolean()) }) } } },
+    '200': {
+      description: 'Pause flags',
+      content: {
+        'application/json': { schema: z.object({ pauseFlags: z.record(z.string(), z.boolean()) }) },
+      },
+    },
   },
 });
 
 registry.registerPath({
-  method: 'get', path: '/api/admin/status',
+  method: 'get',
+  path: '/api/admin/status',
   summary: 'Admin status (pause flags + reindex state)',
   tags: ['admin'],
   security: [{ bearerAuth: [] }],
   responses: {
-    '200': { description: 'Admin status', content: { 'application/json': { schema: z.object({ pauseFlags: z.record(z.string(), z.boolean()), reindex: z.record(z.string(), z.unknown()) }) } } },
+    '200': {
+      description: 'Admin status',
+      content: {
+        'application/json': {
+          schema: z.object({
+            pauseFlags: z.record(z.string(), z.boolean()),
+            reindex: z.record(z.string(), z.unknown()),
+          }),
+        },
+      },
+    },
     '401': errorResponses['401'],
   },
 });
 
 registry.registerPath({
-  method: 'get', path: '/api/admin/pause',
+  method: 'get',
+  path: '/api/admin/pause',
   summary: 'Get pause flags',
   tags: ['admin'],
   security: [{ bearerAuth: [] }],
   responses: {
-    '200': { description: 'Pause flags', content: { 'application/json': { schema: z.record(z.string(), z.boolean()) } } },
+    '200': {
+      description: 'Pause flags',
+      content: { 'application/json': { schema: z.record(z.string(), z.boolean()) } },
+    },
     '401': errorResponses['401'],
   },
 });
 
 registry.registerPath({
-  method: 'put', path: '/api/admin/pause',
+  method: 'put',
+  path: '/api/admin/pause',
   summary: 'Update pause flags',
   tags: ['admin'],
   security: [{ bearerAuth: [] }],
@@ -683,7 +815,14 @@ registry.registerPath({
     },
   },
   responses: {
-    '200': { description: 'Updated pause flags', content: { 'application/json': { schema: z.object({ message: z.string(), pauseFlags: z.record(z.string(), z.boolean()) }) } } },
+    '200': {
+      description: 'Updated pause flags',
+      content: {
+        'application/json': {
+          schema: z.object({ message: z.string(), pauseFlags: z.record(z.string(), z.boolean()) }),
+        },
+      },
+    },
     '400': errorResponses['400'],
     '401': errorResponses['401'],
     '503': errorResponses['503'],
@@ -691,69 +830,105 @@ registry.registerPath({
 });
 
 registry.registerPath({
-  method: 'get', path: '/api/admin/reindex',
+  method: 'get',
+  path: '/api/admin/reindex',
   summary: 'Get reindex state',
   tags: ['admin'],
   security: [{ bearerAuth: [] }],
   responses: {
-    '200': { description: 'Reindex state', content: { 'application/json': { schema: z.record(z.string(), z.unknown()) } } },
+    '200': {
+      description: 'Reindex state',
+      content: { 'application/json': { schema: z.record(z.string(), z.unknown()) } },
+    },
     '401': errorResponses['401'],
   },
 });
 
 registry.registerPath({
-  method: 'post', path: '/api/admin/reindex',
+  method: 'post',
+  path: '/api/admin/reindex',
   summary: 'Trigger reindex',
   tags: ['admin'],
   security: [{ bearerAuth: [] }],
   responses: {
-    '202': { description: 'Reindex started', content: { 'application/json': { schema: z.object({ message: z.string(), reindex: z.record(z.string(), z.unknown()) }) } } },
+    '202': {
+      description: 'Reindex started',
+      content: {
+        'application/json': {
+          schema: z.object({ message: z.string(), reindex: z.record(z.string(), z.unknown()) }),
+        },
+      },
+    },
     '401': errorResponses['401'],
     '409': errorResponses['409'],
   },
 });
 
 registry.registerPath({
-  method: 'get', path: '/api/admin/api-keys',
+  method: 'get',
+  path: '/api/admin/api-keys',
   summary: 'List API keys (hashes only)',
   tags: ['admin'],
   security: [{ bearerAuth: [] }],
   responses: {
-    '200': { description: 'API key list', content: { 'application/json': { schema: z.object({ apiKeys: z.array(z.record(z.string(), z.unknown())) }) } } },
+    '200': {
+      description: 'API key list',
+      content: {
+        'application/json': {
+          schema: z.object({ apiKeys: z.array(z.record(z.string(), z.unknown())) }),
+        },
+      },
+    },
     '401': errorResponses['401'],
   },
 });
 
 registry.registerPath({
-  method: 'post', path: '/api/admin/api-keys',
+  method: 'post',
+  path: '/api/admin/api-keys',
   summary: 'Create API key',
   tags: ['admin'],
   security: [{ bearerAuth: [] }],
   request: {
-    body: { required: true, content: { 'application/json': { schema: z.object({ name: z.string().openapi({ example: 'my-service' }) }) } } },
+    body: {
+      required: true,
+      content: {
+        'application/json': {
+          schema: z.object({ name: z.string().openapi({ example: 'my-service' }) }),
+        },
+      },
+    },
   },
   responses: {
-    '201': { description: 'API key created (raw key returned once)', content: { 'application/json': { schema: z.record(z.string(), z.unknown()) } } },
+    '201': {
+      description: 'API key created (raw key returned once)',
+      content: { 'application/json': { schema: z.record(z.string(), z.unknown()) } },
+    },
     '400': errorResponses['400'],
     '401': errorResponses['401'],
   },
 });
 
 registry.registerPath({
-  method: 'post', path: '/api/admin/api-keys/{id}/rotate',
+  method: 'post',
+  path: '/api/admin/api-keys/{id}/rotate',
   summary: 'Rotate API key',
   tags: ['admin'],
   security: [{ bearerAuth: [] }],
   request: { params: z.object({ id: z.string() }) },
   responses: {
-    '200': { description: 'New raw key returned once', content: { 'application/json': { schema: z.record(z.string(), z.unknown()) } } },
+    '200': {
+      description: 'New raw key returned once',
+      content: { 'application/json': { schema: z.record(z.string(), z.unknown()) } },
+    },
     '401': errorResponses['401'],
     '404': errorResponses['404'],
   },
 });
 
 registry.registerPath({
-  method: 'delete', path: '/api/admin/api-keys/{id}',
+  method: 'delete',
+  path: '/api/admin/api-keys/{id}',
   summary: 'Revoke API key',
   tags: ['admin'],
   security: [{ bearerAuth: [] }],
@@ -768,7 +943,8 @@ registry.registerPath({
 // ── DLQ ───────────────────────────────────────────────────────────────────────
 
 registry.registerPath({
-  method: 'get', path: '/admin/dlq',
+  method: 'get',
+  path: '/admin/dlq',
   summary: 'List dead-letter queue entries',
   tags: ['admin'],
   security: [{ bearerAuth: [] }],
@@ -780,7 +956,10 @@ registry.registerPath({
     }),
   },
   responses: {
-    '200': { description: 'DLQ entries', content: { 'application/json': { schema: z.record(z.string(), z.unknown()) } } },
+    '200': {
+      description: 'DLQ entries',
+      content: { 'application/json': { schema: z.record(z.string(), z.unknown()) } },
+    },
     '400': errorResponses['400'],
     '401': errorResponses['401'],
     '403': errorResponses['403'],
@@ -788,13 +967,17 @@ registry.registerPath({
 });
 
 registry.registerPath({
-  method: 'get', path: '/admin/dlq/{id}',
+  method: 'get',
+  path: '/admin/dlq/{id}',
   summary: 'Get DLQ entry',
   tags: ['admin'],
   security: [{ bearerAuth: [] }],
   request: { params: z.object({ id: z.string() }) },
   responses: {
-    '200': { description: 'DLQ entry', content: { 'application/json': { schema: z.record(z.string(), z.unknown()) } } },
+    '200': {
+      description: 'DLQ entry',
+      content: { 'application/json': { schema: z.record(z.string(), z.unknown()) } },
+    },
     '401': errorResponses['401'],
     '403': errorResponses['403'],
     '404': errorResponses['404'],
@@ -802,13 +985,17 @@ registry.registerPath({
 });
 
 registry.registerPath({
-  method: 'delete', path: '/admin/dlq/{id}',
+  method: 'delete',
+  path: '/admin/dlq/{id}',
   summary: 'Delete DLQ entry',
   tags: ['admin'],
   security: [{ bearerAuth: [] }],
   request: { params: z.object({ id: z.string() }) },
   responses: {
-    '200': { description: 'Entry deleted', content: { 'application/json': { schema: z.record(z.string(), z.unknown()) } } },
+    '200': {
+      description: 'Entry deleted',
+      content: { 'application/json': { schema: z.record(z.string(), z.unknown()) } },
+    },
     '401': errorResponses['401'],
     '403': errorResponses['403'],
     '404': errorResponses['404'],
@@ -816,13 +1003,17 @@ registry.registerPath({
 });
 
 registry.registerPath({
-  method: 'post', path: '/admin/dlq/{id}/retry',
+  method: 'post',
+  path: '/admin/dlq/{id}/retry',
   summary: 'Retry DLQ entry',
   tags: ['admin'],
   security: [{ bearerAuth: [] }],
   request: { params: z.object({ id: z.string() }) },
   responses: {
-    '200': { description: 'Retry queued', content: { 'application/json': { schema: z.record(z.string(), z.unknown()) } } },
+    '200': {
+      description: 'Retry queued',
+      content: { 'application/json': { schema: z.record(z.string(), z.unknown()) } },
+    },
     '401': errorResponses['401'],
     '403': errorResponses['403'],
     '404': errorResponses['404'],
@@ -832,27 +1023,36 @@ registry.registerPath({
 // ── Rate limits ───────────────────────────────────────────────────────────────
 
 registry.registerPath({
-  method: 'get', path: '/api/rate-limits',
+  method: 'get',
+  path: '/api/rate-limits',
   summary: "Caller's current rate-limit status",
   tags: ['rate-limits'],
   responses: {
-    '200': { description: 'Rate-limit status', content: { 'application/json': { schema: z.record(z.string(), z.unknown()) } } },
+    '200': {
+      description: 'Rate-limit status',
+      content: { 'application/json': { schema: z.record(z.string(), z.unknown()) } },
+    },
   },
 });
 
 registry.registerPath({
-  method: 'get', path: '/api/rate-limits/config',
+  method: 'get',
+  path: '/api/rate-limits/config',
   summary: 'Active rate-limit config (admin)',
   tags: ['rate-limits'],
   security: [{ bearerAuth: [] }],
   responses: {
-    '200': { description: 'Rate-limit config', content: { 'application/json': { schema: z.record(z.string(), z.unknown()) } } },
+    '200': {
+      description: 'Rate-limit config',
+      content: { 'application/json': { schema: z.record(z.string(), z.unknown()) } },
+    },
     '401': errorResponses['401'],
   },
 });
 
 registry.registerPath({
-  method: 'put', path: '/api/rate-limits/config',
+  method: 'put',
+  path: '/api/rate-limits/config',
   summary: 'Update rate-limit config (admin)',
   tags: ['rate-limits'],
   security: [{ bearerAuth: [] }],
@@ -862,9 +1062,27 @@ registry.registerPath({
       content: {
         'application/json': {
           schema: z.object({
-            ip: z.object({ windowMs: z.number().optional(), max: z.number().optional(), enabled: z.boolean().optional() }).optional(),
-            apiKey: z.object({ windowMs: z.number().optional(), max: z.number().optional(), enabled: z.boolean().optional() }).optional(),
-            admin: z.object({ windowMs: z.number().optional(), max: z.number().optional(), enabled: z.boolean().optional() }).optional(),
+            ip: z
+              .object({
+                windowMs: z.number().optional(),
+                max: z.number().optional(),
+                enabled: z.boolean().optional(),
+              })
+              .optional(),
+            apiKey: z
+              .object({
+                windowMs: z.number().optional(),
+                max: z.number().optional(),
+                enabled: z.boolean().optional(),
+              })
+              .optional(),
+            admin: z
+              .object({
+                windowMs: z.number().optional(),
+                max: z.number().optional(),
+                enabled: z.boolean().optional(),
+              })
+              .optional(),
           }),
           example: { ip: { max: 200 } },
         },
@@ -872,7 +1090,10 @@ registry.registerPath({
     },
   },
   responses: {
-    '200': { description: 'Updated config', content: { 'application/json': { schema: z.record(z.string(), z.unknown()) } } },
+    '200': {
+      description: 'Updated config',
+      content: { 'application/json': { schema: z.record(z.string(), z.unknown()) } },
+    },
     '400': errorResponses['400'],
     '401': errorResponses['401'],
     '409': errorResponses['409'],
@@ -882,7 +1103,8 @@ registry.registerPath({
 // ── Internal indexer ──────────────────────────────────────────────────────────
 
 registry.registerPath({
-  method: 'post', path: '/internal/indexer/contract-events',
+  method: 'post',
+  path: '/internal/indexer/contract-events',
   summary: 'Ingest contract event batch',
   tags: ['indexer'],
   security: [{ indexerWorkerToken: [] }],
@@ -892,23 +1114,52 @@ registry.registerPath({
       content: {
         'application/json': {
           schema: z.object({ events: z.array(z.record(z.string(), z.unknown())).max(100) }),
-          example: { events: [{ eventId: 'evt-001', ledger: 1000, contractId: 'C...', topic: 'stream.created', payload: {} }] },
+          example: {
+            events: [
+              {
+                eventId: 'evt-001',
+                ledger: 1000,
+                contractId: 'C...',
+                topic: 'stream.created',
+                payload: {},
+              },
+            ],
+          },
         },
       },
     },
   },
   responses: {
-    '200': { description: 'Batch persisted', content: { 'application/json': { schema: successSchema(z.object({ outcome: z.string(), insertedCount: z.number(), duplicateCount: z.number(), insertedEventIds: z.array(z.string()), duplicateEventIds: z.array(z.string()) })) } } },
+    '200': {
+      description: 'Batch persisted',
+      content: {
+        'application/json': {
+          schema: successSchema(
+            z.object({
+              outcome: z.string(),
+              insertedCount: z.number(),
+              duplicateCount: z.number(),
+              insertedEventIds: z.array(z.string()),
+              duplicateEventIds: z.array(z.string()),
+            })
+          ),
+        },
+      },
+    },
     '401': errorResponses['401'],
     '409': errorResponses['409'],
-    '413': { description: 'Payload too large', content: { 'application/json': { schema: ErrorEnvelope } } },
+    '413': {
+      description: 'Payload too large',
+      content: { 'application/json': { schema: ErrorEnvelope } },
+    },
     '429': errorResponses['429'],
     '503': errorResponses['503'],
   },
 });
 
 registry.registerPath({
-  method: 'get', path: '/internal/indexer/events',
+  method: 'get',
+  path: '/internal/indexer/events',
   summary: 'List stored contract events',
   tags: ['indexer'],
   security: [{ indexerWorkerToken: [] }],
@@ -923,19 +1174,26 @@ registry.registerPath({
     }),
   },
   responses: {
-    '200': { description: 'Event list', content: { 'application/json': { schema: successSchema(z.record(z.string(), z.unknown())) } } },
+    '200': {
+      description: 'Event list',
+      content: { 'application/json': { schema: successSchema(z.record(z.string(), z.unknown())) } },
+    },
     '401': errorResponses['401'],
   },
 });
 
 registry.registerPath({
-  method: 'get', path: '/internal/indexer/events/replay',
+  method: 'get',
+  path: '/internal/indexer/events/replay',
   summary: 'Cursor-based event replay',
   tags: ['indexer'],
   security: [{ indexerWorkerToken: [] }],
   request: {
     query: z.object({
-      afterEventId: z.string().optional().openapi({ description: 'Exclusive cursor; omit to start from beginning' }),
+      afterEventId: z
+        .string()
+        .optional()
+        .openapi({ description: 'Exclusive cursor; omit to start from beginning' }),
       fromLedger: z.string().optional(),
       toledger: z.string().optional(),
       contractId: z.string().optional(),
@@ -944,7 +1202,10 @@ registry.registerPath({
     }),
   },
   responses: {
-    '200': { description: 'Cursor-paginated event page', content: { 'application/json': { schema: successSchema(z.record(z.string(), z.unknown())) } } },
+    '200': {
+      description: 'Cursor-paginated event page',
+      content: { 'application/json': { schema: successSchema(z.record(z.string(), z.unknown())) } },
+    },
     '401': errorResponses['401'],
   },
 });
@@ -952,33 +1213,63 @@ registry.registerPath({
 // ── Webhooks ──────────────────────────────────────────────────────────────────
 
 registry.registerPath({
-  method: 'post', path: '/internal/webhooks/receive',
+  method: 'post',
+  path: '/internal/webhooks/receive',
   summary: 'Receive and verify an inbound Fluxora webhook',
   tags: ['webhooks'],
   request: {
     headers: z.object({
-      'x-fluxora-delivery-id': z.string().openapi({ description: 'Stable delivery ID for deduplication' }),
+      'x-fluxora-delivery-id': z
+        .string()
+        .openapi({ description: 'Stable delivery ID for deduplication' }),
       'x-fluxora-timestamp': z.string().openapi({ description: 'Unix timestamp in seconds' }),
       'x-fluxora-signature': z.string().openapi({ description: 'HMAC-SHA256 hex signature' }),
       'x-fluxora-event': z.string().optional().openapi({ example: 'stream.created' }),
     }),
-    body: { required: true, content: { 'application/json': { schema: z.record(z.string(), z.unknown()) } } },
+    body: {
+      required: true,
+      content: { 'application/json': { schema: z.record(z.string(), z.unknown()) } },
+    },
   },
   responses: {
-    '200': { description: 'Webhook verified and accepted', content: { 'application/json': { schema: z.object({ ok: z.literal(true), deliveryId: z.string(), eventType: z.string().nullable(), event: z.unknown() }) } } },
+    '200': {
+      description: 'Webhook verified and accepted',
+      content: {
+        'application/json': {
+          schema: z.object({
+            ok: z.literal(true),
+            deliveryId: z.string(),
+            eventType: z.string().nullable(),
+            event: z.unknown(),
+          }),
+        },
+      },
+    },
     '400': errorResponses['400'],
     '401': errorResponses['401'],
-    '413': { description: 'Payload too large', content: { 'application/json': { schema: ErrorEnvelope } } },
+    '413': {
+      description: 'Payload too large',
+      content: { 'application/json': { schema: ErrorEnvelope } },
+    },
   },
 });
 
 registry.registerPath({
-  method: 'post', path: '/internal/webhooks/queue',
+  method: 'post',
+  path: '/internal/webhooks/queue',
   summary: 'Queue a webhook delivery',
   tags: ['webhooks'],
-  request: { body: { required: true, content: { 'application/json': { schema: z.record(z.string(), z.unknown()) } } } },
+  request: {
+    body: {
+      required: true,
+      content: { 'application/json': { schema: z.record(z.string(), z.unknown()) } },
+    },
+  },
   responses: {
-    '200': { description: 'Queued', content: { 'application/json': { schema: z.record(z.string(), z.unknown()) } } },
+    '200': {
+      description: 'Queued',
+      content: { 'application/json': { schema: z.record(z.string(), z.unknown()) } },
+    },
     '400': errorResponses['400'],
   },
 });
@@ -986,11 +1277,15 @@ registry.registerPath({
 // ── Metrics ───────────────────────────────────────────────────────────────────
 
 registry.registerPath({
-  method: 'get', path: '/metrics',
+  method: 'get',
+  path: '/metrics',
   summary: 'Prometheus metrics',
   tags: ['observability'],
   responses: {
-    '200': { description: 'Prometheus text format', content: { 'text/plain': { schema: z.string() } } },
+    '200': {
+      description: 'Prometheus text format',
+      content: { 'text/plain': { schema: z.string() } },
+    },
   },
 });
 
@@ -1002,7 +1297,7 @@ registry.registerPath({
  */
 export function buildOpenApiSpec(): Record<string, unknown> {
   const generator = new OpenApiGeneratorV31(registry.definitions);
-  return generator.generateDocument({
+  const document = generator.generateDocument({
     openapi: '3.1.0',
     info: {
       title: 'Fluxora Backend API',
@@ -1010,7 +1305,10 @@ export function buildOpenApiSpec(): Record<string, unknown> {
       description:
         'REST API for the Fluxora treasury streaming protocol on Stellar. ' +
         'Covers stream CRUD, health, admin, indexer ingestion, webhook delivery, and observability.',
-      contact: { name: 'Fluxora Engineering', url: 'https://github.com/Fluxora-Org/Fluxora-Backend' },
+      contact: {
+        name: 'Fluxora Engineering',
+        url: 'https://github.com/Fluxora-Org/Fluxora-Backend',
+      },
       license: { name: 'MIT' },
     },
     servers: [{ url: 'http://localhost:3000', description: 'Local development' }],
@@ -1028,4 +1326,25 @@ export function buildOpenApiSpec(): Record<string, unknown> {
       { name: 'observability', description: 'Metrics' },
     ],
   }) as unknown as Record<string, unknown>;
+
+  applyOpenApiMetadataFixups(document);
+  return document;
+}
+
+function asObject(value: unknown): Record<string, unknown> | undefined {
+  return value !== null && typeof value === 'object' && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : undefined;
+}
+
+function applyOpenApiMetadataFixups(document: Record<string, unknown>): void {
+  const components = asObject(document['components']);
+  const schemas = asObject(components?.['schemas']);
+  const streamListPage = asObject(schemas?.['StreamListPage']);
+  const streamListPageProperties = asObject(streamListPage?.['properties']);
+  const nextCursor = asObject(streamListPageProperties?.['next_cursor']);
+
+  if (nextCursor && typeof nextCursor['description'] !== 'string') {
+    nextCursor['description'] = NEXT_CURSOR_DESCRIPTION;
+  }
 }

--- a/src/routes/streams.ts
+++ b/src/routes/streams.ts
@@ -65,18 +65,17 @@ import {
   asyncHandler,
   tooManyRequests,
 } from '../middleware/errorHandler.js';
-import { requireIdempotencyKey, parseIdempotencyKeyHeader } from '../middleware/requestProtection.js';
+import {
+  requireIdempotencyKey,
+  parseIdempotencyKeyHeader,
+} from '../middleware/requestProtection.js';
 import { SerializationLogger, info, debug, warn } from '../utils/logger.js';
 import { recordAuditEvent } from '../lib/auditLog.js';
 import { authenticate, requireAuth } from '../middleware/auth.js';
 import { successResponse, idempotentReplayResponse } from '../utils/response.js';
 import { streamRepository } from '../db/repositories/streamRepository.js';
 import { PoolExhaustedError } from '../db/pool.js';
-import {
-  CreateStreamSchema,
-  parseBody,
-  formatZodIssues,
-} from '../validation/schemas.js';
+import { CreateStreamSchema, parseBody, formatZodIssues } from '../validation/schemas.js';
 import { PaginationSchema } from '../validation/paginationSchema.js';
 import type { StreamStatus, StreamFilter, StreamRecord } from '../db/types.js';
 import { isTerminalStatus } from '../streams/status.js';
@@ -94,12 +93,7 @@ import {
   resolveSseConnectionLimits,
   tryAcquireSseConnection,
 } from '../streams/sseConnectionLimiter.js';
-import {
-  RedisIdempotencyStore,
-  NoOpIdempotencyStore,
-  InMemoryIdempotencyStore,
-  type IdempotencyStore,
-} from '../redis/idempotencyStore.js';
+import { InMemoryIdempotencyStore, type IdempotencyStore } from '../redis/idempotencyStore.js';
 
 export const streamsRouter = Router();
 
@@ -111,6 +105,8 @@ export interface Stream {
   sender: string;
   recipient: string;
   depositAmount: string;
+  streamedAmount: string;
+  remainingAmount: string;
   ratePerSecond: string;
   startTime: number;
   endTime: number;
@@ -137,7 +133,7 @@ const SSE_HEARTBEAT_INTERVAL_MS = 30_000;
 // ── Dependency state (injectable for tests) ───────────────────────────────────
 
 const streamListingDependency = { state: 'healthy' as DependencyState };
-const idempotencyDependency   = { state: 'healthy' as DependencyState };
+const idempotencyDependency = { state: 'healthy' as DependencyState };
 
 // Idempotency store — starts as InMemoryIdempotencyStore; replaced at startup
 // by wireIdempotencyStore() in app.ts with a RedisIdempotencyStore when Redis
@@ -182,10 +178,7 @@ export function resetStreamIdempotencyStore(): void {
  * The cast below is safe because the route handler always stores and reads
  * values of the correct shape.
  */
-export function setIdempotencyStore(
-  store: IdempotencyStore<unknown>,
-  ttlSeconds?: number,
-): void {
+export function setIdempotencyStore(store: IdempotencyStore<unknown>, ttlSeconds?: number): void {
   idempotencyStore = store as IdempotencyStore<ReturnType<typeof successResponse<Stream>>>;
   if (ttlSeconds !== undefined) idempotencyTtlSeconds = ttlSeconds;
 }
@@ -194,14 +187,16 @@ export function setIdempotencyStore(
 
 function toApiStream(record: StreamRecord): Stream {
   return {
-    id:            record.id,
-    sender:        record.sender_address,
-    recipient:     record.recipient_address,
+    id: record.id,
+    sender: record.sender_address,
+    recipient: record.recipient_address,
     depositAmount: record.amount,
+    streamedAmount: record.streamed_amount,
+    remainingAmount: record.remaining_amount,
     ratePerSecond: record.rate_per_second,
-    startTime:     record.start_time,
-    endTime:       record.end_time,
-    status:        record.status,
+    startTime: record.start_time,
+    endTime: record.end_time,
+    status: record.status,
   };
 }
 
@@ -218,10 +213,7 @@ function streamEntityTag(metadata: StreamResourceMetadata): string {
   return `W/"${fingerprint}"`;
 }
 
-function setStreamResourceHeaders(
-  res: Response,
-  metadata: StreamResourceMetadata,
-): void {
+function setStreamResourceHeaders(res: Response, metadata: StreamResourceMetadata): void {
   res.set('ETag', streamEntityTag(metadata));
   res.set('Last-Modified', new Date(metadata.updated_at).toUTCString());
 }
@@ -241,8 +233,10 @@ function decodeCursor(cursor: string): StreamsCursor {
     throw validationError('cursor must be a valid opaque pagination token');
   }
   if (
-    typeof parsed !== 'object' || parsed === null ||
-    !('v' in parsed) || !('lastId' in parsed) ||
+    typeof parsed !== 'object' ||
+    parsed === null ||
+    !('v' in parsed) ||
+    !('lastId' in parsed) ||
     (parsed as { v?: unknown }).v !== 1 ||
     typeof (parsed as { lastId?: unknown }).lastId !== 'string' ||
     (parsed as { lastId: string }).lastId.trim() === ''
@@ -254,32 +248,12 @@ function decodeCursor(cursor: string): StreamsCursor {
 
 // ── Query-param parsers ───────────────────────────────────────────────────────
 
-function parseLimit(limitParam: unknown): number {
-  if (limitParam === undefined) return 50;
-  if (Array.isArray(limitParam) || typeof limitParam !== 'string' || !/^\d+$/.test(limitParam)) {
-    throw validationError('limit must be an integer between 1 and 100');
-  }
-  const n = Number.parseInt(limitParam, 10);
-  if (n < 1 || n > 100) throw validationError('limit must be an integer between 1 and 100');
-  return n;
-}
-
 function parseCursor(cursorParam: unknown): StreamsCursor | undefined {
   if (cursorParam === undefined) return undefined;
   if (Array.isArray(cursorParam) || typeof cursorParam !== 'string' || cursorParam.trim() === '') {
     throw validationError('cursor must be a valid opaque pagination token');
   }
   return decodeCursor(cursorParam);
-}
-
-function parseIncludeTotal(includeTotalParam: unknown): boolean {
-  if (includeTotalParam === undefined) return false;
-  if (Array.isArray(includeTotalParam) || typeof includeTotalParam !== 'string') {
-    throw validationError('include_total must be true or false');
-  }
-  if (includeTotalParam === 'true') return true;
-  if (includeTotalParam === 'false') return false;
-  throw validationError('include_total must be true or false');
 }
 
 // ── Body normaliser ───────────────────────────────────────────────────────────
@@ -293,7 +267,7 @@ function normalizeCreateInput(body: Record<string, unknown>): NormalizedCreateIn
       ApiErrorCode.VALIDATION_ERROR,
       formatted[0]?.message ?? 'Validation failed',
       400,
-      formatted.map((e) => e.message).join('; '),
+      formatted.map((e) => e.message).join('; ')
     );
   }
 
@@ -301,14 +275,20 @@ function normalizeCreateInput(body: Record<string, unknown>): NormalizedCreateIn
 
   const amountValidation = validateAmountFields(
     { depositAmount, ratePerSecond } as Record<string, unknown>,
-    AMOUNT_FIELDS as unknown as string[],
+    AMOUNT_FIELDS as unknown as string[]
   );
   if (!amountValidation.valid) {
     throw new ApiError(
       ApiErrorCode.VALIDATION_ERROR,
       'Invalid decimal string format for amount fields',
       400,
-      { errors: amountValidation.errors.map((e) => ({ field: e.field, code: e.code, message: e.message })) },
+      {
+        errors: amountValidation.errors.map((e) => ({
+          field: e.field,
+          code: e.code,
+          message: e.message,
+        })),
+      }
     );
   }
 
@@ -325,12 +305,12 @@ function normalizeCreateInput(body: Record<string, unknown>): NormalizedCreateIn
   }
 
   return {
-    sender:        sender.trim(),
-    recipient:     recipient.trim(),
+    sender: sender.trim(),
+    recipient: recipient.trim(),
     depositAmount: validatedDeposit,
     ratePerSecond: validatedRate,
-    startTime:     startTime ?? Math.floor(Date.now() / 1000),
-    endTime:       endTime   ?? 0,
+    startTime: startTime ?? Math.floor(Date.now() / 1000),
+    endTime: endTime ?? 0,
   };
 }
 
@@ -348,25 +328,26 @@ function wrapDbError(err: unknown): never {
 
 // ── API status state machine ──────────────────────────────────────────────────
 
-type ApiStreamStatus = 'scheduled' | 'active' | 'paused' | 'completed' | 'cancelled';
+type ApiStreamStatus = 'active' | 'paused' | 'completed' | 'cancelled';
 
 const API_TRANSITIONS: Record<ApiStreamStatus, ApiStreamStatus[]> = {
-  scheduled:  ['active', 'cancelled'],
-  active:     ['paused', 'completed', 'cancelled'],
-  paused:     ['active', 'cancelled'],
-  completed:  [],
-  cancelled:  [],
+  active: ['paused', 'completed', 'cancelled'],
+  paused: ['active', 'cancelled'],
+  completed: [],
+  cancelled: [],
 };
 
 function assertValidApiTransition(
   from: ApiStreamStatus,
-  to: ApiStreamStatus,
+  to: ApiStreamStatus
 ): { ok: true } | { ok: false; message: string } {
   const allowed = API_TRANSITIONS[from] ?? [];
   if (allowed.includes(to)) return { ok: true };
   if (from === to) return { ok: false, message: `Stream is already ${from}` };
-  if (from === 'completed') return { ok: false, message: 'Stream is already completed and cannot be transitioned' };
-  if (from === 'cancelled') return { ok: false, message: 'Stream is already cancelled and cannot be transitioned' };
+  if (from === 'completed')
+    return { ok: false, message: 'Stream is already completed and cannot be transitioned' };
+  if (from === 'cancelled')
+    return { ok: false, message: 'Stream is already cancelled and cannot be transitioned' };
   return { ok: false, message: `Cannot transition stream from '${from}' to '${to}'` };
 }
 
@@ -380,23 +361,24 @@ function assertValidApiTransition(
  * @param next Express next middleware function.
  */
 export function enforceStreamScope(req: Request, res: Response, next: NextFunction): void {
-    // Check if the user is authenticated and if the role requires scoping.
-    if (!req.user || req.user.role === 'operator') {
-        // Operator role bypasses scoping checks.
-        return next();
-    }
+  // Check if the user is authenticated and if the role requires scoping.
+  if (!req.user || req.user.role === 'operator') {
+    // Operator role bypasses scoping checks.
+    return next();
+  }
 
-    const callerAddress = req.user.address as string | undefined;
-    if (!callerAddress) {
-        // Should not happen if authenticate middleware is working, but safe fail.
-        return res.status(500).json({ error: { code: 'INTERNAL_ERROR', message: 'Caller address missing' } });
-    }
+  const callerAddress = req.user.address as string | undefined;
+  if (!callerAddress) {
+    // Should not happen if authenticate middleware is working, but safe fail.
+    res.status(500).json({ error: { code: 'INTERNAL_ERROR', message: 'Caller address missing' } });
+    return;
+  }
 
-    // Attach caller address to the request object for repository consumption.
-    req.callerAddress = callerAddress;
+  // Attach caller address to the request object for repository consumption.
+  req.callerAddress = callerAddress;
 
-    // Move to the next handler which will use req.callerAddress
-    next();
+  // Move to the next handler which will use req.callerAddress
+  next();
 }
 
 // ── Routes ────────────────────────────────────────────────────────────────────
@@ -419,28 +401,37 @@ streamsRouter.get(
       const first = parsed.error.issues[0];
       throw validationError(first?.message ?? 'Invalid query parameters');
     }
-    const { limit, cursor: rawCursor, status: statusFilter, sender: senderFilter,
-            recipient: recipientFilter, include_total } = parsed.data;
+    const {
+      limit,
+      cursor: rawCursor,
+      status: statusFilter,
+      sender: senderFilter,
+      recipient: recipientFilter,
+      include_total,
+    } = parsed.data;
 
-    const cursor       = rawCursor !== undefined ? parseCursor(rawCursor) : undefined;
+    const cursor = rawCursor !== undefined ? parseCursor(rawCursor) : undefined;
     const includeTotal = include_total === 'true';
 
     if (streamListingDependency.state !== 'healthy') {
       warn('Stream listing dependency unavailable', { dependency: 'stream-list-view', requestId });
-      throw serviceUnavailable('Stream list is temporarily unavailable. Retry when dependency health is restored.');
+      throw serviceUnavailable(
+        'Stream list is temporarily unavailable. Retry when dependency health is restored.'
+      );
     }
 
     let result: { streams: Stream[]; hasMore: boolean; total?: number };
     try {
       const filter: StreamFilter = {};
-      if (statusFilter !== undefined) filter.status = statusFilter as NonNullable<StreamFilter['status']>;
+      if (statusFilter !== undefined)
+        filter.status = statusFilter as NonNullable<StreamFilter['status']>;
       if (senderFilter !== undefined) filter.sender_address = senderFilter;
       if (recipientFilter !== undefined) filter.recipient_address = recipientFilter;
       const dbResult = await streamRepository.findWithCursor(
         filter,
         limit,
         cursor?.lastId,
-        includeTotal,
+        includeTotal
       );
       result = {
         streams: dbResult.streams.map(toApiStream),
@@ -452,10 +443,11 @@ streamsRouter.get(
     }
 
     const pageStreams = result!.streams;
-    const hasMore     = result!.hasMore;
-    const nextCursor  = hasMore && pageStreams.length > 0
-      ? encodeCursor(pageStreams[pageStreams.length - 1]!.id)
-      : null;
+    const hasMore = result!.hasMore;
+    const nextCursor =
+      hasMore && pageStreams.length > 0
+        ? encodeCursor(pageStreams[pageStreams.length - 1]!.id)
+        : null;
 
     info('Listing streams', { limit, returned: pageStreams.length, hasMore, requestId });
 
@@ -471,13 +463,10 @@ streamsRouter.get(
     // Cache only when every stream on the page is in a terminal state.
     // An empty page is treated as all-terminal (nothing mutable present).
     const allTerminal = pageStreams.every((s) => isTerminalStatus(s.status as ApiStreamStatus));
-    res.set(
-      'Cache-Control',
-      allTerminal ? CACHEABLE_STREAM_HEADERS : NO_STORE_STREAM_HEADERS,
-    );
+    res.set('Cache-Control', allTerminal ? CACHEABLE_STREAM_HEADERS : NO_STORE_STREAM_HEADERS);
 
     res.json(successResponse(response, requestId));
-  }),
+  })
 );
 
 /**
@@ -513,7 +502,7 @@ streamsRouter.head(
 
     setStreamResourceHeaders(res, { id, updated_at: record.updated_at });
     res.status(200).end();
-  }),
+  })
 );
 
 /**
@@ -544,10 +533,10 @@ streamsRouter.get(
       'Cache-Control',
       isTerminalStatus(stream.status as ApiStreamStatus)
         ? CACHEABLE_STREAM_HEADERS
-        : NO_STORE_STREAM_HEADERS,
+        : NO_STORE_STREAM_HEADERS
     );
     res.json(successResponse({ stream }, requestId));
-  }),
+  })
 );
 
 /**
@@ -574,7 +563,9 @@ streamsRouter.post(
         // Never log the key value at warn/error level — it could be a secret
         idempotencyKeyLength: idempotencyKey.length,
       });
-      throw serviceUnavailable('Idempotency processing is temporarily unavailable. Retry after dependency health is restored.');
+      throw serviceUnavailable(
+        'Idempotency processing is temporarily unavailable. Retry after dependency health is restored.'
+      );
     }
 
     info('Creating new stream', { requestId, correlationId });
@@ -584,19 +575,27 @@ streamsRouter.post(
       normalizedInput = normalizeCreateInput(req.body ?? {});
     } catch (error) {
       const av = validateAmountFields(
-        { depositAmount: req.body?.depositAmount, ratePerSecond: req.body?.ratePerSecond } as Record<string, unknown>,
-        AMOUNT_FIELDS as unknown as string[],
+        {
+          depositAmount: req.body?.depositAmount,
+          ratePerSecond: req.body?.ratePerSecond,
+        } as Record<string, unknown>,
+        AMOUNT_FIELDS as unknown as string[]
       );
       if (!av.valid) {
         for (const err of av.errors) {
-          SerializationLogger.validationFailed(err.field || 'unknown', err.rawValue, err.code, requestId);
+          SerializationLogger.validationFailed(
+            err.field || 'unknown',
+            err.rawValue,
+            err.code,
+            requestId
+          );
         }
       }
       throw error;
     }
 
     const requestFingerprint = fingerprintInput(normalizedInput);
-    const existingResponse   = await idempotencyStore.get(idempotencyKey);
+    const existingResponse = await idempotencyStore.get(idempotencyKey);
 
     if (existingResponse) {
       if (existingResponse.requestFingerprint !== requestFingerprint) {
@@ -611,7 +610,7 @@ streamsRouter.post(
           ApiErrorCode.CONFLICT,
           'Idempotency-Key has already been used for a different request payload',
           409,
-          { hint: 'Use a new Idempotency-Key or retry with the original request body' },
+          { hint: 'Use a new Idempotency-Key or retry with the original request body' }
         );
       }
       info('Replaying idempotent stream creation', {
@@ -622,9 +621,9 @@ streamsRouter.post(
       });
       res.set('Idempotency-Key', idempotencyKey);
       res.set('Idempotency-Replayed', 'true');
-      res.status(existingResponse.statusCode).json(
-        idempotentReplayResponse(existingResponse.body.data, requestId),
-      );
+      res
+        .status(existingResponse.statusCode)
+        .json(idempotentReplayResponse(existingResponse.body.data, requestId));
       return;
     }
 
@@ -637,20 +636,23 @@ streamsRouter.post(
 
     let upsertResult;
     try {
-      upsertResult = await streamRepository.upsertStream({
-        id,
-        sender_address:    normalizedInput.sender,
-        recipient_address: normalizedInput.recipient,
-        amount:            normalizedInput.depositAmount,
-        streamed_amount:   '0',
-        remaining_amount:  normalizedInput.depositAmount,
-        rate_per_second:   normalizedInput.ratePerSecond,
-        start_time:        normalizedInput.startTime,
-        end_time:          normalizedInput.endTime,
-        contract_id:       'api-created',
-        transaction_hash:  idHash,
-        event_index:       0,
-      }, requestId);
+      upsertResult = await streamRepository.upsertStream(
+        {
+          id,
+          sender_address: normalizedInput.sender,
+          recipient_address: normalizedInput.recipient,
+          amount: normalizedInput.depositAmount,
+          streamed_amount: '0',
+          remaining_amount: normalizedInput.depositAmount,
+          rate_per_second: normalizedInput.ratePerSecond,
+          start_time: normalizedInput.startTime,
+          end_time: normalizedInput.endTime,
+          contract_id: 'api-created',
+          transaction_hash: idHash,
+          event_index: 0,
+        },
+        requestId
+      );
     } catch (err) {
       wrapDbError(err);
     }
@@ -660,7 +662,7 @@ streamsRouter.post(
     await idempotencyStore.set(
       idempotencyKey,
       { requestFingerprint, statusCode: 201, body: responseEnvelope },
-      idempotencyTtlSeconds,
+      idempotencyTtlSeconds
     );
 
     SerializationLogger.amountSerialized(2, requestId);
@@ -668,8 +670,8 @@ streamsRouter.post(
     recordAuditEvent('STREAM_CREATED', 'stream', stream.id, correlationId ?? '', {
       depositAmount: normalizedInput.depositAmount,
       ratePerSecond: normalizedInput.ratePerSecond,
-      sender:        normalizedInput.sender,
-      recipient:     normalizedInput.recipient,
+      sender: normalizedInput.sender,
+      recipient: normalizedInput.recipient,
     });
 
     streamsCreatedTotal.inc({ status: stream.status });
@@ -677,7 +679,7 @@ streamsRouter.post(
     res.set('Idempotency-Key', idempotencyKey);
     res.set('Idempotency-Replayed', 'false');
     res.status(201).json(responseEnvelope);
-  }),
+  })
 );
 
 /**
@@ -723,7 +725,7 @@ streamsRouter.delete(
     recordAuditEvent('STREAM_CANCELLED', 'stream', id, req.correlationId ?? '');
 
     res.json(successResponse({ message: 'Stream cancelled', id }, requestId));
-  }),
+  })
 );
 
 /**
@@ -745,9 +747,9 @@ streamsRouter.patch(
       throw notFound('Stream', '');
     }
 
-    const validStatuses: ApiStreamStatus[] = ['scheduled', 'active', 'paused', 'completed', 'cancelled'];
+    const validStatuses: ApiStreamStatus[] = ['active', 'paused', 'completed', 'cancelled'];
     if (typeof newStatus !== 'string' || !validStatuses.includes(newStatus as ApiStreamStatus)) {
-      throw validationError('status must be one of: scheduled, active, paused, completed, cancelled');
+      throw validationError('status must be one of: active, paused, completed, cancelled');
     }
 
     let record;
@@ -759,7 +761,10 @@ streamsRouter.patch(
 
     if (!record) throw notFound('Stream', id);
 
-    const guard = assertValidApiTransition(record!.status as ApiStreamStatus, newStatus as ApiStreamStatus);
+    const guard = assertValidApiTransition(
+      record!.status as ApiStreamStatus,
+      newStatus as ApiStreamStatus
+    );
     if (!guard.ok) {
       throw new ApiError(ApiErrorCode.CONFLICT, guard.message, 409, {
         streamId: id,
@@ -770,9 +775,11 @@ streamsRouter.patch(
 
     let updated;
     try {
-      // 'scheduled' is an API-only concept; map to 'active' in DB
-      const dbStatus = newStatus === 'scheduled' ? 'active' : newStatus as StreamStatus;
-      updated = await streamRepository.updateStream(id, { status: dbStatus }, requestId ?? '');
+      updated = await streamRepository.updateStream(
+        id,
+        { status: newStatus as StreamStatus },
+        requestId ?? ''
+      );
     } catch (err) {
       wrapDbError(err);
     }
@@ -781,7 +788,7 @@ streamsRouter.patch(
     recordAuditEvent('STREAM_STATUS_UPDATED', 'stream', id, req.correlationId ?? '');
 
     res.json(successResponse(toApiStream(updated!), requestId));
-  }),
+  })
 );
 
 /**
@@ -1000,8 +1007,7 @@ streamsRouter.get(
     // A valid event ID is 1–200 printable non-whitespace characters.
     const rawLastEventId = req.headers['last-event-id'];
     const lastEventId =
-      typeof rawLastEventId === 'string' &&
-      /^[\x21-\x7E]{1,200}$/.test(rawLastEventId.trim())
+      typeof rawLastEventId === 'string' && /^[\x21-\x7E]{1,200}$/.test(rawLastEventId.trim())
         ? rawLastEventId.trim()
         : undefined;
 
@@ -1027,14 +1033,14 @@ streamsRouter.get(
               if (eventMatchesStreamId(event, id)) {
                 const written = writeSse(
                   `id: ${event.eventId}\n` +
-                  `event: ${SSE_STREAM_UPDATE_EVENT}\n` +
-                  `data: ${JSON.stringify({
-                    type: 'stream_update',
-                    streamId: id,
-                    eventId: event.eventId,
-                    payload: event.payload,
-                    correlationId: req.correlationId,
-                  })}\n\n`,
+                    `event: ${SSE_STREAM_UPDATE_EVENT}\n` +
+                    `data: ${JSON.stringify({
+                      type: 'stream_update',
+                      streamId: id,
+                      eventId: event.eventId,
+                      payload: event.payload,
+                      correlationId: req.correlationId,
+                    })}\n\n`
                 );
                 if (!written) break;
               }
@@ -1049,7 +1055,7 @@ streamsRouter.get(
               `event: error\ndata: ${JSON.stringify({
                 code: STALE_CURSOR_ERROR_CODE,
                 message: 'Replay cursor no longer exists; resync from fromLedger',
-              })}\n\n`,
+              })}\n\n`
             );
             warn('SSE replay cursor is stale', {
               afterEventId: err.afterEventId,
@@ -1075,20 +1081,20 @@ streamsRouter.get(
       if (event.streamId === id) {
         writeSse(
           `id: ${event.eventId}\n` +
-          `event: ${SSE_STREAM_UPDATE_EVENT}\n` +
-          `data: ${JSON.stringify({
-            type: 'stream_update',
-            streamId: event.streamId,
-            eventId: event.eventId,
-            payload: event.payload,
-            correlationId: req.correlationId || event.correlationId,
-          })}\n\n`,
+            `event: ${SSE_STREAM_UPDATE_EVENT}\n` +
+            `data: ${JSON.stringify({
+              type: 'stream_update',
+              streamId: event.streamId,
+              eventId: event.eventId,
+              payload: event.payload,
+              correlationId: req.correlationId || event.correlationId,
+            })}\n\n`
         );
       }
     };
 
     unsubscribeLiveUpdates = subscribeToSseStream(id, listener);
-  }),
+  })
 );
 
 export function _resetStreams(): void {}

--- a/src/types/express.d.ts
+++ b/src/types/express.d.ts
@@ -5,7 +5,7 @@ declare global {
   // The public `express.Request` extends `Express.Request`, so augmenting the
   // `Express` global namespace is what reaches `req.user` / `req.correlationId`
   // call-sites without breaking existing typings.
-   
+
   namespace Express {
     interface Request {
       /** Attached by auth middleware when a valid JWT is present. */
@@ -14,6 +14,8 @@ declare global {
       correlationId?: string;
       /** Attached by requestIdMiddleware (errors.ts). */
       id?: string;
+      /** Attached by stream scoping middleware for repository filters. */
+      callerAddress?: string;
       /** Attached by apiVersion middleware based on the Accept-Version header. */
       apiVersion?: string;
     }

--- a/src/webhooks/retry.ts
+++ b/src/webhooks/retry.ts
@@ -38,7 +38,7 @@ export interface RetrySchedule {
 
 export interface WebhookOutboxRetryInput {
   /** The actual consumer endpoint URL — used as the rate-limit key. */
-  consumerUrl?: string;
+  consumerUrl: string;
   streamId: string;
   eventType: string;
   payload: unknown;
@@ -61,11 +61,13 @@ export interface WebhookOutboxRetryPlan {
 // ---------------------------------------------------------------------------
 
 /** Calculate raw backoff delay (before jitter) for a given attempt number. */
-export function calculateBackoffDelay(
-  attemptNumber: number,
-  policy: EnhancedRetryPolicy,
-): number {
-  const { backoffStrategy = 'exponential', initialBackoffMs, backoffMultiplier, maxBackoffMs } = policy;
+export function calculateBackoffDelay(attemptNumber: number, policy: EnhancedRetryPolicy): number {
+  const {
+    backoffStrategy = 'exponential',
+    initialBackoffMs,
+    backoffMultiplier,
+    maxBackoffMs,
+  } = policy;
 
   let baseDelay: number;
   switch (backoffStrategy) {
@@ -102,8 +104,6 @@ export function applyJitter(delayMs: number, policy: EnhancedRetryPolicy): numbe
   }
 }
 
-
-
 /** Determine if a status code is retryable with enhanced logic. */
 /**
  * Determine whether an HTTP status code should trigger a retry.
@@ -128,66 +128,10 @@ export function applyJitter(delayMs: number, policy: EnhancedRetryPolicy): numbe
  */
 export function isRetryableStatusCode(
   statusCode: number | undefined,
-  policy: EnhancedRetryPolicy = DEFAULT_RETRY_POLICY,
+  policy: EnhancedRetryPolicy = DEFAULT_RETRY_POLICY
 ): boolean {
   if (statusCode === undefined) return true;
   return policy.retryableStatusCodes.includes(statusCode);
-}
-
-/** Return the absolute timestamp for the next retry attempt. */
-export function calculateNextRetryTime(
-  attemptNumber: number,
-  policy: EnhancedRetryPolicy,
-  now: number = Date.now(),
-): number {
-  const delayMs = applyJitter(calculateBackoffDelay(attemptNumber, policy), policy);
-  return now + delayMs;
-}
-
-/** Generate retry metadata for every configured attempt. */
-export function generateRetrySchedule(
-  policy: EnhancedRetryPolicy,
-  now: number = Date.now(),
-): RetrySchedule[] {
-  return Array.from({ length: policy.maxAttempts }, (_, index) => {
-    const attemptNumber = index + 1;
-    const delayMs = applyJitter(calculateBackoffDelay(attemptNumber, policy), policy);
-
-    return {
-      attemptNumber,
-      delayMs,
-      retryAt: now + delayMs,
-    };
-  });
-}
-
-/** Attach retry metadata to an outbox payload and return the next retry time. */
-export function scheduleWebhookOutboxRetry(input: WebhookOutboxRetryInput): WebhookOutboxRetryPlan {
-  const policy = input.policy ?? DEFAULT_RETRY_POLICY;
-  const nextAttemptNumber = input.attemptNumber + 1;
-
-  if (nextAttemptNumber > policy.maxAttempts) {
-    return {
-      shouldRetry: false,
-      attemptNumber: input.attemptNumber,
-      retryAt: null,
-      payload: input.payload,
-    };
-  }
-
-  const payload =
-    typeof input.payload === 'object' && input.payload !== null && !Array.isArray(input.payload)
-      ? { ...(input.payload as Record<string, unknown>), _webhookRetry: { attemptNumber: nextAttemptNumber } }
-      : { _webhookRetry: { attemptNumber: nextAttemptNumber } };
-
-  return {
-    shouldRetry: true,
-    attemptNumber: nextAttemptNumber,
-    retryAt: new Date(calculateNextRetryTime(input.attemptNumber, policy, input.now)),
-    payload,
-  };
-  const retryable = policy.retryableStatusCodes ?? DEFAULT_RETRY_POLICY.retryableStatusCodes;
-  return retryable.includes(statusCode);
 }
 
 /**
@@ -197,7 +141,7 @@ export function scheduleWebhookOutboxRetry(input: WebhookOutboxRetryInput): Webh
 export function calculateNextRetryTime(
   attemptNumber: number,
   policy: EnhancedRetryPolicy = DEFAULT_RETRY_POLICY,
-  now: number = Date.now(),
+  now: number = Date.now()
 ): number {
   if (attemptNumber >= policy.maxAttempts) return 0;
   const raw = calculateBackoffDelay(attemptNumber, policy);
@@ -210,7 +154,7 @@ export function calculateNextRetryTime(
  */
 export function generateRetrySchedule(
   policy: EnhancedRetryPolicy = DEFAULT_RETRY_POLICY,
-  now: number = Date.now(),
+  now: number = Date.now()
 ): RetrySchedule[] {
   return Array.from({ length: policy.maxAttempts }, (_, i) => {
     const delayMs = Math.round(applyJitter(calculateBackoffDelay(i, policy), policy));
@@ -223,7 +167,7 @@ export function shouldRetry(
   attempt: WebhookDeliveryAttempt,
   attemptNumber: number,
   policy: EnhancedRetryPolicy = DEFAULT_RETRY_POLICY,
-  consecutiveFailures: number = 0,
+  consecutiveFailures: number = 0
 ): boolean {
   if (attemptNumber >= policy.maxAttempts) return false;
 
@@ -240,7 +184,7 @@ export function shouldRetry(
 export function shouldSendToDLQ(
   attemptNumber: number,
   policy: EnhancedRetryPolicy = DEFAULT_RETRY_POLICY,
-  createdAt: number = Date.now(),
+  createdAt: number = Date.now()
 ): boolean {
   if (attemptNumber >= policy.maxAttempts) return true;
 
@@ -254,7 +198,7 @@ export function shouldSendToDLQ(
 /** Return the absolute timestamp at which the circuit breaker should reset. */
 export function calculateCircuitBreakerResetTime(
   policy: EnhancedRetryPolicy = DEFAULT_RETRY_POLICY,
-  now: number = Date.now(),
+  now: number = Date.now()
 ): number {
   return policy.circuitBreakerResetMs ? now + policy.circuitBreakerResetMs : 0;
 }
@@ -269,7 +213,7 @@ export const HALF_OPEN_CONTENTION_DEFERRAL_MS = 1_000;
 export function resolveCircuitBreakerDeferral(
   breaker: Pick<WebhookCircuitBreakerCheckResult, 'state' | 'resetAt'>,
   policy: EnhancedRetryPolicy = DEFAULT_RETRY_POLICY,
-  now: number = Date.now(),
+  now: number = Date.now()
 ): Date {
   if (breaker.resetAt !== null && breaker.resetAt > now) {
     return new Date(breaker.resetAt);
@@ -284,9 +228,14 @@ export function resolveCircuitBreakerDeferral(
 /** Return true when a failed attempt should increment the circuit-breaker failure count. */
 export function countsTowardCircuitBreaker(
   attempt: WebhookDeliveryAttempt,
-  policy: EnhancedRetryPolicy = DEFAULT_RETRY_POLICY,
+  policy: EnhancedRetryPolicy = DEFAULT_RETRY_POLICY
 ): boolean {
-  if (attempt.statusCode !== undefined && attempt.statusCode >= 200 && attempt.statusCode < 300 && !attempt.error) {
+  if (
+    attempt.statusCode !== undefined &&
+    attempt.statusCode >= 200 &&
+    attempt.statusCode < 300 &&
+    !attempt.error
+  ) {
     return false;
   }
   if (attempt.statusCode === undefined) return true;
@@ -304,7 +253,8 @@ export function formatRetryPolicy(policy: EnhancedRetryPolicy): string {
   if (policy.backoffStrategy) extras.push(`strategy=${policy.backoffStrategy}`);
   if (policy.jitterAlgorithm) extras.push(`jitter=${policy.jitterAlgorithm}`);
   if (policy.deadLetterAfterMs) extras.push(`dlq_after=${policy.deadLetterAfterMs}ms`);
-  if (policy.circuitBreakerThreshold) extras.push(`circuit_breaker=${policy.circuitBreakerThreshold}`);
+  if (policy.circuitBreakerThreshold)
+    extras.push(`circuit_breaker=${policy.circuitBreakerThreshold}`);
 
   return extras.length > 0 ? `${base}, ${extras.join(', ')}` : base;
 }
@@ -357,7 +307,7 @@ export async function checkWebhookDeliveryGate(
   consumerUrl: string,
   policy: EnhancedRetryPolicy = DEFAULT_RETRY_POLICY,
   deps: WebhookDeliveryGateDeps = {},
-  now: number = Date.now(),
+  now: number = Date.now()
 ): Promise<WebhookDeliveryGateResult> {
   const circuitBreakerStore = deps.circuitBreakerStore ?? getWebhookCircuitBreakerStore();
 
@@ -396,7 +346,7 @@ export async function checkWebhookDeliveryGate(
 export async function attemptWebhookDeliveryWithRateLimit(
   input: WebhookOutboxRetryInput,
   deliver: () => Promise<WebhookDeliveryAttempt>,
-  deps: WebhookDeliveryGateDeps = {},
+  deps: WebhookDeliveryGateDeps = {}
 ): Promise<WebhookOutboxRetryPlan & { attempt?: WebhookDeliveryAttempt }> {
   const policy = input.policy ?? DEFAULT_RETRY_POLICY;
   const now = input.now ?? Date.now();
@@ -424,14 +374,14 @@ export async function attemptWebhookDeliveryWithRateLimit(
   if (success) {
     const breakerRecord = await circuitBreakerStore.recordSuccess(
       input.consumerUrl,
-      policy as CircuitBreakerPolicy,
+      policy as CircuitBreakerPolicy
     );
     consecutiveFailures = breakerRecord.consecutiveFailures;
   } else if (countsTowardCircuitBreaker(attempt, policy)) {
     const breakerRecord = await circuitBreakerStore.recordFailure(
       input.consumerUrl,
       policy as CircuitBreakerPolicy,
-      now,
+      now
     );
     consecutiveFailures = breakerRecord.consecutiveFailures;
   }

--- a/tests/routes/docs.test.ts
+++ b/tests/routes/docs.test.ts
@@ -10,7 +10,10 @@ beforeEach(() => {
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
 /** Traverse a resolved $ref or inline schema in the components. */
-function resolveRef(spec: Record<string, unknown>, ref: string): Record<string, unknown> | undefined {
+function resolveRef(
+  spec: Record<string, unknown>,
+  ref: string
+): Record<string, unknown> | undefined {
   // ref format: '#/components/schemas/Foo'
   const parts = ref.replace('#/', '').split('/');
   let node: unknown = spec;
@@ -19,6 +22,10 @@ function resolveRef(spec: Record<string, unknown>, ref: string): Record<string, 
     node = (node as Record<string, unknown>)[part];
   }
   return node as Record<string, unknown>;
+}
+
+function schemaProperties(schema: Record<string, unknown>): Record<string, unknown> {
+  return (schema['properties'] ?? {}) as Record<string, unknown>;
 }
 
 describe('GET /openapi.json', () => {
@@ -125,7 +132,10 @@ describe('GET /openapi.json', () => {
 
   it('POST /api/streams requires bearerAuth security', async () => {
     const res = await request(app).get('/openapi.json');
-    const postStreams = (res.body.paths['/api/streams'] as Record<string, unknown>)?.post as Record<string, unknown>;
+    const postStreams = (res.body.paths['/api/streams'] as Record<string, unknown>)?.post as Record<
+      string,
+      unknown
+    >;
     expect(postStreams?.security).toBeDefined();
     const sec = postStreams.security as Array<Record<string, unknown>>;
     expect(sec.some((s) => 'bearerAuth' in s)).toBe(true);
@@ -133,14 +143,18 @@ describe('GET /openapi.json', () => {
 
   it('POST /internal/indexer/contract-events requires indexerWorkerToken', async () => {
     const res = await request(app).get('/openapi.json');
-    const route = (res.body.paths['/internal/indexer/contract-events'] as Record<string, unknown>)?.post as Record<string, unknown>;
+    const route = (res.body.paths['/internal/indexer/contract-events'] as Record<string, unknown>)
+      ?.post as Record<string, unknown>;
     const sec = route?.security as Array<Record<string, unknown>>;
     expect(sec?.some((s) => 'indexerWorkerToken' in s)).toBe(true);
   });
 
   it('includes error response schemas (400, 401, 404, 500)', async () => {
     const res = await request(app).get('/openapi.json');
-    const postStreams = (res.body.paths['/api/streams'] as Record<string, unknown>)?.post as Record<string, unknown>;
+    const postStreams = (res.body.paths['/api/streams'] as Record<string, unknown>)?.post as Record<
+      string,
+      unknown
+    >;
     const responses = postStreams?.responses as Record<string, unknown>;
     expect(responses?.['400']).toBeDefined();
     expect(responses?.['401']).toBeDefined();
@@ -148,9 +162,15 @@ describe('GET /openapi.json', () => {
 
   it('includes example payloads for POST /api/streams', async () => {
     const res = await request(app).get('/openapi.json');
-    const postStreams = (res.body.paths['/api/streams'] as Record<string, unknown>)?.post as Record<string, unknown>;
+    const postStreams = (res.body.paths['/api/streams'] as Record<string, unknown>)?.post as Record<
+      string,
+      unknown
+    >;
     const body = postStreams?.requestBody as Record<string, unknown>;
-    const content = (body?.content as Record<string, unknown>)?.['application/json'] as Record<string, unknown>;
+    const content = (body?.content as Record<string, unknown>)?.['application/json'] as Record<
+      string,
+      unknown
+    >;
     expect(content?.example).toBeDefined();
   });
 
@@ -169,12 +189,85 @@ describe('GET /openapi.json', () => {
     expect(res.headers['cache-control']).toMatch(/max-age/);
   });
 
+  describe('Stream schema drift guard', () => {
+    const streamRecordToApiKeys = {
+      id: 'id',
+      sender_address: 'sender',
+      recipient_address: 'recipient',
+      amount: 'depositAmount',
+      streamed_amount: 'streamedAmount',
+      remaining_amount: 'remainingAmount',
+      rate_per_second: 'ratePerSecond',
+      start_time: 'startTime',
+      end_time: 'endTime',
+      status: 'status',
+    } as const;
+
+    it('documents every public stream field mapped from StreamRecord', async () => {
+      const res = await request(app).get('/openapi.json');
+      const schemas = (res.body.components?.schemas ?? {}) as Record<string, unknown>;
+      const streamSchema = schemas['Stream'] as Record<string, unknown>;
+      const documentedKeys = Object.keys(schemaProperties(streamSchema)).sort();
+      const mappedKeys = Object.values(streamRecordToApiKeys).sort();
+
+      expect(documentedKeys).toEqual(mappedKeys);
+    });
+
+    it('does not expose raw database column names in the public Stream schema', async () => {
+      const res = await request(app).get('/openapi.json');
+      const schemas = (res.body.components?.schemas ?? {}) as Record<string, unknown>;
+      const streamSchema = schemas['Stream'] as Record<string, unknown>;
+      const documentedKeys = Object.keys(schemaProperties(streamSchema));
+
+      expect(documentedKeys).not.toContain('sender_address');
+      expect(documentedKeys).not.toContain('recipient_address');
+      expect(documentedKeys).not.toContain('rate_per_second');
+      expect(documentedKeys).not.toContain('streamed_amount');
+      expect(documentedKeys).not.toContain('remaining_amount');
+    });
+
+    it('keeps StreamStatus aligned with persisted stream statuses', async () => {
+      const res = await request(app).get('/openapi.json');
+      const schemas = (res.body.components?.schemas ?? {}) as Record<string, unknown>;
+      const streamStatus = schemas['StreamStatus'] as Record<string, unknown>;
+
+      expect(streamStatus['enum']).toEqual(['active', 'paused', 'completed', 'cancelled']);
+      expect(streamStatus['enum']).not.toContain('scheduled');
+    });
+
+    it('documents all monetary response fields as decimal strings', async () => {
+      const res = await request(app).get('/openapi.json');
+      const spec = res.body as Record<string, unknown>;
+      const schemas = (spec.components as Record<string, unknown>)?.['schemas'] as Record<
+        string,
+        unknown
+      >;
+      const streamSchema = schemas['Stream'] as Record<string, unknown>;
+      const props = schemaProperties(streamSchema);
+
+      for (const key of ['depositAmount', 'streamedAmount', 'remainingAmount', 'ratePerSecond']) {
+        const fieldSchema = props[key] as Record<string, unknown>;
+        expect(fieldSchema['$ref']).toBe('#/components/schemas/DecimalString');
+        const resolved = resolveRef(spec, fieldSchema['$ref'] as string);
+        expect(resolved?.['type']).toBe('string');
+      }
+    });
+
+    it('uses real-looking Stellar G-address examples consistently', async () => {
+      const res = await request(app).get('/openapi.json');
+      const schemas = (res.body.components?.schemas ?? {}) as Record<string, unknown>;
+      const stellarAddress = schemas['StellarAddress'] as Record<string, unknown>;
+
+      expect(stellarAddress['example']).toMatch(/^G[A-Z2-7]{55}$/);
+    });
+  });
+
   it('returns the same spec on repeated calls (cached)', async () => {
     const res1 = await request(app).get('/openapi.json');
     const res2 = await request(app).get('/openapi.json');
     expect(res1.body.info.version).toBe(res2.body.info.version);
     expect(Object.keys(res1.body.paths as object).length).toBe(
-      Object.keys(res2.body.paths as object).length,
+      Object.keys(res2.body.paths as object).length
     );
   });
 
@@ -184,9 +277,8 @@ describe('GET /openapi.json', () => {
     async function getListOp() {
       const res = await request(app).get('/openapi.json');
       const spec = res.body as Record<string, unknown>;
-      return (
-        (spec.paths as Record<string, unknown>)['/api/streams'] as Record<string, unknown>
-      )?.get as Record<string, unknown>;
+      return ((spec.paths as Record<string, unknown>)['/api/streams'] as Record<string, unknown>)
+        ?.get as Record<string, unknown>;
     }
 
     // ── cursor param documentation ───────────────────────────────────────────
@@ -204,7 +296,9 @@ describe('GET /openapi.json', () => {
       const params = op.parameters as Array<Record<string, unknown>>;
       const cursorParam = params?.find((p) => p['name'] === 'cursor');
       const schema = cursorParam?.['schema'] as Record<string, unknown>;
-      const description: string = (schema?.['description'] ?? cursorParam?.['description'] ?? '') as string;
+      const description: string = (schema?.['description'] ??
+        cursorParam?.['description'] ??
+        '') as string;
       expect(description.toLowerCase()).toMatch(/opaque/);
     });
 
@@ -234,7 +328,10 @@ describe('GET /openapi.json', () => {
       const cursorParam = params?.find((p) => p['name'] === 'cursor');
       const schema = cursorParam?.['schema'] as Record<string, unknown>;
       const example = schema?.['example'] as string;
-      const decoded = JSON.parse(Buffer.from(example, 'base64url').toString('utf8')) as Record<string, unknown>;
+      const decoded = JSON.parse(Buffer.from(example, 'base64url').toString('utf8')) as Record<
+        string,
+        unknown
+      >;
       expect(decoded['v']).toBe(1);
       expect(typeof decoded['lastId']).toBe('string');
       expect((decoded['lastId'] as string).length).toBeGreaterThan(0);
@@ -306,7 +403,9 @@ describe('GET /openapi.json', () => {
       const op = await getListOp();
       const responses = op['responses'] as Record<string, unknown>;
       const r400 = responses?.['400'] as Record<string, unknown>;
-      const content = (r400?.['content'] as Record<string, unknown>)?.['application/json'] as Record<string, unknown>;
+      const content = (r400?.['content'] as Record<string, unknown>)?.[
+        'application/json'
+      ] as Record<string, unknown>;
       const examples = content?.['examples'] as Record<string, unknown> | undefined;
       expect(examples?.['invalidCursor']).toBeDefined();
     });
@@ -315,7 +414,9 @@ describe('GET /openapi.json', () => {
       const op = await getListOp();
       const responses = op['responses'] as Record<string, unknown>;
       const r400 = responses?.['400'] as Record<string, unknown>;
-      const content = (r400?.['content'] as Record<string, unknown>)?.['application/json'] as Record<string, unknown>;
+      const content = (r400?.['content'] as Record<string, unknown>)?.[
+        'application/json'
+      ] as Record<string, unknown>;
       const examples = content?.['examples'] as Record<string, unknown>;
       const example = examples?.['invalidCursor'] as Record<string, unknown>;
       const value = example?.['value'] as Record<string, unknown>;
@@ -326,7 +427,9 @@ describe('GET /openapi.json', () => {
       const op = await getListOp();
       const responses = op['responses'] as Record<string, unknown>;
       const r400 = responses?.['400'] as Record<string, unknown>;
-      const content = (r400?.['content'] as Record<string, unknown>)?.['application/json'] as Record<string, unknown>;
+      const content = (r400?.['content'] as Record<string, unknown>)?.[
+        'application/json'
+      ] as Record<string, unknown>;
       const examples = content?.['examples'] as Record<string, unknown>;
       const example = examples?.['invalidCursor'] as Record<string, unknown>;
       const value = example?.['value'] as Record<string, unknown>;
@@ -341,7 +444,9 @@ describe('GET /openapi.json', () => {
       const op = await getListOp();
       const responses = op['responses'] as Record<string, unknown>;
       const r200 = responses?.['200'] as Record<string, unknown>;
-      const content = (r200?.['content'] as Record<string, unknown>)?.['application/json'] as Record<string, unknown>;
+      const content = (r200?.['content'] as Record<string, unknown>)?.[
+        'application/json'
+      ] as Record<string, unknown>;
       const examples = content?.['examples'] as Record<string, unknown> | undefined;
       expect(examples).toBeDefined();
     });
@@ -349,7 +454,9 @@ describe('GET /openapi.json', () => {
     it('200 response has firstPage example', async () => {
       const op = await getListOp();
       const responses = op['responses'] as Record<string, unknown>;
-      const content = ((responses?.['200'] as Record<string, unknown>)?.['content'] as Record<string, unknown>)?.['application/json'] as Record<string, unknown>;
+      const content = (
+        (responses?.['200'] as Record<string, unknown>)?.['content'] as Record<string, unknown>
+      )?.['application/json'] as Record<string, unknown>;
       const examples = content?.['examples'] as Record<string, unknown>;
       expect(examples?.['firstPage']).toBeDefined();
     });
@@ -357,7 +464,9 @@ describe('GET /openapi.json', () => {
     it('200 response has nextPage example', async () => {
       const op = await getListOp();
       const responses = op['responses'] as Record<string, unknown>;
-      const content = ((responses?.['200'] as Record<string, unknown>)?.['content'] as Record<string, unknown>)?.['application/json'] as Record<string, unknown>;
+      const content = (
+        (responses?.['200'] as Record<string, unknown>)?.['content'] as Record<string, unknown>
+      )?.['application/json'] as Record<string, unknown>;
       const examples = content?.['examples'] as Record<string, unknown>;
       expect(examples?.['nextPage']).toBeDefined();
     });
@@ -365,7 +474,9 @@ describe('GET /openapi.json', () => {
     it('200 response has lastPage example', async () => {
       const op = await getListOp();
       const responses = op['responses'] as Record<string, unknown>;
-      const content = ((responses?.['200'] as Record<string, unknown>)?.['content'] as Record<string, unknown>)?.['application/json'] as Record<string, unknown>;
+      const content = (
+        (responses?.['200'] as Record<string, unknown>)?.['content'] as Record<string, unknown>
+      )?.['application/json'] as Record<string, unknown>;
       const examples = content?.['examples'] as Record<string, unknown>;
       expect(examples?.['lastPage']).toBeDefined();
     });
@@ -373,10 +484,15 @@ describe('GET /openapi.json', () => {
     it('firstPage example has has_more=true and non-null next_cursor', async () => {
       const op = await getListOp();
       const responses = op['responses'] as Record<string, unknown>;
-      const content = ((responses?.['200'] as Record<string, unknown>)?.['content'] as Record<string, unknown>)?.['application/json'] as Record<string, unknown>;
+      const content = (
+        (responses?.['200'] as Record<string, unknown>)?.['content'] as Record<string, unknown>
+      )?.['application/json'] as Record<string, unknown>;
       const examples = content?.['examples'] as Record<string, unknown>;
       const firstPage = examples?.['firstPage'] as Record<string, unknown>;
-      const data = ((firstPage?.['value'] as Record<string, unknown>)?.['data']) as Record<string, unknown>;
+      const data = (firstPage?.['value'] as Record<string, unknown>)?.['data'] as Record<
+        string,
+        unknown
+      >;
       expect(data?.['has_more']).toBe(true);
       expect(data?.['next_cursor']).not.toBeNull();
       expect(typeof data?.['next_cursor']).toBe('string');
@@ -385,12 +501,20 @@ describe('GET /openapi.json', () => {
     it('firstPage example next_cursor decodes to a valid v:1 cursor', async () => {
       const op = await getListOp();
       const responses = op['responses'] as Record<string, unknown>;
-      const content = ((responses?.['200'] as Record<string, unknown>)?.['content'] as Record<string, unknown>)?.['application/json'] as Record<string, unknown>;
+      const content = (
+        (responses?.['200'] as Record<string, unknown>)?.['content'] as Record<string, unknown>
+      )?.['application/json'] as Record<string, unknown>;
       const examples = content?.['examples'] as Record<string, unknown>;
       const firstPage = examples?.['firstPage'] as Record<string, unknown>;
-      const data = ((firstPage?.['value'] as Record<string, unknown>)?.['data']) as Record<string, unknown>;
+      const data = (firstPage?.['value'] as Record<string, unknown>)?.['data'] as Record<
+        string,
+        unknown
+      >;
       const token = data?.['next_cursor'] as string;
-      const decoded = JSON.parse(Buffer.from(token, 'base64url').toString('utf8')) as Record<string, unknown>;
+      const decoded = JSON.parse(Buffer.from(token, 'base64url').toString('utf8')) as Record<
+        string,
+        unknown
+      >;
       expect(decoded['v']).toBe(1);
       expect(typeof decoded['lastId']).toBe('string');
     });
@@ -398,10 +522,15 @@ describe('GET /openapi.json', () => {
     it('nextPage example has has_more=true and non-null next_cursor', async () => {
       const op = await getListOp();
       const responses = op['responses'] as Record<string, unknown>;
-      const content = ((responses?.['200'] as Record<string, unknown>)?.['content'] as Record<string, unknown>)?.['application/json'] as Record<string, unknown>;
+      const content = (
+        (responses?.['200'] as Record<string, unknown>)?.['content'] as Record<string, unknown>
+      )?.['application/json'] as Record<string, unknown>;
       const examples = content?.['examples'] as Record<string, unknown>;
       const nextPage = examples?.['nextPage'] as Record<string, unknown>;
-      const data = ((nextPage?.['value'] as Record<string, unknown>)?.['data']) as Record<string, unknown>;
+      const data = (nextPage?.['value'] as Record<string, unknown>)?.['data'] as Record<
+        string,
+        unknown
+      >;
       expect(data?.['has_more']).toBe(true);
       expect(data?.['next_cursor']).not.toBeNull();
     });
@@ -409,10 +538,15 @@ describe('GET /openapi.json', () => {
     it('lastPage example has has_more=false and next_cursor=null', async () => {
       const op = await getListOp();
       const responses = op['responses'] as Record<string, unknown>;
-      const content = ((responses?.['200'] as Record<string, unknown>)?.['content'] as Record<string, unknown>)?.['application/json'] as Record<string, unknown>;
+      const content = (
+        (responses?.['200'] as Record<string, unknown>)?.['content'] as Record<string, unknown>
+      )?.['application/json'] as Record<string, unknown>;
       const examples = content?.['examples'] as Record<string, unknown>;
       const lastPage = examples?.['lastPage'] as Record<string, unknown>;
-      const data = ((lastPage?.['value'] as Record<string, unknown>)?.['data']) as Record<string, unknown>;
+      const data = (lastPage?.['value'] as Record<string, unknown>)?.['data'] as Record<
+        string,
+        unknown
+      >;
       expect(data?.['has_more']).toBe(false);
       expect(data?.['next_cursor']).toBeNull();
     });
@@ -420,11 +554,16 @@ describe('GET /openapi.json', () => {
     it('each page example contains a non-empty streams array', async () => {
       const op = await getListOp();
       const responses = op['responses'] as Record<string, unknown>;
-      const content = ((responses?.['200'] as Record<string, unknown>)?.['content'] as Record<string, unknown>)?.['application/json'] as Record<string, unknown>;
+      const content = (
+        (responses?.['200'] as Record<string, unknown>)?.['content'] as Record<string, unknown>
+      )?.['application/json'] as Record<string, unknown>;
       const examples = content?.['examples'] as Record<string, unknown>;
       for (const key of ['firstPage', 'nextPage', 'lastPage']) {
         const ex = examples?.[key] as Record<string, unknown>;
-        const data = ((ex?.['value'] as Record<string, unknown>)?.['data']) as Record<string, unknown>;
+        const data = (ex?.['value'] as Record<string, unknown>)?.['data'] as Record<
+          string,
+          unknown
+        >;
         expect(Array.isArray(data?.['streams'])).toBe(true);
         expect((data?.['streams'] as unknown[]).length).toBeGreaterThan(0);
       }
@@ -462,7 +601,10 @@ describe('GET /openapi.json', () => {
       const schema = schemas['StreamCursorToken'] as Record<string, unknown>;
       const example = schema?.['example'] as string;
       // The decoded payload should contain a stream-id (string), not a raw integer id
-      const decoded = JSON.parse(Buffer.from(example, 'base64url').toString('utf8')) as Record<string, unknown>;
+      const decoded = JSON.parse(Buffer.from(example, 'base64url').toString('utf8')) as Record<
+        string,
+        unknown
+      >;
       expect(typeof decoded['lastId']).toBe('string');
       // lastId must not be a plain number string that could enumerate internal rows
       expect(isNaN(Number(decoded['lastId']))).toBe(true);
@@ -481,7 +623,8 @@ describe('GET /openapi.json', () => {
       const schemas = (res.body?.components?.schemas ?? {}) as Record<string, unknown>;
       const schema = schemas['StreamListPage'] as Record<string, unknown>;
       const props = schema?.['properties'] as Record<string, unknown>;
-      const hasMorDesc = ((props?.['has_more'] as Record<string, unknown>)?.['description'] ?? '') as string;
+      const hasMorDesc = ((props?.['has_more'] as Record<string, unknown>)?.['description'] ??
+        '') as string;
       expect(hasMorDesc.toLowerCase()).toMatch(/page|more/);
     });
 


### PR DESCRIPTION
Fixes #333

## Summary
- align the public `Stream` OpenAPI schema with the camelCase stream API response shape
- remove the API-only `scheduled` status so `StreamStatus` matches the persisted DB enum (`active`, `paused`, `completed`, `cancelled`)
- document `streamedAmount` and `remainingAmount` as decimal-string response fields
- update stream examples to use real-looking Stellar `G...` addresses and include all monetary response fields
- add OpenAPI drift guard coverage for Stream schema keys, status enum values, monetary field refs, and `/docs`

## Notes
- Public stream responses remain camelCase while the docs test maps those keys back to the `StreamRecord` source columns.
- `src/webhooks/retry.ts` had duplicate exports/unreachable code that prevented docs tests from collecting once the app imports were exercised, so this PR keeps the cleanup required for the docs route test harness.

## Validation
- `node .\node_modules\vitest\vitest.mjs run tests/routes/docs.test.ts --reporter=dot` (61 passed)
- `node .\node_modules\eslint\bin\eslint.js src/openapi/spec.ts src/routes/streams.ts src/types/express.d.ts src/webhooks/retry.ts tests/routes/docs.test.ts`
- `git diff --check`
- touched-file filtered `tsc --noEmit --pretty false` output had no matches for the modified files

Full `tsc --noEmit` still returns nonzero because of existing repository-wide baseline TypeScript errors outside this change.