### PR TITLE
refactor(errors): consolidate api error class

### DIFF
--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,33 +1,62 @@
 import { randomUUID } from 'node:crypto';
 import type { Request, Response, NextFunction } from 'express';
-import { ApiError as MiddlewareApiError } from './middleware/errorHandler.js';
 
+/**
+ * Canonical API error type.
+ *
+ * `expose=false` keeps internal messages/details out of client responses while
+ * preserving the original error metadata for logs.
+ */
 export class ApiError extends Error {
-  status: number;
-  code: string;
-  details: Record<string, unknown> | undefined;
-  expose: boolean;
+  readonly status: number;
+  readonly statusCode: number;
+  readonly code: string;
+  readonly details: unknown | undefined;
+  readonly expose: boolean;
 
   constructor(
     status: number,
     code: string,
     message: string,
-    details?: Record<string, unknown>,
+    details?: unknown,
+    expose?: boolean,
+  );
+  constructor(
+    code: string,
+    message: string,
+    statusCode?: number,
+    details?: unknown,
+    expose?: boolean,
+  );
+  constructor(
+    statusOrCode: number | string,
+    codeOrMessage: string,
+    messageOrStatusCode: string | number = 500,
+    details?: unknown,
     expose = true,
   ) {
-    super(message);
+    const legacyOrder = typeof statusOrCode === 'string';
+    const status = legacyOrder
+      ? (typeof messageOrStatusCode === 'number' ? messageOrStatusCode : 500)
+      : statusOrCode;
+    const code = legacyOrder ? statusOrCode : codeOrMessage;
+    const resolvedMessage = legacyOrder ? codeOrMessage : String(messageOrStatusCode);
+
+    super(resolvedMessage);
+    this.name = 'ApiError';
     this.status = status;
+    this.statusCode = status;
     this.code = code;
     this.details = details;
     this.expose = expose;
   }
 }
 
-export function serviceUnavailable(message: string, details?: Record<string, unknown>): ApiError {
+export function serviceUnavailable(message: string, details?: unknown): ApiError {
   return new ApiError(503, 'service_unavailable', message, details);
 }
 
-export function unauthorizedError(message: string, details?: Record<string, unknown>): ApiError {
+export function unauthorizedError(message: string, details?: unknown): ApiError {
   return new ApiError(401, 'unauthorized', message, details);
 }
 
@@ -52,11 +81,6 @@ function normalizeExpressError(error: unknown): ApiError {
     return new ApiError(413, 'payload_too_large', 'Request body exceeds the 256 KiB limit');
   }
   if (error instanceof ApiError) return error;
-
-  // Also handle ApiError from middleware/errorHandler (streams route)
-  if (error instanceof MiddlewareApiError) {
-    return new ApiError(error.statusCode, error.code, error.message, undefined, true);
-  }
 
   return new ApiError(500, 'internal_error', 'Internal server error', undefined, false);
 }
@@ -88,11 +112,11 @@ export function errorHandler(
 
   const errorBody: Record<string, unknown> = {
     code: normalized.code,
-    message: normalized.message,
+    message: normalized.expose ? normalized.message : 'Internal server error',
     status: normalized.status,
     requestId,
   };
-  if (normalized.details !== undefined) {
+  if (normalized.expose && normalized.details !== undefined) {
     errorBody['details'] = normalized.details;
   }
 

--- a/src/middleware/errorHandler.ts
+++ b/src/middleware/errorHandler.ts
@@ -2,7 +2,9 @@ import type { Request, Response, NextFunction } from 'express';
 import { DecimalSerializationError } from '../serialization/decimal.js';
 import { SerializationLogger, error as logError } from '../utils/logger.js';
 import { errorResponse } from '../utils/response.js';
-import { QueryTimeoutError } from '../db/pool.js';
+import { ApiError } from '../errors.js';
+
+export { ApiError } from '../errors.js';
 
 export interface ApiErrorResponse {
   success: false;
@@ -26,18 +28,6 @@ export enum ApiErrorCode {
   GATEWAY_TIMEOUT = 'GATEWAY_TIMEOUT',
 }
 
-export class ApiError extends Error {
-  constructor(
-    public readonly code: ApiErrorCode,
-    message: string,
-    public readonly statusCode: number = 500,
-    public readonly details?: unknown,
-  ) {
-    super(message);
-    this.name = 'ApiError';
-  }
-}
-
 /**
  * Express error handler middleware
  */
@@ -49,7 +39,7 @@ export function errorHandler(
 ): void {
   const requestId = req.id ?? (res.locals['requestId'] as string | undefined);
 
-  if (err instanceof QueryTimeoutError) {
+  if (err.name === 'QueryTimeoutError') {
     res.status(504).json(
       errorResponse(ApiErrorCode.GATEWAY_TIMEOUT, 'Query timed out', undefined, requestId)
     );
@@ -70,9 +60,18 @@ export function errorHandler(
   }
 
   if (err instanceof ApiError) {
-    logError(`API error: ${err.message}`, { code: err.code, statusCode: err.statusCode, details: err.details, requestId });
+    const clientCode = err.expose ? err.code : ApiErrorCode.INTERNAL_ERROR;
+    const clientMessage = err.expose ? err.message : 'An unexpected error occurred. Please try again later.';
+    const clientDetails = err.expose ? err.details : undefined;
+    logError(`API error: ${err.message}`, {
+      code: err.code,
+      statusCode: err.statusCode,
+      details: err.details,
+      expose: err.expose,
+      requestId,
+    });
     res.status(err.statusCode).json(
-      errorResponse(err.code, err.message, err.details, requestId)
+      errorResponse(clientCode, clientMessage, clientDetails, requestId)
     );
     return;
   }
@@ -129,41 +128,41 @@ export function asyncHandler(
 }
 
 export function notFound(resource: string, id?: string): ApiError {
-  return new ApiError(ApiErrorCode.NOT_FOUND, id !== undefined ? `${resource} '${id}' not found` : `${resource} not found`, 404);
+  return new ApiError(404, ApiErrorCode.NOT_FOUND, id !== undefined ? `${resource} '${id}' not found` : `${resource} not found`);
 }
 
 export function validationError(message: string, details?: unknown): ApiError {
-  return new ApiError(ApiErrorCode.VALIDATION_ERROR, message, 400, details);
+  return new ApiError(400, ApiErrorCode.VALIDATION_ERROR, message, details);
 }
 
 export function conflictError(message: string, details?: unknown): ApiError {
-  return new ApiError(ApiErrorCode.CONFLICT, message, 409, details);
+  return new ApiError(409, ApiErrorCode.CONFLICT, message, details);
 }
 
 export function serviceUnavailable(message: string): ApiError {
-  return new ApiError(ApiErrorCode.SERVICE_UNAVAILABLE, message, 503);
+  return new ApiError(503, ApiErrorCode.SERVICE_UNAVAILABLE, message);
 }
 
 export function unauthorized(message: string, details?: unknown): ApiError {
-  return new ApiError(ApiErrorCode.UNAUTHORIZED, message, 401, details);
+  return new ApiError(401, ApiErrorCode.UNAUTHORIZED, message, details);
 }
 
 export function forbidden(message: string, details?: unknown): ApiError {
-  return new ApiError(ApiErrorCode.FORBIDDEN, message, 403, details);
+  return new ApiError(403, ApiErrorCode.FORBIDDEN, message, details);
 }
 
 export function payloadTooLarge(message: string, details?: unknown): ApiError {
-  return new ApiError(ApiErrorCode.PAYLOAD_TOO_LARGE, message, 413, details);
+  return new ApiError(413, ApiErrorCode.PAYLOAD_TOO_LARGE, message, details);
 }
 
 export function tooManyRequests(message: string, details?: unknown): ApiError {
-  return new ApiError(ApiErrorCode.TOO_MANY_REQUESTS, message, 429, details);
+  return new ApiError(429, ApiErrorCode.TOO_MANY_REQUESTS, message, details);
 }
 
 export function requestTimeout(message: string): ApiError {
-  return new ApiError(ApiErrorCode.REQUEST_TIMEOUT, message, 408);
+  return new ApiError(408, ApiErrorCode.REQUEST_TIMEOUT, message);
 }
 
 export function gatewayTimeout(message: string): ApiError {
-  return new ApiError(ApiErrorCode.GATEWAY_TIMEOUT, message, 504);
+  return new ApiError(504, ApiErrorCode.GATEWAY_TIMEOUT, message);
 }

--- a/tests/middleware/errorHandler.apiError.test.ts
+++ b/tests/middleware/errorHandler.apiError.test.ts
@@ -1,0 +1,64 @@
+import express from 'express';
+import request from 'supertest';
+import { describe, expect, it, vi } from 'vitest';
+import { ApiError as CanonicalApiError } from '../../src/errors.js';
+import { ApiError, ApiErrorCode, errorHandler } from '../../src/middleware/errorHandler.js';
+
+function buildApp(errorFactory: () => Error): express.Application {
+  const app = express();
+  app.get('/boom', () => {
+    throw errorFactory();
+  });
+  app.use(errorHandler);
+  return app;
+}
+
+describe('errorHandler canonical ApiError handling', () => {
+  it('re-exports the canonical ApiError class from middleware/errorHandler', () => {
+    const err = new ApiError(ApiErrorCode.VALIDATION_ERROR, 'Invalid payload', 400, {
+      field: 'amount',
+    });
+
+    expect(err).toBeInstanceOf(CanonicalApiError);
+    expect(err.statusCode).toBe(400);
+    expect(err.code).toBe(ApiErrorCode.VALIDATION_ERROR);
+    expect(err.details).toEqual({ field: 'amount' });
+  });
+
+  it('exposes message and details for public ApiErrors', async () => {
+    const app = buildApp(() => new ApiError(ApiErrorCode.CONFLICT, 'Duplicate idempotency key', 409, {
+      hint: 'retry original payload',
+    }));
+
+    const res = await request(app).get('/boom');
+
+    expect(res.status).toBe(409);
+    expect(res.body.error).toMatchObject({
+      code: ApiErrorCode.CONFLICT,
+      message: 'Duplicate idempotency key',
+      details: { hint: 'retry original payload' },
+    });
+  });
+
+  it('hides message and details for non-exposed ApiErrors', async () => {
+    const logSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    const app = buildApp(() => new CanonicalApiError(
+      500,
+      ApiErrorCode.INTERNAL_ERROR,
+      'database password leaked in stack',
+      { secret: 'do-not-return' },
+      false,
+    ));
+
+    const res = await request(app).get('/boom');
+
+    expect(res.status).toBe(500);
+    expect(res.body.error).toEqual({
+      code: ApiErrorCode.INTERNAL_ERROR,
+      message: 'An unexpected error occurred. Please try again later.',
+    });
+    expect(JSON.stringify(res.body)).not.toContain('database password');
+    expect(JSON.stringify(res.body)).not.toContain('do-not-return');
+    logSpy.mockRestore();
+  });
+});


### PR DESCRIPTION
Fixes #368

## Summary
- consolidate `ApiError` on the canonical implementation from `src/errors.ts`
- keep `src/middleware/errorHandler.ts` exporting `ApiError` for existing imports while removing its duplicate class definition
- preserve legacy constructor order compatibility for current middleware/route callers
- honor `expose=false` so internal messages/details are not returned to clients
- add focused coverage for the re-export, exposed errors, and hidden errors

## Validation
- `node .\node_modules\vitest\vitest.mjs run tests\middleware\errorHandler.apiError.test.ts tests\requestProtection.test.ts src\middleware\requestProtection.test.ts tests\db\pool.statementTimeout.test.ts tests\routes\streams.pagination.test.ts tests\routes\streams-head.test.ts --reporter=dot` (51 tests passed)
- `node .\node_modules\eslint\bin\eslint.js src\errors.ts src\middleware\errorHandler.ts tests\middleware\errorHandler.apiError.test.ts tests\routes\streams.pagination.test.ts tests\routes\streams-head.test.ts tests\db\pool.statementTimeout.test.ts` (passes; existing module type warning)
- `git diff --check`

## Notes
- Full `tsc --noEmit --pretty false` is currently blocked by existing syntax errors in `src/openapi/spec.ts` starting at line 294, unrelated to this change.