### PR TITLE
feat(tracing): trace sse fanout dispatch

### DIFF
--- a/docs/TRACING.md
+++ b/docs/TRACING.md
@@ -549,6 +549,19 @@ Emitted by `src/ws/hub.ts` for every `broadcast()` call that delivers at least o
 
 This span uses `eventId` as its `traceId` because broadcasts happen outside an HTTP request context.
 
+### Server-Sent Events Fan-Out - `sse.dispatch`
+
+Emitted by `src/streams/sseEmitter.ts` for each live SSE stream update delivered through the shared SSE dispatcher.
+
+| Attribute | Value |
+|-----------|-------|
+| `span.name` | `sse.dispatch` |
+| `sse.stream_id` | Stream being emitted |
+| `sse.event_id` | Unique update event identifier |
+| `sse.subscriber_count` | Number of SSE subscribers targeted by the fan-out |
+
+The span is per update, not per subscriber, so fan-out cardinality stays bounded. SSE `data:` frames also include `correlationId` and `traceId` with the same non-sensitive correlation identifier so browser/EventSource clients can correlate a received update with backend logs and spans.
+
 ---
 
 ## correlationId Propagation Through Async Boundaries

--- a/docs/api/sse-streams.md
+++ b/docs/api/sse-streams.md
@@ -116,6 +116,12 @@ The endpoint exports these Prometheus metrics through the existing registry:
 
 Live updates are indexed by `streamId` in memory. A broadcast for `stream-123` is delivered only to active SSE clients subscribed to `stream-123`; other SSE connections do not run per-event filter checks.
 
+### Trace propagation
+
+Each `stream_update` SSE data payload includes both `correlationId` and `traceId`. They carry the same non-sensitive correlation identifier for the emitted update so clients can link received events back to server logs and tracing spans. The value is either the originating event correlation ID or, for replayed events, the current SSE request correlation ID.
+
+When tracing is enabled, live fan-out is wrapped in one `sse.dispatch` span per emitted stream update. The span records `sse.stream_id`, `sse.event_id`, and `sse.subscriber_count`; it does not create one span per subscriber. Subscriber write failures are isolated so one broken connection cannot stop the rest of the fan-out, and the dispatch span is still closed.
+
 ---
 
 ## Heartbeat and Keep-Alive
@@ -139,11 +145,11 @@ Upon initial connection, the server sends an `: ok` acknowledgement. Then, as st
 
 id: evt-001
 event: stream_update
-data: {"type":"stream_update","streamId":"stream-123","eventId":"evt-001","payload":{"status":"active","streamedAmount":"100"},"correlationId":"44526bf5-b33d-45f2-bd1d-9ce414f13635"}
+data: {"type":"stream_update","streamId":"stream-123","eventId":"evt-001","payload":{"status":"active","streamedAmount":"100"},"correlationId":"44526bf5-b33d-45f2-bd1d-9ce414f13635","traceId":"44526bf5-b33d-45f2-bd1d-9ce414f13635"}
 
 : heartbeat
 
 id: evt-002
 event: stream_update
-data: {"type":"stream_update","streamId":"stream-123","eventId":"evt-002","payload":{"status":"completed","streamedAmount":"1000"},"correlationId":"63ad759f-ba95-4c6b-a5db-86a491fcded9"}
+data: {"type":"stream_update","streamId":"stream-123","eventId":"evt-002","payload":{"status":"completed","streamedAmount":"1000"},"correlationId":"63ad759f-ba95-4c6b-a5db-86a491fcded9","traceId":"63ad759f-ba95-4c6b-a5db-86a491fcded9"}
 ```

--- a/src/openapi/spec.ts
+++ b/src/openapi/spec.ts
@@ -249,23 +249,6 @@ const StreamListPage = registry.register(
   }),
 );
 
-/** 400 body specific to invalid/expired cursor. */
-const InvalidCursorError = z.object({
-  success: z.literal(false),
-  error: z.object({
-    code: z.literal('VALIDATION_ERROR').openapi({ example: 'VALIDATION_ERROR' }),
-    message: z.string().openapi({
-      example: 'cursor must be a valid opaque pagination token',
-    }),
-  }),
-}).openapi({
-  description:
-    'Returned when the `cursor` parameter is present but cannot be decoded ' +
-    '(bad base64url, wrong JSON shape, missing version tag, or empty lastId). ' +
-    'The client must discard the cursor and restart pagination from the first page ' +
-    'by omitting the `cursor` parameter.',
-});
-
 registry.registerPath({
   method: 'get', path: '/api/streams',
   summary: 'List streams (cursor-paginated)',
@@ -291,7 +274,7 @@ registry.registerPath({
       }),
       cursor: z.string().optional().openapi({
         description:
-          'Opaque cursor from the previous page's `next_cursor`. ' +
+          "Opaque cursor from the previous page's `next_cursor`. " +
           'Omit to request the first page. ' +
           'Treated as a black box — do not construct manually.',
         example: 'eyJ2IjoxLCJsYXN0SWQiOiJzdHJlYW0tYWJjMTIzIn0',

--- a/src/routes/streams.ts
+++ b/src/routes/streams.ts
@@ -95,8 +95,6 @@ import {
   tryAcquireSseConnection,
 } from '../streams/sseConnectionLimiter.js';
 import {
-  RedisIdempotencyStore,
-  NoOpIdempotencyStore,
   InMemoryIdempotencyStore,
   type IdempotencyStore,
 } from '../redis/idempotencyStore.js';
@@ -254,32 +252,12 @@ function decodeCursor(cursor: string): StreamsCursor {
 
 // ── Query-param parsers ───────────────────────────────────────────────────────
 
-function parseLimit(limitParam: unknown): number {
-  if (limitParam === undefined) return 50;
-  if (Array.isArray(limitParam) || typeof limitParam !== 'string' || !/^\d+$/.test(limitParam)) {
-    throw validationError('limit must be an integer between 1 and 100');
-  }
-  const n = Number.parseInt(limitParam, 10);
-  if (n < 1 || n > 100) throw validationError('limit must be an integer between 1 and 100');
-  return n;
-}
-
 function parseCursor(cursorParam: unknown): StreamsCursor | undefined {
   if (cursorParam === undefined) return undefined;
   if (Array.isArray(cursorParam) || typeof cursorParam !== 'string' || cursorParam.trim() === '') {
     throw validationError('cursor must be a valid opaque pagination token');
   }
   return decodeCursor(cursorParam);
-}
-
-function parseIncludeTotal(includeTotalParam: unknown): boolean {
-  if (includeTotalParam === undefined) return false;
-  if (Array.isArray(includeTotalParam) || typeof includeTotalParam !== 'string') {
-    throw validationError('include_total must be true or false');
-  }
-  if (includeTotalParam === 'true') return true;
-  if (includeTotalParam === 'false') return false;
-  throw validationError('include_total must be true or false');
 }
 
 // ── Body normaliser ───────────────────────────────────────────────────────────
@@ -1034,6 +1012,7 @@ streamsRouter.get(
                     eventId: event.eventId,
                     payload: event.payload,
                     correlationId: req.correlationId,
+                    traceId: req.correlationId,
                   })}\n\n`,
                 );
                 if (!written) break;
@@ -1073,6 +1052,7 @@ streamsRouter.get(
     // 6. Subscribe to Real-Time Updates.
     const listener = (event: StreamUpdateEvent) => {
       if (event.streamId === id) {
+        const traceId = event.correlationId || req.correlationId;
         writeSse(
           `id: ${event.eventId}\n` +
           `event: ${SSE_STREAM_UPDATE_EVENT}\n` +
@@ -1081,7 +1061,8 @@ streamsRouter.get(
             streamId: event.streamId,
             eventId: event.eventId,
             payload: event.payload,
-            correlationId: req.correlationId || event.correlationId,
+            correlationId: traceId,
+            traceId,
           })}\n\n`,
         );
       }

--- a/src/streams/sseEmitter.ts
+++ b/src/streams/sseEmitter.ts
@@ -1,5 +1,6 @@
 import { EventEmitter } from 'node:events';
 import type { StreamEventRecord } from '../db/types.js';
+import { traceSseDispatch } from '../tracing/hooks.js';
 
 export const SSE_STREAM_UPDATE_EVENT = 'stream_update';
 
@@ -38,13 +39,16 @@ function dispatchLiveSseEvent(event: LiveSseStreamUpdateEvent): void {
 
   // Snapshot before iterating so a subscriber can disconnect during delivery
   // without mutating the Set currently being traversed.
-  for (const subscriber of Array.from(subscribers)) {
-    try {
-      subscriber(event);
-    } catch {
-      // Isolate one failing connection from the rest of the stream fan-out.
+  const targets = Array.from(subscribers);
+  traceSseDispatch(event.streamId, event.eventId, targets.length, event.correlationId, () => {
+    for (const subscriber of targets) {
+      try {
+        subscriber(event);
+      } catch {
+        // Isolate one failing connection from the rest of the stream fan-out.
+      }
     }
-  }
+  });
 }
 
 function isDispatchAttached(): boolean {

--- a/src/tracing/hooks.ts
+++ b/src/tracing/hooks.ts
@@ -466,7 +466,7 @@ export function resetTracer(): void {
 // produced by auto-instrumentation.  All helpers are no-ops when tracing is
 // disabled (traceSpan delegates to the global Tracer which short-circuits).
 
-import { trace, context, SpanStatusCode } from '@opentelemetry/api';
+import { trace } from '@opentelemetry/api';
 
 /**
  * Wrap a database query in an OTel span.
@@ -533,6 +533,62 @@ export async function traceWebhookDispatch<T>(
 }
 
 /**
+ * Wrap one Server-Sent Events fan-out in a bounded tracing span.
+ *
+ * The span is per emitted stream update, not per subscriber, so high fan-out
+ * streams record subscriber cardinality without creating one span per client.
+ *
+ * `correlationId` is safe to expose as the trace identifier for SSE clients:
+ * it is generated/validated by the correlation middleware when it originates
+ * from a request, and it carries no auth tokens or secrets.
+ */
+export function traceSseDispatch<T>(
+  streamId: string,
+  eventId: string,
+  subscriberCount: number,
+  correlationId: string | undefined,
+  fn: (span: Span) => T,
+): T {
+  const traceId = correlationId && correlationId.length > 0
+    ? correlationId
+    : getCorrelationIdFromContext();
+  const tracer = getTracer();
+  const boundedSubscriberCount = Math.max(0, subscriberCount);
+  const span = tracer.startSpan({
+    traceId,
+    serviceName: 'fluxora-sse',
+    tags: {
+      'span.name': 'sse.dispatch',
+      'sse.stream_id': streamId,
+      'sse.event_id': eventId,
+      'sse.subscriber_count': boundedSubscriberCount,
+    },
+  });
+
+  try {
+    const result = fn(span);
+    tracer.recordEvent(span, 'sse.dispatch', {
+      streamId,
+      eventId,
+      subscriberCount: boundedSubscriberCount,
+      correlationId: traceId,
+    });
+    tracer.endSpan(span, 'ok');
+    return result;
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    tracer.recordEvent(span, 'sse.dispatch.error', {
+      streamId,
+      eventId,
+      subscriberCount: boundedSubscriberCount,
+      error: message,
+    });
+    tracer.endSpan(span, 'error', message);
+    throw err;
+  }
+}
+
+/**
  * Record a WebSocket broadcast event on the active OTel span (if any).
  * Does not create a new span — attaches an event to the current context.
  */
@@ -583,7 +639,9 @@ export function enrichSpanWithStream(
   if (recipient) span.context.tags['fluxora.recipient'] = recipient;
 
   // 2. Enrich the internal OTel span if it exists in tags
-  const otelSpan = span.context.tags['_otelSpan'] as any;
+  const otelSpan = span.context.tags['_otelSpan'] as
+    | { setAttribute: (key: string, value: string) => void }
+    | undefined;
   if (otelSpan && typeof otelSpan.setAttribute === 'function') {
     try {
       if (streamId) otelSpan.setAttribute('fluxora.stream_id', streamId);

--- a/src/webhooks/retry.ts
+++ b/src/webhooks/retry.ts
@@ -134,62 +134,6 @@ export function isRetryableStatusCode(
   return policy.retryableStatusCodes.includes(statusCode);
 }
 
-/** Return the absolute timestamp for the next retry attempt. */
-export function calculateNextRetryTime(
-  attemptNumber: number,
-  policy: EnhancedRetryPolicy,
-  now: number = Date.now(),
-): number {
-  const delayMs = applyJitter(calculateBackoffDelay(attemptNumber, policy), policy);
-  return now + delayMs;
-}
-
-/** Generate retry metadata for every configured attempt. */
-export function generateRetrySchedule(
-  policy: EnhancedRetryPolicy,
-  now: number = Date.now(),
-): RetrySchedule[] {
-  return Array.from({ length: policy.maxAttempts }, (_, index) => {
-    const attemptNumber = index + 1;
-    const delayMs = applyJitter(calculateBackoffDelay(attemptNumber, policy), policy);
-
-    return {
-      attemptNumber,
-      delayMs,
-      retryAt: now + delayMs,
-    };
-  });
-}
-
-/** Attach retry metadata to an outbox payload and return the next retry time. */
-export function scheduleWebhookOutboxRetry(input: WebhookOutboxRetryInput): WebhookOutboxRetryPlan {
-  const policy = input.policy ?? DEFAULT_RETRY_POLICY;
-  const nextAttemptNumber = input.attemptNumber + 1;
-
-  if (nextAttemptNumber > policy.maxAttempts) {
-    return {
-      shouldRetry: false,
-      attemptNumber: input.attemptNumber,
-      retryAt: null,
-      payload: input.payload,
-    };
-  }
-
-  const payload =
-    typeof input.payload === 'object' && input.payload !== null && !Array.isArray(input.payload)
-      ? { ...(input.payload as Record<string, unknown>), _webhookRetry: { attemptNumber: nextAttemptNumber } }
-      : { _webhookRetry: { attemptNumber: nextAttemptNumber } };
-
-  return {
-    shouldRetry: true,
-    attemptNumber: nextAttemptNumber,
-    retryAt: new Date(calculateNextRetryTime(input.attemptNumber, policy, input.now)),
-    payload,
-  };
-  const retryable = policy.retryableStatusCodes ?? DEFAULT_RETRY_POLICY.retryableStatusCodes;
-  return retryable.includes(statusCode);
-}
-
 /**
  * Calculate the absolute timestamp (ms since epoch) at which the next retry
  * should be attempted, or 0 if the attempt number has reached maxAttempts.

--- a/tests/routes/streams-sse.test.ts
+++ b/tests/routes/streams-sse.test.ts
@@ -11,6 +11,7 @@ import {
   getLiveSseSubscriberCount,
   SSE_STREAM_UPDATE_EVENT,
   sseEventBus,
+  subscribeToSseStream,
 } from '../../src/streams/sseEmitter.js';
 import { getStreamHub } from '../../src/ws/hub.js';
 import { generateToken } from '../../src/lib/auth.js';
@@ -20,6 +21,8 @@ import {
 } from '../../src/streams/sseConnectionLimiter.js';
 import { sseActiveConnectionsGauge, sseConnectionsRejectedTotal } from '../../src/metrics/businessMetrics.js';
 import { StaleCursorError } from '../../src/indexer/store.js';
+import { SpanBuffer } from '../../src/tracing/builtin.js';
+import { initializeTracer, resetTracer } from '../../src/tracing/hooks.js';
 
 // ── Mock the repository and Redis before importing the app ──────────────────────────────
 const mockGetById = vi.fn();
@@ -213,6 +216,8 @@ describe('GET /api/streams/:id/events (SSE Endpoint)', () => {
     process.env.SSE_MAX_CONNECTION_DURATION_MS = String(30 * 60 * 1000);
     process.env.SSE_RETRY_AFTER_SECONDS = '15';
     _resetSseConnectionLimiter();
+    resetTracer();
+    initializeTracer({ enabled: false });
     mockGetById.mockResolvedValue(undefined);
     mockGetEvents.mockResolvedValue({ events: [], total: 0 });
     
@@ -229,6 +234,7 @@ describe('GET /api/streams/:id/events (SSE Endpoint)', () => {
 
   afterEach(async () => {
     vi.restoreAllMocks();
+    resetTracer();
     _resetSseConnectionLimiter();
     _resetSseSubscriptionsForTest();
     await new Promise<void>((resolve) => server.close(() => resolve()));
@@ -444,17 +450,23 @@ describe('GET /api/streams/:id/events (SSE Endpoint)', () => {
 
   it('streams live events via sseEventBus', async () => {
     mockGetById.mockResolvedValue(makeDbRecord({ id: 'stream-123' }));
+    const spanBuffer = new SpanBuffer({ logEvents: false });
+    resetTracer();
+    initializeTracer({ enabled: true, hooks: spanBuffer });
 
     const resPromise = new Promise<string>((resolve) => {
       const req = http.get(`http://127.0.0.1:${port}/api/streams/stream-123/events`, (res) => {
         let data = '';
+        let liveEventEmitted = false;
         res.on('data', (chunk) => {
           data += chunk.toString();
-          if (data.includes(': ok\n\n')) {
+          if (!liveEventEmitted && data.includes(': ok\n\n')) {
+            liveEventEmitted = true;
             sseEventBus.emit(SSE_STREAM_UPDATE_EVENT, {
               streamId: 'stream-123',
               eventId: 'evt-live-001',
               payload: { status: 'cancelled' },
+              correlationId: 'corr-live-001',
             });
           }
           if (data.includes('evt-live-001') && data.includes('cancelled')) {
@@ -470,6 +482,54 @@ describe('GET /api/streams/:id/events (SSE Endpoint)', () => {
     expect(output).toContain('id: evt-live-001');
     expect(output).toContain('event: stream_update');
     expect(output).toContain('cancelled');
+    expect(output).toContain('"correlationId":"corr-live-001"');
+    expect(output).toContain('"traceId":"corr-live-001"');
+
+    const sseSpans = spanBuffer.getSpans().filter(
+      (span) => span.context.tags?.['span.name'] === 'sse.dispatch',
+    );
+    expect(sseSpans).toHaveLength(1);
+    expect(sseSpans[0].context.traceId).toBe('corr-live-001');
+    expect(sseSpans[0].context.tags).toMatchObject({
+      'span.name': 'sse.dispatch',
+      'sse.stream_id': 'stream-123',
+      'sse.event_id': 'evt-live-001',
+      'sse.subscriber_count': 1,
+    });
+    expect(sseSpans[0].status).toBe('ok');
+  });
+
+  it('closes the SSE fan-out span when one subscriber throws', () => {
+    const spanBuffer = new SpanBuffer({ logEvents: false });
+    resetTracer();
+    initializeTracer({ enabled: true, hooks: spanBuffer });
+
+    const unsubscribeThrowing = subscribeToSseStream('stream-123', () => {
+      throw new Error('socket closed');
+    });
+    const delivered = vi.fn();
+    const unsubscribeHealthy = subscribeToSseStream('stream-123', delivered);
+
+    sseEventBus.emit(SSE_STREAM_UPDATE_EVENT, {
+      streamId: 'stream-123',
+      eventId: 'evt-live-throw',
+      payload: { status: 'active' },
+      correlationId: 'corr-live-throw',
+    });
+
+    expect(delivered).toHaveBeenCalledWith(expect.objectContaining({
+      eventId: 'evt-live-throw',
+      correlationId: 'corr-live-throw',
+    }));
+
+    const spans = spanBuffer.getSpans();
+    expect(spans).toHaveLength(1);
+    expect(spans[0].context.traceId).toBe('corr-live-throw');
+    expect(spans[0].context.tags?.['sse.subscriber_count']).toBe(2);
+    expect(spans[0].status).toBe('ok');
+
+    unsubscribeThrowing();
+    unsubscribeHealthy();
   });
 
   it('removes listener when client disconnects', async () => {

--- a/tests/tracing/hooks.test.ts
+++ b/tests/tracing/hooks.test.ts
@@ -19,6 +19,7 @@ import {
   initializeTracer,
   getTracer,
   resetTracer,
+  traceSseDispatch,
 } from '../../src/tracing/hooks.js';
 import {
   SpanBuffer,
@@ -428,6 +429,56 @@ describe('Distributed Tracing Hooks', () => {
       const retrieved = tracer.getSpan(span.context.spanId);
 
       expect(retrieved).toBe(span);
+    });
+  });
+
+  describe('traceSseDispatch helper', () => {
+    it('records one span per fan-out with bounded subscriber count', () => {
+      const buffer = new SpanBuffer({ logEvents: false });
+      initializeTracer({ enabled: true, hooks: buffer });
+
+      const result = traceSseDispatch(
+        'stream-123',
+        'evt-123',
+        3,
+        'corr-sse-123',
+        () => 'delivered',
+      );
+
+      expect(result).toBe('delivered');
+      const spans = buffer.getSpans();
+      expect(spans).toHaveLength(1);
+      expect(spans[0].context.traceId).toBe('corr-sse-123');
+      expect(spans[0].context.serviceName).toBe('fluxora-sse');
+      expect(spans[0].context.tags).toMatchObject({
+        'span.name': 'sse.dispatch',
+        'sse.stream_id': 'stream-123',
+        'sse.event_id': 'evt-123',
+        'sse.subscriber_count': 3,
+      });
+      expect(spans[0].events[0].name).toBe('sse.dispatch');
+      expect(spans[0].status).toBe('ok');
+    });
+
+    it('closes the span as error when fan-out throws', () => {
+      const buffer = new SpanBuffer({ logEvents: false });
+      initializeTracer({ enabled: true, hooks: buffer });
+
+      expect(() => traceSseDispatch(
+        'stream-123',
+        'evt-err',
+        1,
+        'corr-sse-err',
+        () => {
+          throw new Error('subscriber write failed');
+        },
+      )).toThrow('subscriber write failed');
+
+      const spans = buffer.getSpans();
+      expect(spans).toHaveLength(1);
+      expect(spans[0].status).toBe('error');
+      expect(spans[0].statusMessage).toBe('subscriber write failed');
+      expect(spans[0].events[0].name).toBe('sse.dispatch.error');
     });
   });
 

--- a/tests/tracing/otel.test.ts
+++ b/tests/tracing/otel.test.ts
@@ -30,6 +30,7 @@ import {
   traceRedisCommand,
   traceStellarRpc,
   traceWebhookDispatch,
+  traceSseDispatch,
   recordWsBroadcast,
 } from '../../src/tracing/hooks.js';
 import { SpanBuffer } from '../../src/tracing/builtin.js';
@@ -293,6 +294,41 @@ describe('traceWebhookDispatch', () => {
   });
 });
 
+describe('traceSseDispatch', () => {
+  let buffer: SpanBuffer;
+
+  beforeEach(() => {
+    buffer = new SpanBuffer({ logEvents: false });
+    resetTracer();
+    initializeTracer({ enabled: true, hooks: buffer });
+  });
+  afterEach(() => resetTracer());
+
+  it('returns the result of fn', () => {
+    const result = traceSseDispatch('stream-1', 'evt-1', 2, 'corr-1', () => 'sent');
+    expect(result).toBe('sent');
+  });
+
+  it('records a span with sse.* attributes', () => {
+    traceSseDispatch('stream-1', 'evt-1', 2, 'corr-1', () => {});
+
+    const spans = buffer.getSpans();
+    expect(spans[0].context.traceId).toBe('corr-1');
+    expect(spans[0].context.tags?.['sse.stream_id']).toBe('stream-1');
+    expect(spans[0].context.tags?.['sse.event_id']).toBe('evt-1');
+    expect(spans[0].context.tags?.['sse.subscriber_count']).toBe(2);
+    expect(spans[0].status).toBe('ok');
+  });
+
+  it('marks span as error when fan-out throws', () => {
+    expect(() => traceSseDispatch('stream-1', 'evt-1', 2, 'corr-1', () => {
+      throw new Error('write failed');
+    })).toThrow('write failed');
+
+    expect(buffer.getSpans()[0].status).toBe('error');
+  });
+});
+
 describe('recordWsBroadcast', () => {
   it('is a no-op when there is no active OTel span', () => {
     expect(() => recordWsBroadcast('stream-1', 'evt-1', 5)).not.toThrow();
@@ -318,6 +354,11 @@ describe('helpers with tracing disabled', () => {
 
   it('traceWebhookDispatch still returns fn result when tracing is disabled', async () => {
     const result = await traceWebhookDispatch('stream.created', 'https://x.com', 0, async () => true);
+    expect(result).toBe(true);
+  });
+
+  it('traceSseDispatch still returns fn result when tracing is disabled', () => {
+    const result = traceSseDispatch('stream-1', 'evt-1', 0, undefined, () => true);
     expect(result).toBe(true);
   });
 });


### PR DESCRIPTION
Fixes #362

## Summary
- add `traceSseDispatch()` to wrap live SSE fan-out in one bounded span per emitted update
- record `sse.stream_id`, `sse.event_id`, and `sse.subscriber_count` without creating per-subscriber spans
- include non-sensitive `correlationId` and `traceId` in SSE `stream_update` payloads for client-side correlation
- document the SSE trace propagation contract and security assumptions
- remove existing collection blockers in `src/webhooks/retry.ts` and `src/openapi/spec.ts` so focused SSE/tracing tests can run

## Validation
- `corepack pnpm@8.15.9 install --frozen-lockfile --ignore-scripts`
- `node .\node_modules\vitest\vitest.mjs run tests\routes\streams-sse.test.ts tests\tracing\hooks.test.ts tests\tracing\otel.test.ts --reporter=dot` (84 tests passed)
- `node .\node_modules\eslint\bin\eslint.js src\tracing\hooks.ts src\streams\sseEmitter.ts src\routes\streams.ts src\webhooks\retry.ts src\openapi\spec.ts tests\routes\streams-sse.test.ts tests\tracing\hooks.test.ts tests\tracing\otel.test.ts` (passes with existing warnings in test files and module-type warning)
- `git diff --check`

## Notes
- Full `tsc --noEmit --pretty false` remains blocked by existing repository-wide baseline type errors unrelated to this change (for example `src/config/health.ts`, `src/db/repositories/streamRepository.ts`, `src/webhooks/dispatcher.ts`, and multiple test typing baselines).
- Ordinary `git push` hit an HTTPS connection reset, so the fork branch was created through the GitHub Git Data API using Git Credential Manager authorization.