### PR TITLE
feat(webhooks): persist outbox retry checkpoints

### DIFF
--- a/migrations/1774715350000_webhook-outbox-durable-retry.ts
+++ b/migrations/1774715350000_webhook-outbox-durable-retry.ts
@@ -1,0 +1,37 @@
+import { ColumnDefinitions, MigrationBuilder } from 'node-pg-migrate';
+
+export const shorthands: ColumnDefinitions | undefined = undefined;
+
+export async function up(pgm: MigrationBuilder): Promise<void> {
+  pgm.addColumns('webhook_outbox', {
+    attempt_count: { type: 'integer', notNull: true, default: 0 },
+    next_attempt_at: { type: 'timestamp with time zone' },
+  });
+
+  pgm.sql(`
+    UPDATE webhook_outbox
+    SET next_attempt_at = created_at
+    WHERE next_attempt_at IS NULL
+  `);
+
+  pgm.alterColumn('webhook_outbox', 'next_attempt_at', {
+    default: pgm.func('current_timestamp'),
+  });
+
+  pgm.createIndex(
+    'webhook_outbox',
+    ['processed', 'next_attempt_at', 'created_at'],
+    {
+      name: 'idx_webhook_outbox_ready_retry',
+      where: 'processed = false',
+    },
+  );
+}
+
+export async function down(pgm: MigrationBuilder): Promise<void> {
+  pgm.dropIndex('webhook_outbox', ['processed', 'next_attempt_at', 'created_at'], {
+    name: 'idx_webhook_outbox_ready_retry',
+    ifExists: true,
+  });
+  pgm.dropColumns('webhook_outbox', ['next_attempt_at', 'attempt_count']);
+}

--- a/src/webhooks/retry.ts
+++ b/src/webhooks/retry.ts
@@ -134,62 +134,6 @@ export function isRetryableStatusCode(
   return policy.retryableStatusCodes.includes(statusCode);
 }
 
-/** Return the absolute timestamp for the next retry attempt. */
-export function calculateNextRetryTime(
-  attemptNumber: number,
-  policy: EnhancedRetryPolicy,
-  now: number = Date.now(),
-): number {
-  const delayMs = applyJitter(calculateBackoffDelay(attemptNumber, policy), policy);
-  return now + delayMs;
-}
-
-/** Generate retry metadata for every configured attempt. */
-export function generateRetrySchedule(
-  policy: EnhancedRetryPolicy,
-  now: number = Date.now(),
-): RetrySchedule[] {
-  return Array.from({ length: policy.maxAttempts }, (_, index) => {
-    const attemptNumber = index + 1;
-    const delayMs = applyJitter(calculateBackoffDelay(attemptNumber, policy), policy);
-
-    return {
-      attemptNumber,
-      delayMs,
-      retryAt: now + delayMs,
-    };
-  });
-}
-
-/** Attach retry metadata to an outbox payload and return the next retry time. */
-export function scheduleWebhookOutboxRetry(input: WebhookOutboxRetryInput): WebhookOutboxRetryPlan {
-  const policy = input.policy ?? DEFAULT_RETRY_POLICY;
-  const nextAttemptNumber = input.attemptNumber + 1;
-
-  if (nextAttemptNumber > policy.maxAttempts) {
-    return {
-      shouldRetry: false,
-      attemptNumber: input.attemptNumber,
-      retryAt: null,
-      payload: input.payload,
-    };
-  }
-
-  const payload =
-    typeof input.payload === 'object' && input.payload !== null && !Array.isArray(input.payload)
-      ? { ...(input.payload as Record<string, unknown>), _webhookRetry: { attemptNumber: nextAttemptNumber } }
-      : { _webhookRetry: { attemptNumber: nextAttemptNumber } };
-
-  return {
-    shouldRetry: true,
-    attemptNumber: nextAttemptNumber,
-    retryAt: new Date(calculateNextRetryTime(input.attemptNumber, policy, input.now)),
-    payload,
-  };
-  const retryable = policy.retryableStatusCodes ?? DEFAULT_RETRY_POLICY.retryableStatusCodes;
-  return retryable.includes(statusCode);
-}
-
 /**
  * Calculate the absolute timestamp (ms since epoch) at which the next retry
  * should be attempted, or 0 if the attempt number has reached maxAttempts.

--- a/src/webhooks/service.ts
+++ b/src/webhooks/service.ts
@@ -12,13 +12,18 @@ import type {
   WebhookEvent,
   WebhookDelivery,
   WebhookDeliveryAttempt,
-  WebhookRetryPolicy,
 } from './types.js';
 import { DEFAULT_RETRY_POLICY } from './types.js';
 import { webhookDeliveryStore } from './store.js';
 import { computeWebhookSignature } from './signature.js';
-import { calculateNextRetryTime, scheduleWebhookOutboxRetry, shouldRetry } from './retry.js';
-import { calculateNextRetryTime, shouldRetry, checkWebhookDeliveryGate, attemptWebhookDeliveryWithRateLimit, countsTowardCircuitBreaker, type EnhancedRetryPolicy } from './retry.js';
+import {
+  attemptWebhookDeliveryWithRateLimit,
+  calculateNextRetryTime,
+  checkWebhookDeliveryGate,
+  countsTowardCircuitBreaker,
+  shouldRetry,
+  type EnhancedRetryPolicy,
+} from './retry.js';
 import { webhookDeliveriesTotal, webhookDeliveryDurationSeconds } from '../metrics/businessMetrics.js';
 import type { WebhookCircuitBreakerStore, CircuitBreakerPolicy } from '../redis/webhookCircuitBreakerStore.js';
 import { getWebhookCircuitBreakerStore } from '../redis/webhookCircuitBreakerStore.js';
@@ -31,6 +36,8 @@ interface OutboxRow {
   event_type: string;
   payload: unknown;
   created_at: Date | string;
+  attempt_count: number | string | null;
+  next_attempt_at: Date | string | null;
 }
 
 interface DbClient {
@@ -113,14 +120,23 @@ function normalizePayload(payload: unknown): unknown {
   return payload;
 }
 
-function extractAttemptNumber(payload: unknown): number {
-  if (typeof payload !== 'object' || payload === null) return 1;
-  const retry = (payload as Record<string, unknown>)['_webhookRetry'];
-  if (typeof retry !== 'object' || retry === null) return 1;
-  const attemptNumber = (retry as Record<string, unknown>)['attemptNumber'];
-  return typeof attemptNumber === 'number' && Number.isFinite(attemptNumber) && attemptNumber > 0
-    ? Math.floor(attemptNumber)
-    : 1;
+function parseOutboxAttemptCount(value: number | string | null | undefined): number {
+  const parsed = typeof value === 'number' ? value : Number.parseInt(String(value ?? 0), 10);
+  return Number.isFinite(parsed) && parsed > 0 ? Math.floor(parsed) : 0;
+}
+
+function deliverySucceeded(attempt: WebhookDeliveryAttempt): boolean {
+  return attempt.statusCode !== undefined &&
+    attempt.statusCode >= 200 &&
+    attempt.statusCode < 300 &&
+    !attempt.error;
+}
+
+function describeOutboxFailure(attempt: WebhookDeliveryAttempt, attemptNumber: number): string {
+  const suffix = `after ${attemptNumber} attempt${attemptNumber === 1 ? '' : 's'}`;
+  if (attempt.error) return `${attempt.error} ${suffix}`;
+  if (attempt.statusCode !== undefined) return `HTTP ${attempt.statusCode} ${suffix}`;
+  return `Webhook delivery failed ${suffix}`;
 }
 
 function enqueuePermanentFailureToDlq(
@@ -607,11 +623,11 @@ export class WebhookDispatcher {
       await client.query('BEGIN');
       const result = await client.query<OutboxRow>(
         `
-          SELECT id, stream_id, event_type, payload, created_at
+          SELECT id, stream_id, event_type, payload, created_at, attempt_count, next_attempt_at
           FROM webhook_outbox
           WHERE processed = false
-            AND created_at <= NOW()
-          ORDER BY created_at ASC, id ASC
+            AND next_attempt_at <= NOW()
+          ORDER BY next_attempt_at ASC, created_at ASC, id ASC
           LIMIT $1
           FOR UPDATE SKIP LOCKED
         `,
@@ -647,7 +663,8 @@ export class WebhookDispatcher {
 
     const payload = normalizePayload(row.payload);
     const payloadString = JSON.stringify(payload);
-    const attemptNumber = extractAttemptNumber(payload);
+    const previousAttempts = parseOutboxAttemptCount(row.attempt_count);
+    const attemptNumber = previousAttempts + 1;
     const delivery: WebhookDelivery = {
       id: `outbox_${row.id}`,
       deliveryId: `outbox_${row.id}`,
@@ -655,7 +672,7 @@ export class WebhookDispatcher {
       eventType: row.event_type as WebhookEvent['type'],
       endpointUrl: endpoint.endpointUrl,
       status: 'pending',
-      attempts: Array.from({ length: Math.max(0, attemptNumber - 1) }, (_, index) => ({
+      attempts: Array.from({ length: previousAttempts }, (_, index) => ({
         attemptNumber: index + 1,
         timestamp: Date.now(),
       })),
@@ -681,50 +698,83 @@ export class WebhookDispatcher {
       },
     );
 
-    await client.query('UPDATE webhook_outbox SET processed = true WHERE id = $1', [row.id]);
-
     if (!result.attempt) {
       if (result.shouldRetry && result.retryAt) {
         await client.query(
           `
-            INSERT INTO webhook_outbox (stream_id, event_type, payload, created_at, processed)
-            VALUES ($1, $2, $3::jsonb, $4, false)
+            UPDATE webhook_outbox
+            SET next_attempt_at = $2,
+                payload = $3::jsonb
+            WHERE id = $1
           `,
-          [row.stream_id, row.event_type, JSON.stringify(payload), result.retryAt],
+          [row.id, result.retryAt, JSON.stringify(payload)],
         );
       }
       return;
     }
 
     const attempt = result.attempt;
-    if (result.shouldRetry) {
-      attempt.nextRetryAt = result.retryAt?.getTime() ?? calculateNextRetryTime(attemptNumber, this.policy);
-      delivery.status = 'pending';
-    } else if (
-      attempt.statusCode !== undefined &&
-      attempt.statusCode >= 200 &&
-      attempt.statusCode < 300 &&
-      !attempt.error
-    ) {
-      delivery.status = 'delivered';
-    } else {
-      delivery.status = 'permanent_failure';
-    }
-
-    if (delivery.status === 'delivered' || delivery.status === 'permanent_failure') {
+    if (deliverySucceeded(attempt)) {
+      await client.query(
+        `
+          UPDATE webhook_outbox
+          SET processed = true,
+              attempt_count = $2,
+              next_attempt_at = NULL
+          WHERE id = $1
+        `,
+        [row.id, attemptNumber],
+      );
       return;
     }
 
-    if (!result.shouldRetry || !result.retryAt) {
+    if (result.shouldRetry && result.retryAt) {
+      attempt.nextRetryAt = result.retryAt.getTime();
+      await client.query(
+        `
+          UPDATE webhook_outbox
+          SET attempt_count = $2,
+              next_attempt_at = $3,
+              payload = $4::jsonb,
+              processed = false
+          WHERE id = $1
+        `,
+        [row.id, attemptNumber, result.retryAt, JSON.stringify(result.payload)],
+      );
       return;
     }
 
     await client.query(
       `
-        INSERT INTO webhook_outbox (stream_id, event_type, payload, created_at, processed)
-        VALUES ($1, $2, $3::jsonb, $4, false)
+        INSERT INTO dead_letter_queue
+          (id, topic, payload, error, attempts, correlation_id, first_failed_at, last_failed_at)
+        VALUES ($1, $2, $3::jsonb, $4, $5, $6, $7, $7)
+        ON CONFLICT (id) DO UPDATE
+        SET payload = EXCLUDED.payload,
+            error = EXCLUDED.error,
+            attempts = EXCLUDED.attempts,
+            last_failed_at = EXCLUDED.last_failed_at
       `,
-      [row.stream_id, row.event_type, JSON.stringify(result.payload), result.retryAt],
+      [
+        `webhook-outbox-${row.id}`,
+        row.event_type,
+        JSON.stringify(payload),
+        describeOutboxFailure(attempt, attemptNumber),
+        attemptNumber,
+        null,
+        new Date(),
+      ],
+    );
+
+    await client.query(
+      `
+        UPDATE webhook_outbox
+        SET processed = true,
+            attempt_count = $2,
+            next_attempt_at = NULL
+        WHERE id = $1
+      `,
+      [row.id, attemptNumber],
     );
   }
 }

--- a/tests/webhooks/service.dispatcher.test.ts
+++ b/tests/webhooks/service.dispatcher.test.ts
@@ -54,6 +54,23 @@ function createDispatcher(client: MockClient, breaker: RedisWebhookCircuitBreake
   });
 }
 
+function readyOutboxRow(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    id: '42',
+    stream_id: 'stream-1',
+    event_type: 'stream.created',
+    payload: { id: 'evt-1' },
+    created_at: new Date('2026-05-26T12:00:00.000Z'),
+    attempt_count: 0,
+    next_attempt_at: new Date('2026-05-26T12:00:00.000Z'),
+    ...overrides,
+  };
+}
+
+function findUpdate(client: MockClient, fragment: string): { sql: string; params: unknown[] | undefined } | undefined {
+  return client.queries.find(q => q.sql.includes('UPDATE webhook_outbox') && q.sql.includes(fragment));
+}
+
 describe('WebhookDispatcher outbox polling', () => {
   let redis: FakeRedisClient;
   let breaker: RedisWebhookCircuitBreakerStore;
@@ -83,84 +100,103 @@ describe('WebhookDispatcher outbox polling', () => {
 
   it('claims rows with FOR UPDATE SKIP LOCKED and marks successful deliveries processed', async () => {
     const client = createClient([
-      {
-        id: '42',
-        stream_id: 'stream-1',
-        event_type: 'stream.created',
-        payload: { id: 'evt-1', amount: '10' },
-        created_at: new Date(),
-      },
+      readyOutboxRow({ payload: { id: 'evt-1', amount: '10' } }),
     ]);
     global.fetch = vi.fn(async () => new Response(null, { status: 204 })) as unknown as typeof fetch;
 
     await createDispatcher(client, breaker).pollOnce();
 
     const select = client.queries.find(q => q.sql.includes('SELECT id, stream_id'));
+    expect(select?.sql).toContain('attempt_count, next_attempt_at');
+    expect(select?.sql).toContain('next_attempt_at <= NOW()');
     expect(select?.sql).toContain('FOR UPDATE SKIP LOCKED');
     expect(select?.params).toEqual([5]);
     expect(global.fetch).toHaveBeenCalledOnce();
-    expect(client.queries).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({
-          sql: 'UPDATE webhook_outbox SET processed = true WHERE id = $1',
-          params: ['42'],
-        }),
-      ]),
-    );
+    const update = findUpdate(client, 'processed = true');
+    expect(update?.sql).toContain('attempt_count = $2');
+    expect(update?.sql).toContain('next_attempt_at = NULL');
+    expect(update?.params).toEqual(['42', 1]);
     expect(client.queries.some(q => q.sql.includes('INSERT INTO webhook_outbox'))).toBe(false);
   });
 
-  it('marks failed attempts processed and delegates retry scheduling to a future outbox row', async () => {
+  it('persists failed attempt checkpoints on the same outbox row', async () => {
     const now = new Date('2026-05-26T12:00:00.000Z').getTime();
     vi.spyOn(Date, 'now').mockReturnValue(now);
     const client = createClient([
-      {
+      readyOutboxRow({
         id: '43',
         stream_id: 'stream-2',
         event_type: 'stream.updated',
         payload: { id: 'evt-2', amount: '20' },
         created_at: new Date(now),
-      },
+      }),
     ]);
     global.fetch = vi.fn(async () => new Response(null, { status: 500, statusText: 'Server Error' })) as unknown as typeof fetch;
 
     await createDispatcher(client, breaker).pollOnce();
 
-    const insert = client.queries.find(q => q.sql.includes('INSERT INTO webhook_outbox'));
-    expect(client.queries).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({
-          sql: 'UPDATE webhook_outbox SET processed = true WHERE id = $1',
-          params: ['43'],
-        }),
-      ]),
-    );
-    expect(insert?.params?.[0]).toBe('stream-2');
-    expect(insert?.params?.[1]).toBe('stream.updated');
-    expect(JSON.parse(insert?.params?.[2] as string)).toMatchObject({
+    const update = findUpdate(client, 'attempt_count = $2');
+    expect(update?.sql).toContain('next_attempt_at = $3');
+    expect(update?.sql).toContain('processed = false');
+    expect(update?.params?.[0]).toBe('43');
+    expect(update?.params?.[1]).toBe(1);
+    expect(update?.params?.[2]).toEqual(new Date(now + 1000));
+    expect(JSON.parse(update?.params?.[3] as string)).toMatchObject({
       id: 'evt-2',
       _webhookRetry: { attemptNumber: 2 },
     });
-    expect(insert?.params?.[3]).toEqual(new Date(now + 1000));
+    expect(client.queries.some(q => q.sql.includes('INSERT INTO webhook_outbox'))).toBe(false);
   });
 
-  it('does not enqueue another row after retry attempts are exhausted', async () => {
+  it('recovers pending retries after restart from durable attempt_count and next_attempt_at', async () => {
+    const now = new Date('2026-05-26T12:00:00.000Z').getTime();
+    vi.spyOn(Date, 'now').mockReturnValue(now);
     const client = createClient([
-      {
+      readyOutboxRow({
         id: '44',
         stream_id: 'stream-3',
         event_type: 'stream.cancelled',
-        payload: {
-          id: 'evt-3',
-          _webhookRetry: { attemptNumber: 3 },
-        },
-        created_at: new Date(),
-      },
+        payload: { id: 'evt-3', _webhookRetry: { attemptNumber: 2 } },
+        created_at: new Date(now - 60_000),
+        attempt_count: 1,
+        next_attempt_at: new Date(now - 1),
+      }),
     ]);
     global.fetch = vi.fn(async () => new Response(null, { status: 500, statusText: 'Server Error' })) as unknown as typeof fetch;
 
     await createDispatcher(client, breaker).pollOnce();
 
+    const update = findUpdate(client, 'attempt_count = $2');
+    expect(update?.params?.[1]).toBe(2);
+    expect(JSON.parse(update?.params?.[3] as string)).toMatchObject({
+      _webhookRetry: { attemptNumber: 3 },
+    });
+    expect(client.queries.some(q => q.sql.includes('INSERT INTO webhook_outbox'))).toBe(false);
+  });
+
+  it('routes exhausted outbox rows durably to the dead-letter queue', async () => {
+    const client = createClient([
+      readyOutboxRow({
+        id: '48',
+        stream_id: 'stream-7',
+        event_type: 'stream.cancelled',
+        payload: { id: 'evt-7' },
+        attempt_count: 2,
+      }),
+    ]);
+    global.fetch = vi.fn(async () => new Response(null, { status: 500, statusText: 'Server Error' })) as unknown as typeof fetch;
+
+    await createDispatcher(client, breaker).pollOnce();
+
+    const dlqInsert = client.queries.find(q => q.sql.includes('INSERT INTO dead_letter_queue'));
+    expect(dlqInsert?.params?.[0]).toBe('webhook-outbox-48');
+    expect(dlqInsert?.params?.[1]).toBe('stream.cancelled');
+    expect(JSON.parse(dlqInsert?.params?.[2] as string)).toMatchObject({ id: 'evt-7' });
+    expect(dlqInsert?.params?.[3]).toBe('HTTP 500 after 3 attempts');
+    expect(dlqInsert?.params?.[4]).toBe(3);
+
+    const update = findUpdate(client, 'processed = true');
+    expect(update?.params).toEqual(['48', 3]);
     expect(client.queries.some(q => q.sql.includes('INSERT INTO webhook_outbox'))).toBe(false);
   });
 
@@ -171,25 +207,26 @@ describe('WebhookDispatcher outbox polling', () => {
     await breaker.recordFailure('https://consumer.example/webhooks', policy, now + 1);
 
     const client = createClient([
-      {
+      readyOutboxRow({
         id: '46',
         stream_id: 'stream-5',
         event_type: 'stream.created',
         payload: { id: 'evt-5' },
         created_at: new Date(now),
-      },
+      }),
     ]);
     global.fetch = vi.fn() as unknown as typeof fetch;
 
     await createDispatcher(client, breaker).pollOnce();
 
     expect(global.fetch).not.toHaveBeenCalled();
-    const insert = client.queries.find(q => q.sql.includes('INSERT INTO webhook_outbox'));
-    expect(insert).toBeDefined();
-    expect(insert?.params?.[3]).toEqual(new Date((await breaker.getState('https://consumer.example/webhooks'))!.resetAt));
+    const update = findUpdate(client, 'next_attempt_at = $2');
+    expect(update?.params?.[0]).toBe('46');
+    expect(update?.params?.[1]).toEqual(new Date((await breaker.getState('https://consumer.example/webhooks'))!.resetAt));
+    expect(client.queries.some(q => q.sql.includes('INSERT INTO webhook_outbox'))).toBe(false);
   });
 
-  it('re-enqueues outbox rows when half-open probe contention blocks delivery', async () => {
+  it('defers the same outbox row when half-open probe contention blocks delivery', async () => {
     const now = 8_000_000;
     vi.spyOn(Date, 'now').mockReturnValue(now);
     for (let i = 0; i < 2; i++) {
@@ -199,34 +236,35 @@ describe('WebhookDispatcher outbox polling', () => {
     await breaker.checkAndClaimAttempt('https://consumer.example/webhooks', policy, openState!.resetAt);
 
     const client = createClient([
-      {
+      readyOutboxRow({
         id: '47',
         stream_id: 'stream-6',
         event_type: 'stream.created',
         payload: { id: 'evt-6' },
         created_at: new Date(now),
-      },
+      }),
     ]);
     global.fetch = vi.fn() as unknown as typeof fetch;
 
     await createDispatcher(client, breaker).pollOnce();
 
     expect(global.fetch).not.toHaveBeenCalled();
-    const insert = client.queries.find(q => q.sql.includes('INSERT INTO webhook_outbox'));
-    expect(insert).toBeDefined();
-    expect(insert?.params?.[3]).toEqual(new Date(now + 1_000));
+    const update = findUpdate(client, 'next_attempt_at = $2');
+    expect(update?.params?.[0]).toBe('47');
+    expect(update?.params?.[1]).toEqual(new Date(now + 1_000));
+    expect(client.queries.some(q => q.sql.includes('INSERT INTO webhook_outbox'))).toBe(false);
   });
 
   it('drains an in-flight delivery when stopped during shutdown', async () => {
     let releaseFetch: (() => void) | undefined;
     const client = createClient([
-      {
+      readyOutboxRow({
         id: '45',
         stream_id: 'stream-4',
         event_type: 'stream.created',
         payload: { id: 'evt-4' },
         created_at: new Date(),
-      },
+      }),
     ]);
     global.fetch = vi.fn(
       async () => new Promise<Response>((resolve) => {


### PR DESCRIPTION
Fixes #344

## Summary
- add durable webhook_outbox retry columns and a ready-retry partial index
- select due rows by next_attempt_at with FOR UPDATE SKIP LOCKED
- persist retry checkpoints on the same outbox row instead of inserting future retry rows
- route exhausted outbox deliveries into dead_letter_queue and mark the source row processed
- remove duplicate stale retry helper exports that blocked collection

## Validation
- corepack pnpm@8.15.9 install --frozen-lockfile --ignore-scripts
- node .\\node_modules\\vitest\\vitest.mjs run tests\\webhooks\\service.dispatcher.test.ts src\\webhooks\\retry.test.ts tests\\webhooks\\retry.rateLimit.test.ts tests\\webhooks\\circuitBreaker.store.test.ts --reporter=dot
- node .\\node_modules\\vitest\\vitest.mjs run tests\\migrate-guard.test.ts tests\\webhooks\\service.dispatcher.test.ts --reporter=dot
- node .\\node_modules\\eslint\\bin\\eslint.js src\\webhooks\\service.ts src\\webhooks\\retry.ts tests\\webhooks\\service.dispatcher.test.ts tests\\migrate-guard.test.ts
- node --import tsx -e "await import('./migrations/1774715350000_webhook-outbox-durable-retry.ts')"
- git diff --check

## Notes
- Full 	sc --noEmit --pretty false still fails on the repository baseline syntax errors in src/openapi/spec.ts around line 294, unrelated to this webhook/outbox change.