### PR TITLE
feat(db): fail over stale replica reads

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -25,6 +25,8 @@ POOL_QUEUE_LIMIT=50
 # Read-replica URL (optional — omit to use primary for all queries)
 # When set, SELECT queries on streams are routed through a dedicated replica pool.
 # DATABASE_REPLICA_URL=postgresql://readonly_user:password@replica-host:5432/fluxora
+# Max tolerated replica replay lag before reads fall back to primary.
+REPLICA_MAX_LAG_SECONDS=30
 
 # Full DATABASE_URL (auto-generated in docker-compose, override if needed)
 DATABASE_URL=postgresql://fluxora:fluxora_secure_password@localhost:5432/fluxora

--- a/docs/database.md
+++ b/docs/database.md
@@ -15,6 +15,8 @@ Fluxora Backend uses a `pg.Pool` (node-postgres) for all database access. The po
 | `DB_IDLE_TIMEOUT` | `30000` | ms before an idle connection is closed |
 | `POOL_QUEUE_LIMIT` | `50` | Max requests allowed to queue before fast-failing with 503 |
 | `STATEMENT_TIMEOUT_MS` | `5000` | Per-connection statement timeout in ms. Set to `0` to disable. |
+| `DATABASE_REPLICA_URL` | unset | Optional read-replica connection string for stream read queries |
+| `REPLICA_MAX_LAG_SECONDS` | `30` | Max tolerated replica replay lag before reads fall back to primary |
 
 ## Statement Timeout
 
@@ -118,6 +120,14 @@ Gauges are updated on every `connect`, `acquire`, and `remove` pool event.
 | `acquire` | Connection checked out | Sync gauges |
 | `remove` | Connection closed/removed | Sync gauges, debug log |
 | `error` | Idle client error | Error log |
+
+## Read Replica Lag Failover
+
+When `DATABASE_REPLICA_URL` is set, stream read queries use a dedicated read-only replica pool. Before serving each read, the pool probes `pg_last_xact_replay_timestamp()` and computes replay lag in seconds. If the lag is unknown, the probe fails, or lag is greater than `REPLICA_MAX_LAG_SECONDS`, that read falls back to the primary pool.
+
+Fallback is reversible. Later reads probe the replica again, so traffic returns to the replica once lag drops below the threshold. The probe does not log the replica URL or credentials.
+
+Prometheus exposes `fluxora_db_replica_lag_seconds` as the last observed lag value. The metric has no host or URL labels to avoid leaking topology details.
 
 ## Caller Behaviour
 

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -3,7 +3,6 @@ import { type StellarNetwork, STELLAR_NETWORKS, type ContractAddresses } from '.
 import {
   getPinnedAddressNetwork,
   isValidStellarContractAddress,
-  STELLAR_CONTRACT_ALLOWLIST,
   STELLAR_NETWORK_PASSPHRASES,
   type PinnedStellarAddressKind,
   type PinnedStellarNetwork,
@@ -165,6 +164,7 @@ export const EnvSchema = z.object({
 
   DATABASE_URL: urlString('DATABASE_URL'),
   DATABASE_REPLICA_URL: optionalUrlString('DATABASE_REPLICA_URL'),
+  REPLICA_MAX_LAG_SECONDS: integerEnv('REPLICA_MAX_LAG_SECONDS', 0).default(30),
   DB_POOL_MIN: integerEnv('DB_POOL_MIN', 1, 100).default(2),
   DB_POOL_MAX: integerEnv('DB_POOL_MAX', 1, 100).default(10),
   DB_CONNECTION_TIMEOUT: integerEnv('DB_CONNECTION_TIMEOUT', 1000, 60000).default(5000),
@@ -307,6 +307,7 @@ export interface Config {
   /** Optional read-replica connection string. When set, SELECT queries on
    *  streams are routed through a dedicated replica pool. */
   databaseReplicaUrl?: string | undefined;
+  replicaMaxLagSeconds: number;
   databasePoolMin: number;
   databasePoolMax: number;
   databaseConnectionTimeout: number;
@@ -448,6 +449,7 @@ function toConfig(env: ParsedEnv): Config {
 
     databaseUrl: env.DATABASE_URL,
     databaseReplicaUrl: env.DATABASE_REPLICA_URL,
+    replicaMaxLagSeconds: env.REPLICA_MAX_LAG_SECONDS,
     databasePoolMin: env.DB_POOL_MIN,
     databasePoolMax: env.DB_POOL_MAX,
     databaseConnectionTimeout: env.DB_CONNECTION_TIMEOUT,

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -5,6 +5,7 @@ dotenv.config();
 export const config = {
   database: {
     url: process.env.DATABASE_URL || 'postgresql://localhost:5432/indexer_db',
+    replicaMaxLagSeconds: parseInt(process.env.REPLICA_MAX_LAG_SECONDS || '30', 10),
   },
   indexer: {
     replayBatchSize: parseInt(process.env.REPLAY_BATCH_SIZE || '1000', 10),

--- a/src/db/replicaPool.ts
+++ b/src/db/replicaPool.ts
@@ -22,16 +22,30 @@
 
 import pg from 'pg';
 import { logger } from '../lib/logger.js';
-import { getPool, createPool, resolvePoolConfig } from './pool.js';
+import { getPool, resolvePoolConfig } from './pool.js';
 import type { PoolConfig } from './pool.js';
+import { dbReplicaLagSeconds } from '../metrics/dbMetrics.js';
 
 const { Pool } = pg;
+const DEFAULT_REPLICA_MAX_LAG_SECONDS = 30;
 
 // ── Internal state ────────────────────────────────────────────────────────────
 
 let _replicaPool: pg.Pool | null = null;
-let _replicaHealthy = false;
 let _healthCheckDone = false;
+
+export interface ReplicaHealth {
+  healthy: boolean;
+  lagSeconds: number;
+  reason?: 'query_failed' | 'lag_unknown' | 'lag_exceeded';
+}
+
+function replicaMaxLagSeconds(): number {
+  const raw = process.env['REPLICA_MAX_LAG_SECONDS'];
+  if (raw === undefined || raw.trim() === '') return DEFAULT_REPLICA_MAX_LAG_SECONDS;
+  const parsed = Number.parseInt(raw, 10);
+  return Number.isFinite(parsed) && parsed >= 0 ? parsed : DEFAULT_REPLICA_MAX_LAG_SECONDS;
+}
 
 /**
  * Extract hostname from a connection string for safe logging.
@@ -104,23 +118,51 @@ export function createReplicaPool(config?: PoolConfig): pg.Pool {
 // ── Health check ──────────────────────────────────────────────────────────────
 
 /**
- * Run a lightweight health-check query (`SELECT 1`) against the replica pool.
- * Returns `true` when the replica is reachable, `false` otherwise.
+ * Check replica connectivity and replay freshness.
  *
- * The check is deliberately simple — it validates TCP connectivity and basic
- * query execution rather than replication lag (which depends on deployment
- * topology and is better monitored externally).
+ * `pg_last_xact_replay_timestamp()` is NULL on a primary or when the replica has
+ * not replayed a transaction yet. For an explicitly configured read-replica,
+ * that is treated as unknown freshness and reads fall back to the primary.
  */
-export async function checkReplicaHealth(pool: pg.Pool): Promise<boolean> {
+export async function checkReplicaHealth(pool: pg.Pool): Promise<ReplicaHealth> {
+  const maxLagSeconds = replicaMaxLagSeconds();
+
   try {
-    await pool.query('SELECT 1');
-    return true;
+    const result = await pool.query<{ lag_seconds: number | string | null }>(
+      `
+        SELECT EXTRACT(
+          EPOCH FROM now() - pg_last_xact_replay_timestamp()
+        ) AS lag_seconds
+      `,
+    );
+    const rawLag = result.rows[0]?.lag_seconds;
+    const lagSeconds = rawLag === null || rawLag === undefined ? Number.NaN : Number(rawLag);
+
+    if (!Number.isFinite(lagSeconds)) {
+      dbReplicaLagSeconds.set(0);
+      logger.warn('Replica health-check could not determine replication lag; falling back to primary');
+      return { healthy: false, lagSeconds: 0, reason: 'lag_unknown' };
+    }
+
+    const normalizedLag = Math.max(0, lagSeconds);
+    dbReplicaLagSeconds.set(normalizedLag);
+
+    if (normalizedLag > maxLagSeconds) {
+      logger.warn('Replica lag exceeds threshold; falling back to primary', undefined, {
+        lagSeconds: normalizedLag,
+        maxLagSeconds,
+      });
+      return { healthy: false, lagSeconds: normalizedLag, reason: 'lag_exceeded' };
+    }
+
+    return { healthy: true, lagSeconds: normalizedLag };
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
-    logger.warn('Replica health-check failed — falling back to primary', undefined, {
+    dbReplicaLagSeconds.set(0);
+    logger.warn('Replica health-check failed; falling back to primary', undefined, {
       error: message,
     });
-    return false;
+    return { healthy: false, lagSeconds: 0, reason: 'query_failed' };
   }
 }
 
@@ -141,32 +183,30 @@ export async function checkReplicaHealth(pool: pg.Pool): Promise<boolean> {
  */
 export async function getReadPool(): Promise<pg.Pool> {
   // Fast path: already resolved.
-  if (_healthCheckDone) {
-    return _replicaHealthy && _replicaPool ? _replicaPool : getPool();
+  if (_healthCheckDone && !_replicaPool) {
+    return getPool();
   }
 
   const cfg = resolveReplicaPoolConfig();
   if (!cfg) {
     logger.info('DATABASE_REPLICA_URL not set — reads will use the primary pool');
     _healthCheckDone = true;
-    _replicaHealthy = false;
+    dbReplicaLagSeconds.set(0);
     return getPool();
   }
 
-  _replicaPool = createReplicaPool(cfg);
-  _replicaHealthy = await checkReplicaHealth(_replicaPool);
+  _replicaPool ??= createReplicaPool(cfg);
+  const health = await checkReplicaHealth(_replicaPool);
   _healthCheckDone = true;
 
-  if (_replicaHealthy) {
+  if (health.healthy) {
     logger.info('Read-replica pool initialised', undefined, {
       host: safeHostname(cfg.connectionString),
+      lagSeconds: health.lagSeconds,
     });
     return _replicaPool;
   }
 
-  // Replica unreachable — close its pool and fall back.
-  await _replicaPool.end().catch(() => {});
-  _replicaPool = null;
   return getPool();
 }
 
@@ -175,13 +215,12 @@ export async function getReadPool(): Promise<pg.Pool> {
 /** Reset internal state (for tests only). */
 export function resetReplicaPool(): void {
   _replicaPool = null;
-  _replicaHealthy = false;
   _healthCheckDone = false;
+  dbReplicaLagSeconds.set(0);
 }
 
 /** Replace the singleton replica pool (for tests only). */
 export function setReplicaPool(pool: pg.Pool | null, healthy = true): void {
   _replicaPool = pool;
-  _replicaHealthy = healthy;
-  _healthCheckDone = true;
+  _healthCheckDone = !healthy || pool === null;
 }

--- a/src/metrics/dbMetrics.ts
+++ b/src/metrics/dbMetrics.ts
@@ -59,6 +59,14 @@ export const dbPoolExhaustedTotal =
     registers: [registry],
   });
 
+export const dbReplicaLagSeconds =
+  (registry.getSingleMetric('fluxora_db_replica_lag_seconds') as Gauge) ||
+  new Gauge({
+    name: 'fluxora_db_replica_lag_seconds',
+    help: 'Last observed read-replica replay lag in seconds; 0 when reads use primary or the replica is current',
+    registers: [registry],
+  });
+
 export function deRegisterDbMetrics(): void {
   registry.removeSingleMetric('fluxora_db_query_duration_seconds');
   registry.removeSingleMetric('fluxora_db_slow_queries_total');
@@ -66,4 +74,5 @@ export function deRegisterDbMetrics(): void {
   registry.removeSingleMetric('fluxora_db_pool_idle_connections');
   registry.removeSingleMetric('fluxora_db_pool_waiting_requests');
   registry.removeSingleMetric('fluxora_db_pool_exhausted_total');
+  registry.removeSingleMetric('fluxora_db_replica_lag_seconds');
 }

--- a/tests/config/env.validation.test.ts
+++ b/tests/config/env.validation.test.ts
@@ -1,6 +1,8 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 const originalEnv = process.env;
+const TESTNET_CONTRACT = 'CASTMR2YNF5IXHFNX3H6B4ICCMSDKRSXNB4YVG5MXXHN74ABCIRTISIC';
+const TESTNET_TOKEN = 'CBFFW3D5R2P3BQOS4P2AKFRHHBEVU234RWPK7QGR4LZQIFJGG5EFTAK6';
 
 function validEnv(overrides: NodeJS.ProcessEnv = {}): NodeJS.ProcessEnv {
   return {
@@ -8,6 +10,9 @@ function validEnv(overrides: NodeJS.ProcessEnv = {}): NodeJS.ProcessEnv {
     DATABASE_URL: 'postgresql://localhost/fluxora_test',
     JWT_SECRET: 'a-very-long-secret-key-for-testing-only-12345',
     INDEXER_WORKER_TOKEN: 'indexer-worker-token-for-testing-only-12345',
+    STELLAR_NETWORK: 'testnet',
+    STELLAR_CONTRACT_ADDRESS: TESTNET_CONTRACT,
+    STELLAR_TOKEN_ADDRESS: TESTNET_TOKEN,
     ...overrides,
   };
 }
@@ -60,6 +65,22 @@ describe('EnvSchema startup validation', () => {
     expect(config.redisEnabled).toBe(true);
     expect(config.maxRequestSizeBytes).toBe(1024 * 1024);
     expect(config.webhookPollIntervalMs).toBe(10000);
+    expect(config.replicaMaxLagSeconds).toBe(30);
+  });
+
+  it('validates and exposes the replica lag failover threshold', async () => {
+    const { loadConfig } = await importEnvWith(validEnv({ REPLICA_MAX_LAG_SECONDS: '45' }));
+
+    const config = loadConfig();
+
+    expect(config.replicaMaxLagSeconds).toBe(45);
+  });
+
+  it('rejects negative replica lag thresholds', async () => {
+    await expect(importEnvWith(validEnv({ REPLICA_MAX_LAG_SECONDS: '-1' }))).rejects.toMatchObject({
+      name: 'EnvironmentError',
+      message: expect.stringContaining('REPLICA_MAX_LAG_SECONDS'),
+    });
   });
 
   it('does not include secret values in validation messages', async () => {

--- a/tests/db/replicaPool.test.ts
+++ b/tests/db/replicaPool.test.ts
@@ -12,6 +12,7 @@
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import pg from 'pg';
+import { dbReplicaLagSeconds } from '../../src/metrics/dbMetrics.js';
 
 // ── Mock the pg module ────────────────────────────────────────────────────────
 
@@ -114,19 +115,45 @@ describe('replicaPool', () => {
   // ── checkReplicaHealth ────────────────────────────────────────────────────
 
   describe('checkReplicaHealth', () => {
-    it('returns true when SELECT 1 succeeds', async () => {
-      mockQuery.mockResolvedValueOnce({ rows: [{ '?column?': 1 }] });
+    it('returns healthy when replica lag is within the threshold', async () => {
+      process.env['REPLICA_MAX_LAG_SECONDS'] = '30';
+      mockQuery.mockResolvedValueOnce({ rows: [{ lag_seconds: '2.5' }] });
       const pool = new pg.Pool();
       const healthy = await checkReplicaHealth(pool);
-      expect(healthy).toBe(true);
-      expect(mockQuery).toHaveBeenCalledWith('SELECT 1');
+      expect(healthy).toEqual({ healthy: true, lagSeconds: 2.5 });
+      expect(mockQuery).toHaveBeenCalledWith(expect.stringContaining('pg_last_xact_replay_timestamp()'));
     });
 
-    it('returns false when SELECT 1 throws', async () => {
+    it('returns stale when replica lag exceeds the threshold', async () => {
+      process.env['REPLICA_MAX_LAG_SECONDS'] = '30';
+      mockQuery.mockResolvedValueOnce({ rows: [{ lag_seconds: '31' }] });
+      const pool = new pg.Pool();
+      const health = await checkReplicaHealth(pool);
+      expect(health).toEqual({ healthy: false, lagSeconds: 31, reason: 'lag_exceeded' });
+    });
+
+    it('returns unhealthy when replica lag cannot be determined', async () => {
+      mockQuery.mockResolvedValueOnce({ rows: [{ lag_seconds: null }] });
+      const pool = new pg.Pool();
+      const health = await checkReplicaHealth(pool);
+      expect(health).toEqual({ healthy: false, lagSeconds: 0, reason: 'lag_unknown' });
+    });
+
+    it('returns unhealthy when the lag probe throws', async () => {
       mockQuery.mockRejectedValueOnce(new Error('Connection refused'));
       const pool = new pg.Pool();
-      const healthy = await checkReplicaHealth(pool);
-      expect(healthy).toBe(false);
+      const health = await checkReplicaHealth(pool);
+      expect(health).toEqual({ healthy: false, lagSeconds: 0, reason: 'query_failed' });
+    });
+
+    it('updates the replica lag metric without exposing topology labels', async () => {
+      mockQuery.mockResolvedValueOnce({ rows: [{ lag_seconds: '7' }] });
+      const pool = new pg.Pool();
+      await checkReplicaHealth(pool);
+
+      const metric = await dbReplicaLagSeconds.get();
+      expect(metric.values[0]?.value).toBe(7);
+      expect(metric.values[0]?.labels).toEqual({});
     });
   });
 
@@ -134,7 +161,7 @@ describe('replicaPool', () => {
 
   describe('createReplicaPool', () => {
     it('creates a pool and registers a connect handler for read-only mode', () => {
-      const pool = createReplicaPool({
+      createReplicaPool({
         connectionString: 'postgresql://replica:5432/fluxora',
         min: 1,
         max: 5,
@@ -187,7 +214,7 @@ describe('replicaPool', () => {
 
     it('returns the replica pool when DATABASE_REPLICA_URL is set and replica is healthy', async () => {
       process.env['DATABASE_REPLICA_URL'] = 'postgresql://replica:5432/fluxora';
-      mockQuery.mockResolvedValueOnce({ rows: [{ '?column?': 1 }] });
+      mockQuery.mockResolvedValueOnce({ rows: [{ lag_seconds: '0.2' }] });
 
       const pool = await getReadPool();
       // Should NOT be the primary pool
@@ -202,15 +229,29 @@ describe('replicaPool', () => {
       expect(pool).toBe(mockPrimaryPool);
     });
 
-    it('caches the result after the first call (healthy replica)', async () => {
+    it('falls back to primary when replica lag is above the threshold', async () => {
       process.env['DATABASE_REPLICA_URL'] = 'postgresql://replica:5432/fluxora';
-      mockQuery.mockResolvedValueOnce({ rows: [{ '?column?': 1 }] });
+      process.env['REPLICA_MAX_LAG_SECONDS'] = '30';
+      mockQuery.mockResolvedValueOnce({ rows: [{ lag_seconds: '120' }] });
 
-      const pool1 = await getReadPool();
-      const pool2 = await getReadPool();
-      expect(pool1).toBe(pool2);
-      // SELECT 1 should only be called once (health-check)
-      expect(mockQuery).toHaveBeenCalledTimes(1);
+      const pool = await getReadPool();
+      expect(pool).toBe(mockPrimaryPool);
+      expect(mockEnd).not.toHaveBeenCalled();
+    });
+
+    it('rechecks lag on later reads so stale fallback is reversible', async () => {
+      process.env['DATABASE_REPLICA_URL'] = 'postgresql://replica:5432/fluxora';
+      process.env['REPLICA_MAX_LAG_SECONDS'] = '30';
+      mockQuery
+        .mockResolvedValueOnce({ rows: [{ lag_seconds: '90' }] })
+        .mockResolvedValueOnce({ rows: [{ lag_seconds: '1' }] });
+
+      const first = await getReadPool();
+      const second = await getReadPool();
+
+      expect(first).toBe(mockPrimaryPool);
+      expect(second).not.toBe(mockPrimaryPool);
+      expect(mockQuery).toHaveBeenCalledTimes(2);
     });
 
     it('caches the result after the first call (no replica URL)', async () => {
@@ -222,12 +263,12 @@ describe('replicaPool', () => {
       expect(pool1).toBe(mockPrimaryPool);
     });
 
-    it('closes the replica pool on health-check failure before falling back', async () => {
+    it('keeps the replica pool available after temporary health-check failure', async () => {
       process.env['DATABASE_REPLICA_URL'] = 'postgresql://replica:5432/fluxora';
       mockQuery.mockRejectedValueOnce(new Error('ECONNREFUSED'));
 
       await getReadPool();
-      expect(mockEnd).toHaveBeenCalled();
+      expect(mockEnd).not.toHaveBeenCalled();
     });
   });
 
@@ -243,7 +284,7 @@ describe('replicaPool', () => {
 
       // Now set the replica URL
       process.env['DATABASE_REPLICA_URL'] = 'postgresql://replica:5432/fluxora';
-      mockQuery.mockResolvedValueOnce({ rows: [{ '?column?': 1 }] });
+      mockQuery.mockResolvedValueOnce({ rows: [{ lag_seconds: '0' }] });
 
       const pool2 = await getReadPool();
       expect(pool2).not.toBe(mockPrimaryPool);


### PR DESCRIPTION
Fixes #355

## Summary
- add a configurable `REPLICA_MAX_LAG_SECONDS` threshold with a 30 second default
- make `checkReplicaHealth()` probe `pg_last_xact_replay_timestamp()` and return lag/failure details
- fall stream reads back to the primary when lag is unknown, the probe fails, or lag exceeds the threshold
- keep stale replica fallback reversible by retaining the replica pool and rechecking later reads
- expose `fluxora_db_replica_lag_seconds` without host/URL labels to avoid leaking topology
- document read-replica lag failover behavior

## Validation
- `node .\node_modules\vitest\vitest.mjs run tests/db/replicaPool.test.ts tests/config/env.validation.test.ts --reporter=dot`
- `node .\node_modules\eslint\bin\eslint.js src/db/replicaPool.ts src/config/env.ts src/config/index.ts src/metrics/dbMetrics.ts tests/db/replicaPool.test.ts tests/config/env.validation.test.ts`
- `git diff --check`
- touched-file filtered `tsc --noEmit --pretty false`: no diagnostics matched changed files

## Baseline note
A broader local test probe that included `tests/streamsRepository.test.ts` and `tests/metrics/businessMetrics.test.ts` still hits existing unrelated baseline failures in `src/webhooks/retry.ts` duplicate exports and `src/db/repositories/streamRepository.ts` ReferenceErrors. Those files are not changed by this PR.