### PR TITLE
Add scoped API key authorization

### DIFF
--- a/docs/auth.md
+++ b/docs/auth.md
@@ -20,8 +20,18 @@ Roles and default permissions
 
 Middleware
 - `authenticate`: verifies JWT and validates payload with Zod (must include `permissions` array).
+- `authenticate`: also accepts `x-api-key` when no Bearer JWT is present, attaching a service principal with the key's stored scopes.
 - `requireAuth`: ensures an authenticated user exists.
 - `requirePermission(permission)`: middleware factory that ensures the caller holds the requested permission.
+- `requireScope(scope)`: same scope gate for JWT and API key principals. Missing, empty, malformed, or unknown scope sets fail closed.
+
+API key scopes
+- `ApiKeyRecord.scopes` is the authorization source for service API keys.
+- API key creation accepts an optional `scopes` array, for example `["streams:read"]`.
+- Omitting `scopes` uses the documented legacy default: all current permissions. This keeps existing keys working while new keys can be issued with least privilege.
+- Unknown or empty scopes are rejected at creation time. If a stored key ever has an empty or invalid scope set, `requireScope` denies access with `403`.
+- Public stream read routes remain anonymously readable. When a client supplies `x-api-key` on those routes, the key must include `streams:read`.
+- Stream write routes require `streams:write`; admin routes require their matching `admin:*` scope.
 
 Notes
 - Tokens without a `permissions` claim are rejected by `authenticate`.

--- a/src/db/types.ts
+++ b/src/db/types.ts
@@ -181,6 +181,8 @@ export interface ApiKeyRecord {
   rotatedAt: string | null;
   /** Whether the key is still active */
   active: boolean;
+  /** Permission scopes granted to this key, e.g. `streams:read`. */
+  scopes: string[];
 }
 
 /**
@@ -194,6 +196,8 @@ export interface ApiKeyCreated {
   key: string;
   prefix: string;
   createdAt: string;
+  /** Permission scopes granted to this key. */
+  scopes: string[];
 }
 
 // ─── Stream Event Store ───────────────────────────────────────────────────────

--- a/src/lib/apiKey.ts
+++ b/src/lib/apiKey.ts
@@ -1,6 +1,7 @@
 import { createId } from '@paralleldrive/cuid2';
 import { createHash, timingSafeEqual } from 'crypto';
 import type { ApiKeyRecord, ApiKeyCreated } from '../db/types.js';
+import { DEFAULT_API_KEY_SCOPES, isKnownPermission } from './permissions.js';
 
 // ---------------------------------------------------------------------------
 // In-memory store (replace with DB-backed store when persistence is needed)
@@ -21,6 +22,43 @@ function generateRawKey(): string {
   return `flx_${randomBytes(32).toString('hex')}`;
 }
 
+function sanitizeStoredScopes(scopes: unknown): string[] {
+  if (scopes === undefined) return [...DEFAULT_API_KEY_SCOPES];
+  if (!Array.isArray(scopes)) return [];
+
+  const normalized = scopes
+    .filter((scope): scope is string => typeof scope === 'string')
+    .map((scope) => scope.trim())
+    .filter((scope) => scope.length > 0);
+
+  if (normalized.length === 0) return [];
+  if (normalized.some((scope) => !isKnownPermission(scope))) return [];
+
+  return Array.from(new Set(normalized));
+}
+
+export function normalizeApiKeyScopes(scopes?: readonly string[]): string[] {
+  if (scopes === undefined) return [...DEFAULT_API_KEY_SCOPES];
+  if (!Array.isArray(scopes)) {
+    throw new Error('scopes must be an array of permission strings');
+  }
+
+  const normalized = Array.from(
+    new Set(scopes.map((scope) => (typeof scope === 'string' ? scope.trim() : ''))),
+  ).filter((scope) => scope.length > 0);
+
+  if (normalized.length === 0) {
+    throw new Error('scopes must include at least one permission');
+  }
+
+  const unknown = normalized.filter((scope) => !isKnownPermission(scope));
+  if (unknown.length > 0) {
+    throw new Error(`unknown API key scope: ${unknown.join(', ')}`);
+  }
+
+  return normalized;
+}
+
 // ---------------------------------------------------------------------------
 // Public API
 // ---------------------------------------------------------------------------
@@ -28,7 +66,7 @@ function generateRawKey(): string {
 /**
  * Creates a new API key. Returns the record plus the raw key (shown once).
  */
-export function createApiKey(name: string): ApiKeyCreated {
+export function createApiKey(name: string, scopes?: readonly string[]): ApiKeyCreated {
   if (!name || typeof name !== 'string' || !name.trim()) {
     throw new Error('name is required');
   }
@@ -36,6 +74,7 @@ export function createApiKey(name: string): ApiKeyCreated {
   const raw = generateRawKey();
   const id = createId();
   const now = new Date().toISOString();
+  const normalizedScopes = normalizeApiKeyScopes(scopes);
 
   const record: ApiKeyRecord = {
     id,
@@ -45,11 +84,19 @@ export function createApiKey(name: string): ApiKeyCreated {
     createdAt: now,
     rotatedAt: null,
     active: true,
+    scopes: normalizedScopes,
   };
 
   store.set(id, record);
 
-  return { id, name: record.name, key: raw, prefix: record.prefix, createdAt: now };
+  return {
+    id,
+    name: record.name,
+    key: raw,
+    prefix: record.prefix,
+    createdAt: now,
+    scopes: [...record.scopes],
+  };
 }
 
 /**
@@ -73,7 +120,14 @@ export function rotateApiKey(id: string): ApiKeyCreated {
 
   store.set(id, updated);
 
-  return { id, name: record.name, key: raw, prefix: updated.prefix, createdAt: record.createdAt };
+  return {
+    id,
+    name: record.name,
+    key: raw,
+    prefix: updated.prefix,
+    createdAt: record.createdAt,
+    scopes: [...sanitizeStoredScopes(updated.scopes)],
+  };
 }
 
 /**
@@ -90,14 +144,17 @@ export function revokeApiKey(id: string): void {
  * Returns all stored key records (hashes only — raw keys are never stored).
  */
 export function listApiKeys(): ApiKeyRecord[] {
-  return Array.from(store.values());
+  return Array.from(store.values()).map((record) => ({
+    ...record,
+    scopes: sanitizeStoredScopes(record.scopes),
+  }));
 }
 
 /**
- * Validates a raw API key against the stored hashes using constant-time comparison.
+ * Looks up a raw API key against the stored hashes using constant-time comparison.
  */
-export function isValidApiKey(rawKey: string): boolean {
-  if (!rawKey) return false;
+export function findApiKeyRecord(rawKey: string): ApiKeyRecord | undefined {
+  if (!rawKey) return undefined;
 
   const hash = sha256hex(rawKey);
   const hashBuf = Buffer.from(hash, 'hex');
@@ -107,14 +164,24 @@ export function isValidApiKey(rawKey: string): boolean {
     try {
       const storedBuf = Buffer.from(record.keyHash, 'hex');
       if (storedBuf.length === hashBuf.length && timingSafeEqual(storedBuf, hashBuf)) {
-        return true;
+        return {
+          ...record,
+          scopes: sanitizeStoredScopes(record.scopes),
+        };
       }
     } catch {
       // length mismatch — skip
     }
   }
 
-  return false;
+  return undefined;
+}
+
+/**
+ * Validates a raw API key against the stored hashes using constant-time comparison.
+ */
+export function isValidApiKey(rawKey: string): boolean {
+  return findApiKeyRecord(rawKey) !== undefined;
 }
 
 /**

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,6 +1,7 @@
 import jwt, { type SignOptions } from 'jsonwebtoken';
 import { getConfig } from '../config/env.js';
 import { warn } from '../utils/logger.js';
+import { ROLE_PERMISSIONS } from './permissions.js';
 
 export interface UserPayload {
   address: string;
@@ -29,20 +30,7 @@ export function generateToken(payload: UserPayload): string {
   // explicit permissions in production tokens.
   const derived = { ...payload } as UserPayload;
   if (!Array.isArray(derived.permissions)) {
-    if (derived.role === 'operator') {
-      derived.permissions = [
-        'streams:read',
-        'streams:write',
-        'dlq:list',
-        'dlq:read',
-        'dlq:replay',
-        'dlq:delete',
-        'audit:read',
-      ];
-    } else {
-      // viewer or unknown role -> minimal read-only permissions
-      derived.permissions = ['streams:read'];
-    }
+    derived.permissions = [...(ROLE_PERMISSIONS[derived.role] ?? ROLE_PERMISSIONS.viewer)];
   }
 
   return jwt.sign(derived, jwtSecret, options);

--- a/src/lib/permissions.ts
+++ b/src/lib/permissions.ts
@@ -1,0 +1,39 @@
+export enum Permission {
+  STREAMS_READ = 'streams:read',
+  STREAMS_WRITE = 'streams:write',
+  ADMIN_READ = 'admin:read',
+  ADMIN_PAUSE = 'admin:pause',
+  ADMIN_REINDEX = 'admin:reindex',
+  ADMIN_API_KEYS = 'admin:api-keys',
+  INDEXER_REPLAY = 'indexer:replay',
+  DLQ_LIST = 'dlq:list',
+  DLQ_READ = 'dlq:read',
+  DLQ_REPLAY = 'dlq:replay',
+  DLQ_DELETE = 'dlq:delete',
+  AUDIT_READ = 'audit:read',
+  AUDIT_WRITE = 'audit:write',
+}
+
+export const ROLE_PERMISSIONS: Record<string, Permission[]> = {
+  operator: [
+    Permission.STREAMS_READ,
+    Permission.STREAMS_WRITE,
+    Permission.DLQ_LIST,
+    Permission.DLQ_READ,
+    Permission.DLQ_REPLAY,
+    Permission.DLQ_DELETE,
+    Permission.AUDIT_READ,
+  ],
+  viewer: [Permission.STREAMS_READ],
+  admin: Object.values(Permission) as Permission[],
+};
+
+export const DEFAULT_API_KEY_SCOPES = Object.freeze(
+  [...ROLE_PERMISSIONS.admin],
+) as readonly Permission[];
+
+const PERMISSION_VALUES = new Set<string>(Object.values(Permission));
+
+export function isKnownPermission(scope: string): scope is Permission {
+  return PERMISSION_VALUES.has(scope);
+}

--- a/src/middleware/adminAuth.ts
+++ b/src/middleware/adminAuth.ts
@@ -1,4 +1,6 @@
 import type { Request, Response, NextFunction } from 'express';
+import { findApiKeyRecord, getApiKeyFromRequest } from '../lib/apiKey.js';
+import { DEFAULT_API_KEY_SCOPES } from '../lib/permissions.js';
 
 /**
  * Middleware that gates admin routes behind a Bearer token.
@@ -9,6 +11,28 @@ import type { Request, Response, NextFunction } from 'express';
  */
 export function requireAdminAuth(req: Request, res: Response, next: NextFunction): void {
   const adminKey = process.env.ADMIN_API_KEY;
+  const rawApiKey = getApiKeyFromRequest(req.headers);
+
+  if (rawApiKey) {
+    const record = findApiKeyRecord(rawApiKey);
+    if (!record) {
+      res.status(401).json({ error: 'Invalid API key.' });
+      return;
+    }
+    req.user = {
+      address: `api-key:${record.id}`,
+      role: 'service',
+      permissions: record.scopes,
+    };
+    req.apiKey = {
+      id: record.id,
+      name: record.name,
+      prefix: record.prefix,
+      scopes: record.scopes,
+    };
+    next();
+    return;
+  }
 
   if (!adminKey) {
     res.status(503).json({
@@ -41,6 +65,11 @@ export function requireAdminAuth(req: Request, res: Response, next: NextFunction
     return;
   }
 
+  req.user = {
+    address: 'admin-api-key',
+    role: 'admin',
+    permissions: [...DEFAULT_API_KEY_SCOPES],
+  };
   next();
 }
 

--- a/src/middleware/auth.ts
+++ b/src/middleware/auth.ts
@@ -4,34 +4,12 @@ import { ApiErrorCode } from './errorHandler.js';
 import { warn, info, debug } from '../utils/logger.js';
 import { z } from 'zod';
 import { isRevoked } from '../redis/jwtRevocationStore.js';
+import { findApiKeyRecord, getApiKeyFromRequest } from '../lib/apiKey.js';
+import { errorResponse } from '../utils/response.js';
+import { Permission, ROLE_PERMISSIONS } from '../lib/permissions.js';
+import type { UserPayload } from '../lib/auth.js';
 
-export enum Permission {
-  STREAMS_READ = 'streams:read',
-  STREAMS_WRITE = 'streams:write',
-  ADMIN_PAUSE = 'admin:pause',
-  ADMIN_REINDEX = 'admin:reindex',
-  INDEXER_REPLAY = 'indexer:replay',
-  DLQ_LIST = 'dlq:list',
-  DLQ_READ = 'dlq:read',
-  DLQ_REPLAY = 'dlq:replay',
-  DLQ_DELETE = 'dlq:delete',
-  AUDIT_READ = 'audit:read',
-  AUDIT_WRITE = 'audit:write',
-}
-
-export const ROLE_PERMISSIONS: Record<string, Permission[]> = {
-  operator: [
-    Permission.STREAMS_READ,
-    Permission.STREAMS_WRITE,
-    Permission.DLQ_LIST,
-    Permission.DLQ_READ,
-    Permission.DLQ_REPLAY,
-    Permission.DLQ_DELETE,
-    Permission.AUDIT_READ,
-  ],
-  viewer: [Permission.STREAMS_READ],
-  admin: Object.values(Permission) as Permission[],
-};
+export { Permission, ROLE_PERMISSIONS };
 
 const tokenSchema = z.object({
   address: z.string(),
@@ -55,10 +33,16 @@ const tokenSchema = z.object({
 export async function authenticate(req: Request, res: Response, next: NextFunction): Promise<void> {
   const authHeader = req.headers.authorization;
   const requestId = req.id ?? req.correlationId;
+  const rawApiKey = getApiKeyFromRequest(req.headers);
 
-  debug('Authentication middleware triggered', { hasAuthHeader: !!authHeader, requestId });
+  debug('Authentication middleware triggered', {
+    hasAuthHeader: !!authHeader,
+    hasApiKey: !!rawApiKey,
+    requestId,
+  });
 
   if (!authHeader) {
+    if (authenticateApiKey(req, res, next, rawApiKey)) return;
     // No credentials — proceed as anonymous
     return next();
   }
@@ -66,15 +50,16 @@ export async function authenticate(req: Request, res: Response, next: NextFuncti
   const [type, token] = authHeader.split(' ');
   if (type !== 'Bearer' || !token) {
     warn('Invalid Authorization header format', { requestId });
+    if (authenticateApiKey(req, res, next, rawApiKey)) return;
     return next();
   }
 
   try {
     // 1. Verify signature and expiry (cryptographic check)
-    const payload = verifyToken(token) as unknown;
+    const payload = verifyToken(token);
 
     // 2. Check revocation list (immediate invalidation check)
-    const jti = (payload as any)?.jti;
+    const jti = (payload as { jti?: string }).jti;
     if (jti) {
       const revoked = await isRevoked(jti);
       if (revoked) {
@@ -91,8 +76,8 @@ export async function authenticate(req: Request, res: Response, next: NextFuncti
     }
 
     // 3. Validate token shape and permissions claim
-    const parsed = tokenSchema.parse(payload);
-    req.user = parsed as any;
+    const parsed = tokenSchema.parse(payload) as UserPayload;
+    req.user = parsed;
     info('User authenticated via JWT', { address: parsed.address, requestId });
     return next();
   } catch (error) {
@@ -105,6 +90,51 @@ export async function authenticate(req: Request, res: Response, next: NextFuncti
       },
     });
   }
+}
+
+function authenticateApiKey(
+  req: Request,
+  res: Response,
+  next: NextFunction,
+  rawApiKey: string | undefined,
+): boolean {
+  const requestId = req.id ?? req.correlationId;
+  if (!rawApiKey) return false;
+
+  const record = findApiKeyRecord(rawApiKey);
+  if (!record) {
+    warn('API key authentication failed', { requestId });
+    res.status(401).json(
+      errorResponse(
+        ApiErrorCode.UNAUTHORIZED,
+        'Invalid API key',
+        undefined,
+        requestId,
+      ),
+    );
+    return true;
+  }
+
+  req.user = {
+    address: `api-key:${record.id}`,
+    role: 'service',
+    permissions: record.scopes,
+  };
+  req.apiKey = {
+    id: record.id,
+    name: record.name,
+    prefix: record.prefix,
+    scopes: record.scopes,
+  };
+
+  info('Service authenticated via API key', {
+    apiKeyId: record.id,
+    prefix: record.prefix,
+    scopes: record.scopes,
+    requestId,
+  });
+  next();
+  return true;
 }
 
 /**
@@ -131,7 +161,16 @@ export function requireAuth(req: Request, res: Response, next: NextFunction): vo
  * Require that the authenticated token includes a specific permission.
  * Must be used after `authenticate` and typically after `requireAuth`.
  */
-export function requirePermission(permission: Permission) {
+export function requirePermission(permission: Permission): ReturnType<typeof requireScope> {
+  return requireScope(permission);
+}
+
+/**
+ * Require that the authenticated principal includes a specific scope.
+ * Missing, empty, or malformed scope sets fail closed with 403.
+ * Must be used after `authenticate` and typically after `requireAuth`.
+ */
+export function requireScope(scope: Permission | string): (req: Request, res: Response, next: NextFunction) => void {
   return (req: Request, res: Response, next: NextFunction): void => {
     const requestId = req.id ?? req.correlationId;
 
@@ -147,19 +186,37 @@ export function requirePermission(permission: Permission) {
       return;
     }
 
-    const permissions: string[] = (req.user as any).permissions ?? [];
-    if (!Array.isArray(permissions) || !permissions.includes(permission)) {
-      warn('Insufficient permissions', { required: permission, have: permissions, path: req.path, requestId });
-      res.status(403).json({
-        error: {
-          code: ApiErrorCode.FORBIDDEN,
-          message: 'Insufficient permissions to access this resource',
+    const permissions = req.user.permissions ?? [];
+    if (!Array.isArray(permissions) || permissions.length === 0 || !permissions.includes(scope)) {
+      warn('Insufficient permissions', { required: scope, have: permissions, path: req.path, requestId });
+      res.status(403).json(
+        errorResponse(
+          ApiErrorCode.FORBIDDEN,
+          'Insufficient permissions to access this resource',
+          { requiredScope: scope },
           requestId,
-        },
-      });
+        ),
+      );
       return;
     }
 
     next();
+  };
+}
+
+/**
+ * Enforce a scope only when credentials were supplied. Public routes can use
+ * this to keep anonymous access while rejecting under-scoped credentials.
+ */
+export function requireScopeIfAuthenticated(
+  scope: Permission | string,
+): (req: Request, res: Response, next: NextFunction) => void {
+  const requireScopedPrincipal = requireScope(scope);
+  return (req: Request, res: Response, next: NextFunction): void => {
+    if (!req.user) {
+      next();
+      return;
+    }
+    requireScopedPrincipal(req, res, next);
   };
 }

--- a/src/middleware/cors.ts
+++ b/src/middleware/cors.ts
@@ -14,7 +14,7 @@ type CorsResponse = {
 type CorsNext = (err?: unknown) => void;
 
 const DEFAULT_ALLOWED_METHODS = 'GET,POST,PUT,PATCH,DELETE,OPTIONS';
-const DEFAULT_ALLOWED_HEADERS = 'Content-Type,Authorization,X-Correlation-ID';
+const DEFAULT_ALLOWED_HEADERS = 'Content-Type,Authorization,X-API-Key,X-Correlation-ID';
 const PREFLIGHT_MAX_AGE = '86400'; // 24 hours in seconds
 
 function parseAllowedOrigins(raw: string | undefined): Set<string> {

--- a/src/openapi/spec.ts
+++ b/src/openapi/spec.ts
@@ -76,6 +76,13 @@ registry.registerComponent('securitySchemes', 'bearerAuth', {
   description: 'JWT issued by POST /api/auth/session',
 });
 
+registry.registerComponent('securitySchemes', 'apiKeyAuth', {
+  type: 'apiKey',
+  in: 'header',
+  name: 'x-api-key',
+  description: 'Scoped service API key. Stream writes require streams:write; stream reads require streams:read when a key is supplied.',
+});
+
 registry.registerComponent('securitySchemes', 'indexerWorkerToken', {
   type: 'apiKey',
   in: 'header',
@@ -212,7 +219,7 @@ registry.registerPath({
  */
 
 /** Cursor token schema with full semantics documented. */
-const StreamCursorToken = registry.register(
+registry.register(
   'StreamCursorToken',
   z.string().openapi({
     description:
@@ -236,9 +243,10 @@ const StreamListPage = registry.register(
       description: 'True when additional pages exist. Fetch them by passing `next_cursor`.',
       example: true,
     }),
-    next_cursor: StreamCursorToken.nullable().openapi({
+    next_cursor: z.string().nullable().openapi({
       description:
         'Cursor to pass as `cursor` on the next request. ' +
+        'Uses the same opaque format as StreamCursorToken. ' +
         'Null on the last page (has_more=false).',
       example: 'eyJ2IjoxLCJsYXN0SWQiOiJzdHJlYW0tYWJjMTIzIn0',
     }),
@@ -291,7 +299,7 @@ registry.registerPath({
       }),
       cursor: z.string().optional().openapi({
         description:
-          'Opaque cursor from the previous page's `next_cursor`. ' +
+          "Opaque cursor from the previous page's `next_cursor`. " +
           'Omit to request the first page. ' +
           'Treated as a black box — do not construct manually.',
         example: 'eyJ2IjoxLCJsYXN0SWQiOiJzdHJlYW0tYWJjMTIzIn0',
@@ -407,7 +415,7 @@ registry.registerPath({
         'Discard the cursor and restart pagination from page 1 (omit `cursor`).',
       content: {
         'application/json': {
-          schema: ErrorEnvelope,
+          schema: InvalidCursorError,
           examples: {
             invalidCursor: {
               summary: 'Invalid or expired cursor',
@@ -470,7 +478,7 @@ registry.registerPath({
   method: 'post', path: '/api/streams',
   summary: 'Create stream',
   tags: ['streams'],
-  security: [{ bearerAuth: [] }],
+  security: [{ bearerAuth: [] }, { apiKeyAuth: [] }],
   request: {
     headers: z.object({ 'Idempotency-Key': z.string().openapi({ description: 'Unique key (1–128 chars) to prevent duplicate creation', example: 'my-key-001' }) }),
     body: {
@@ -503,6 +511,7 @@ registry.registerPath({
     },
     '400': errorResponses['400'],
     '401': errorResponses['401'],
+    '403': errorResponses['403'],
     '409': errorResponses['409'],
     '503': errorResponses['503'],
   },
@@ -512,7 +521,7 @@ registry.registerPath({
   method: 'delete', path: '/api/streams/{id}',
   summary: 'Cancel stream',
   tags: ['streams'],
-  security: [{ bearerAuth: [] }],
+  security: [{ bearerAuth: [] }, { apiKeyAuth: [] }],
   request: { params: z.object({ id: z.string().openapi({ example: 'stream-abc123' }) }) },
   responses: {
     '200': {
@@ -520,6 +529,7 @@ registry.registerPath({
       content: { 'application/json': { schema: successSchema(z.object({ message: z.string(), id: z.string() })) } },
     },
     '401': errorResponses['401'],
+    '403': errorResponses['403'],
     '404': errorResponses['404'],
     '409': errorResponses['409'],
     '503': errorResponses['503'],
@@ -530,6 +540,7 @@ registry.registerPath({
   method: 'patch', path: '/api/streams/{id}/status',
   summary: 'Transition stream status',
   tags: ['streams'],
+  security: [{ bearerAuth: [] }, { apiKeyAuth: [] }],
   request: {
     params: z.object({ id: z.string().openapi({ example: 'stream-abc123' }) }),
     body: {
@@ -545,6 +556,8 @@ registry.registerPath({
   responses: {
     '200': { description: 'Updated stream', content: { 'application/json': { schema: successSchema(StreamObject) } } },
     '400': errorResponses['400'],
+    '401': errorResponses['401'],
+    '403': errorResponses['403'],
     '404': errorResponses['404'],
     '409': errorResponses['409'],
     '503': errorResponses['503'],
@@ -645,10 +658,11 @@ registry.registerPath({
   method: 'get', path: '/api/admin/status',
   summary: 'Admin status (pause flags + reindex state)',
   tags: ['admin'],
-  security: [{ bearerAuth: [] }],
+  security: [{ bearerAuth: [] }, { apiKeyAuth: [] }],
   responses: {
     '200': { description: 'Admin status', content: { 'application/json': { schema: z.object({ pauseFlags: z.record(z.string(), z.boolean()), reindex: z.record(z.string(), z.unknown()) }) } } },
     '401': errorResponses['401'],
+    '403': errorResponses['403'],
   },
 });
 
@@ -656,10 +670,11 @@ registry.registerPath({
   method: 'get', path: '/api/admin/pause',
   summary: 'Get pause flags',
   tags: ['admin'],
-  security: [{ bearerAuth: [] }],
+  security: [{ bearerAuth: [] }, { apiKeyAuth: [] }],
   responses: {
     '200': { description: 'Pause flags', content: { 'application/json': { schema: z.record(z.string(), z.boolean()) } } },
     '401': errorResponses['401'],
+    '403': errorResponses['403'],
   },
 });
 
@@ -667,7 +682,7 @@ registry.registerPath({
   method: 'put', path: '/api/admin/pause',
   summary: 'Update pause flags',
   tags: ['admin'],
-  security: [{ bearerAuth: [] }],
+  security: [{ bearerAuth: [] }, { apiKeyAuth: [] }],
   request: {
     body: {
       required: true,
@@ -694,10 +709,11 @@ registry.registerPath({
   method: 'get', path: '/api/admin/reindex',
   summary: 'Get reindex state',
   tags: ['admin'],
-  security: [{ bearerAuth: [] }],
+  security: [{ bearerAuth: [] }, { apiKeyAuth: [] }],
   responses: {
     '200': { description: 'Reindex state', content: { 'application/json': { schema: z.record(z.string(), z.unknown()) } } },
     '401': errorResponses['401'],
+    '403': errorResponses['403'],
   },
 });
 
@@ -705,10 +721,11 @@ registry.registerPath({
   method: 'post', path: '/api/admin/reindex',
   summary: 'Trigger reindex',
   tags: ['admin'],
-  security: [{ bearerAuth: [] }],
+  security: [{ bearerAuth: [] }, { apiKeyAuth: [] }],
   responses: {
     '202': { description: 'Reindex started', content: { 'application/json': { schema: z.object({ message: z.string(), reindex: z.record(z.string(), z.unknown()) }) } } },
     '401': errorResponses['401'],
+    '403': errorResponses['403'],
     '409': errorResponses['409'],
   },
 });
@@ -717,10 +734,11 @@ registry.registerPath({
   method: 'get', path: '/api/admin/api-keys',
   summary: 'List API keys (hashes only)',
   tags: ['admin'],
-  security: [{ bearerAuth: [] }],
+  security: [{ bearerAuth: [] }, { apiKeyAuth: [] }],
   responses: {
     '200': { description: 'API key list', content: { 'application/json': { schema: z.object({ apiKeys: z.array(z.record(z.string(), z.unknown())) }) } } },
     '401': errorResponses['401'],
+    '403': errorResponses['403'],
   },
 });
 
@@ -728,14 +746,28 @@ registry.registerPath({
   method: 'post', path: '/api/admin/api-keys',
   summary: 'Create API key',
   tags: ['admin'],
-  security: [{ bearerAuth: [] }],
+  security: [{ bearerAuth: [] }, { apiKeyAuth: [] }],
   request: {
-    body: { required: true, content: { 'application/json': { schema: z.object({ name: z.string().openapi({ example: 'my-service' }) }) } } },
+    body: {
+      required: true,
+      content: {
+        'application/json': {
+          schema: z.object({
+            name: z.string().openapi({ example: 'my-service' }),
+            scopes: z.array(z.string()).optional().openapi({
+              example: ['streams:read'],
+              description: 'Optional explicit permission scopes. Omit for the legacy full-scope default.',
+            }),
+          }),
+        },
+      },
+    },
   },
   responses: {
     '201': { description: 'API key created (raw key returned once)', content: { 'application/json': { schema: z.record(z.string(), z.unknown()) } } },
     '400': errorResponses['400'],
     '401': errorResponses['401'],
+    '403': errorResponses['403'],
   },
 });
 
@@ -743,11 +775,12 @@ registry.registerPath({
   method: 'post', path: '/api/admin/api-keys/{id}/rotate',
   summary: 'Rotate API key',
   tags: ['admin'],
-  security: [{ bearerAuth: [] }],
+  security: [{ bearerAuth: [] }, { apiKeyAuth: [] }],
   request: { params: z.object({ id: z.string() }) },
   responses: {
     '200': { description: 'New raw key returned once', content: { 'application/json': { schema: z.record(z.string(), z.unknown()) } } },
     '401': errorResponses['401'],
+    '403': errorResponses['403'],
     '404': errorResponses['404'],
   },
 });
@@ -756,11 +789,12 @@ registry.registerPath({
   method: 'delete', path: '/api/admin/api-keys/{id}',
   summary: 'Revoke API key',
   tags: ['admin'],
-  security: [{ bearerAuth: [] }],
+  security: [{ bearerAuth: [] }, { apiKeyAuth: [] }],
   request: { params: z.object({ id: z.string() }) },
   responses: {
     '204': { description: 'Key revoked' },
     '401': errorResponses['401'],
+    '403': errorResponses['403'],
     '404': errorResponses['404'],
   },
 });

--- a/src/routes/admin.ts
+++ b/src/routes/admin.ts
@@ -1,5 +1,6 @@
 import { Router } from 'express';
 import { requireAdminAuth } from '../middleware/adminAuth.js';
+import { Permission, requireScope } from '../middleware/auth.js';
 import {
   getPauseFlags,
   setPauseFlags,
@@ -30,7 +31,7 @@ adminRouter.use(requireAdminAuth);
  * Returns current pause flags and reindex state so operators can
  * inspect service posture at a glance.
  */
-adminRouter.get('/status', (_req, res) => {
+adminRouter.get('/status', requireScope(Permission.ADMIN_READ), (_req, res) => {
   res.json({
     pauseFlags: getPauseFlags(),
     reindex: getReindexState(),
@@ -41,7 +42,7 @@ adminRouter.get('/status', (_req, res) => {
  * GET /api/admin/pause
  * Read-only view of the current pause flags.
  */
-adminRouter.get('/pause', (_req, res) => {
+adminRouter.get('/pause', requireScope(Permission.ADMIN_PAUSE), (_req, res) => {
   res.json(getPauseFlags());
 });
 
@@ -52,7 +53,7 @@ adminRouter.get('/pause', (_req, res) => {
  * Body (all fields optional):
  *   { "streamCreation": true, "ingestion": false }
  */
-adminRouter.put('/pause', (req, res) => {
+adminRouter.put('/pause', requireScope(Permission.ADMIN_PAUSE), (req, res) => {
   const { streamCreation, ingestion } = req.body ?? {};
 
   if (streamCreation === undefined && ingestion === undefined) {
@@ -102,7 +103,7 @@ adminRouter.put('/pause', (req, res) => {
  * GET /api/admin/reindex
  * Returns the current reindex job state.
  */
-adminRouter.get('/reindex', (_req, res) => {
+adminRouter.get('/reindex', requireScope(Permission.ADMIN_REINDEX), (_req, res) => {
   res.json(getReindexState());
 });
 
@@ -110,7 +111,7 @@ adminRouter.get('/reindex', (_req, res) => {
  * POST /api/admin/reindex
  * Triggers a reindex operation. Returns 409 if one is already running.
  */
-adminRouter.post('/reindex', async (_req, res) => {
+adminRouter.post('/reindex', requireScope(Permission.ADMIN_REINDEX), async (_req, res) => {
   const current = getReindexState();
   if (current.status === 'running') {
     res.status(409).json({
@@ -137,7 +138,7 @@ adminRouter.post('/reindex', async (_req, res) => {
  * POST /api/admin/ws/disconnect
  * Forcibly closes every active WebSocket subscription for a given stream_id.
  */
-adminRouter.post('/ws/disconnect', async (req, res) => {
+adminRouter.post('/ws/disconnect', requireScope(Permission.ADMIN_PAUSE), async (req, res) => {
   const { stream_id: streamIdValue } = req.body ?? {};
 
   if (typeof streamIdValue !== 'string') {
@@ -167,7 +168,7 @@ adminRouter.post('/ws/disconnect', async (req, res) => {
       closeCode: 4000,
       closeReason: 'admin-forced-disconnect',
     });
-  } catch (err) {
+  } catch {
     res.status(503).json({
       error: 'Unable to persist audit log entry. Try again later.',
       disconnectedCount,
@@ -188,7 +189,7 @@ adminRouter.post('/ws/disconnect', async (req, res) => {
  * GET /api/admin/api-keys
  * Lists all API key records (hashes only — raw keys are never returned).
  */
-adminRouter.get('/api-keys', (_req, res) => {
+adminRouter.get('/api-keys', requireScope(Permission.ADMIN_API_KEYS), (_req, res) => {
   res.json({ apiKeys: listApiKeys() });
 });
 
@@ -196,16 +197,16 @@ adminRouter.get('/api-keys', (_req, res) => {
  * POST /api/admin/api-keys
  * Creates a new API key. The raw key is returned exactly once.
  *
- * Body: { "name": "my-service" }
+ * Body: { "name": "my-service", "scopes": ["streams:read"] }
  */
-adminRouter.post('/api-keys', (req, res) => {
-  const { name } = req.body ?? {};
+adminRouter.post('/api-keys', requireScope(Permission.ADMIN_API_KEYS), (req, res) => {
+  const { name, scopes } = req.body ?? {};
   if (!name || typeof name !== 'string') {
     res.status(400).json({ error: 'name (string) is required.' });
     return;
   }
   try {
-    const created = createApiKey(name);
+    const created = createApiKey(name, scopes);
     recordAuditEvent(
       'API_KEY_CREATED',
       'api_key',
@@ -214,6 +215,7 @@ adminRouter.post('/api-keys', (req, res) => {
       {
         prefix: created.prefix,
         name: created.name,
+        scopes: created.scopes,
       },
     );
     res.status(201).json(created);
@@ -227,7 +229,7 @@ adminRouter.post('/api-keys', (req, res) => {
  * Issues a new raw key for an existing key record. The old key is immediately
  * invalidated. The new raw key is returned exactly once.
  */
-adminRouter.post('/api-keys/:id/rotate', (req, res) => {
+adminRouter.post('/api-keys/:id/rotate', requireScope(Permission.ADMIN_API_KEYS), (req, res) => {
   try {
     const rotated = rotateApiKey(req.params.id);
     recordAuditEvent(
@@ -238,6 +240,7 @@ adminRouter.post('/api-keys/:id/rotate', (req, res) => {
       {
         prefix: rotated.prefix,
         name: rotated.name,
+        scopes: rotated.scopes,
       },
     );
     res.json(rotated);
@@ -252,7 +255,7 @@ adminRouter.post('/api-keys/:id/rotate', (req, res) => {
  * DELETE /api/admin/api-keys/:id
  * Revokes an API key. Revoked keys cannot authenticate requests.
  */
-adminRouter.delete('/api-keys/:id', (req, res) => {
+adminRouter.delete('/api-keys/:id', requireScope(Permission.ADMIN_API_KEYS), (req, res) => {
   try {
     revokeApiKey(req.params.id);
     recordAuditEvent(

--- a/src/routes/streams.ts
+++ b/src/routes/streams.ts
@@ -68,7 +68,13 @@ import {
 import { requireIdempotencyKey, parseIdempotencyKeyHeader } from '../middleware/requestProtection.js';
 import { SerializationLogger, info, debug, warn } from '../utils/logger.js';
 import { recordAuditEvent } from '../lib/auditLog.js';
-import { authenticate, requireAuth } from '../middleware/auth.js';
+import {
+  authenticate,
+  Permission,
+  requireAuth,
+  requireScope,
+  requireScopeIfAuthenticated,
+} from '../middleware/auth.js';
 import { successResponse, idempotentReplayResponse } from '../utils/response.js';
 import { streamRepository } from '../db/repositories/streamRepository.js';
 import { PoolExhaustedError } from '../db/pool.js';
@@ -95,8 +101,6 @@ import {
   tryAcquireSseConnection,
 } from '../streams/sseConnectionLimiter.js';
 import {
-  RedisIdempotencyStore,
-  NoOpIdempotencyStore,
   InMemoryIdempotencyStore,
   type IdempotencyStore,
 } from '../redis/idempotencyStore.js';
@@ -254,32 +258,12 @@ function decodeCursor(cursor: string): StreamsCursor {
 
 // ── Query-param parsers ───────────────────────────────────────────────────────
 
-function parseLimit(limitParam: unknown): number {
-  if (limitParam === undefined) return 50;
-  if (Array.isArray(limitParam) || typeof limitParam !== 'string' || !/^\d+$/.test(limitParam)) {
-    throw validationError('limit must be an integer between 1 and 100');
-  }
-  const n = Number.parseInt(limitParam, 10);
-  if (n < 1 || n > 100) throw validationError('limit must be an integer between 1 and 100');
-  return n;
-}
-
 function parseCursor(cursorParam: unknown): StreamsCursor | undefined {
   if (cursorParam === undefined) return undefined;
   if (Array.isArray(cursorParam) || typeof cursorParam !== 'string' || cursorParam.trim() === '') {
     throw validationError('cursor must be a valid opaque pagination token');
   }
   return decodeCursor(cursorParam);
-}
-
-function parseIncludeTotal(includeTotalParam: unknown): boolean {
-  if (includeTotalParam === undefined) return false;
-  if (Array.isArray(includeTotalParam) || typeof includeTotalParam !== 'string') {
-    throw validationError('include_total must be true or false');
-  }
-  if (includeTotalParam === 'true') return true;
-  if (includeTotalParam === 'false') return false;
-  throw validationError('include_total must be true or false');
 }
 
 // ── Body normaliser ───────────────────────────────────────────────────────────
@@ -380,23 +364,25 @@ function assertValidApiTransition(
  * @param next Express next middleware function.
  */
 export function enforceStreamScope(req: Request, res: Response, next: NextFunction): void {
-    // Check if the user is authenticated and if the role requires scoping.
-    if (!req.user || req.user.role === 'operator') {
-        // Operator role bypasses scoping checks.
-        return next();
-    }
-
-    const callerAddress = req.user.address as string | undefined;
-    if (!callerAddress) {
-        // Should not happen if authenticate middleware is working, but safe fail.
-        return res.status(500).json({ error: { code: 'INTERNAL_ERROR', message: 'Caller address missing' } });
-    }
-
-    // Attach caller address to the request object for repository consumption.
-    req.callerAddress = callerAddress;
-
-    // Move to the next handler which will use req.callerAddress
+  // Check if the user is authenticated and if the role requires scoping.
+  if (!req.user || req.user.role === 'operator') {
+    // Operator role bypasses scoping checks.
     next();
+    return;
+  }
+
+  const callerAddress = req.user.address;
+  if (!callerAddress) {
+    // Should not happen if authenticate middleware is working, but safe fail.
+    res.status(500).json({ error: { code: 'INTERNAL_ERROR', message: 'Caller address missing' } });
+    return;
+  }
+
+  // Attach caller address to the request object for repository consumption.
+  req.callerAddress = callerAddress;
+
+  // Move to the next handler which will use req.callerAddress
+  next();
 }
 
 // ── Routes ────────────────────────────────────────────────────────────────────
@@ -410,6 +396,8 @@ export function enforceStreamScope(req: Request, res: Response, next: NextFuncti
  */
 streamsRouter.get(
   '/',
+  authenticate,
+  requireScopeIfAuthenticated(Permission.STREAMS_READ),
   asyncHandler(async (req: Request, res: Response) => {
     const requestId = req.id as string | undefined;
 
@@ -486,6 +474,8 @@ streamsRouter.get(
  */
 streamsRouter.head(
   '/:id',
+  authenticate,
+  requireScopeIfAuthenticated(Permission.STREAMS_READ),
   asyncHandler(async (req: Request, res: Response) => {
     const id = req.params['id'];
     if (!id) {
@@ -522,6 +512,8 @@ streamsRouter.head(
  */
 streamsRouter.get(
   '/:id',
+  authenticate,
+  requireScopeIfAuthenticated(Permission.STREAMS_READ),
   asyncHandler(async (req: Request, res: Response) => {
     const id = req.params['id'];
     const requestId = req.id;
@@ -561,6 +553,7 @@ streamsRouter.post(
   '/',
   authenticate,
   requireAuth,
+  requireScope(Permission.STREAMS_WRITE),
   requireIdempotencyKey,
   asyncHandler(async (req: Request, res: Response) => {
     const requestId = req.id;
@@ -688,6 +681,7 @@ streamsRouter.delete(
   '/:id',
   authenticate,
   requireAuth,
+  requireScope(Permission.STREAMS_WRITE),
   asyncHandler(async (req: Request, res: Response) => {
     const id = req.params['id'];
     const requestId = req.id;
@@ -736,6 +730,9 @@ streamsRouter.delete(
  */
 streamsRouter.patch(
   '/:id/status',
+  authenticate,
+  requireAuth,
+  requireScope(Permission.STREAMS_WRITE),
   asyncHandler(async (req: Request, res: Response) => {
     const id = req.params['id'];
     const requestId = req.id;

--- a/src/types/express.d.ts
+++ b/src/types/express.d.ts
@@ -10,6 +10,13 @@ declare global {
     interface Request {
       /** Attached by auth middleware when a valid JWT is present. */
       user?: UserPayload;
+      /** Attached by auth middleware when a valid scoped API key is present. */
+      apiKey?: {
+        id: string;
+        name: string;
+        prefix: string;
+        scopes: string[];
+      };
       /** Attached by correlationId middleware. */
       correlationId?: string;
       /** Attached by requestIdMiddleware (errors.ts). */

--- a/tests/integration/routes/admin-ws-disconnect.test.ts
+++ b/tests/integration/routes/admin-ws-disconnect.test.ts
@@ -21,6 +21,12 @@ vi.mock('../../../src/db/pool.js', () => ({
       this.name = 'PoolExhaustedError';
     }
   },
+  QueryTimeoutError: class QueryTimeoutError extends Error {
+    constructor() {
+      super('query timeout');
+      this.name = 'QueryTimeoutError';
+    }
+  },
   DuplicateEntryError: class DuplicateEntryError extends Error {
     constructor(detail?: string) {
       super(detail ?? 'duplicate');

--- a/tests/lib/auth.test.ts
+++ b/tests/lib/auth.test.ts
@@ -6,9 +6,11 @@ import {
   rotateApiKey,
   revokeApiKey,
   listApiKeys,
+  findApiKeyRecord,
   isValidApiKey,
   _resetApiKeyStoreForTest,
 } from '../../src/lib/apiKey.js';
+import { DEFAULT_API_KEY_SCOPES, Permission } from '../../src/lib/permissions.js';
 
 // ─── JWT ──────────────────────────────────────────────────────────────────────
 
@@ -64,6 +66,7 @@ describe('API Key Management', () => {
       expect(result.name).toBe('my-service');
       expect(result.id).toBeTruthy();
       expect(result.prefix).toBe(result.key.slice(0, 8));
+      expect(result.scopes).toEqual([...DEFAULT_API_KEY_SCOPES]);
     });
 
     it('stores the key as a hash (raw key not in store)', () => {
@@ -72,6 +75,18 @@ describe('API Key Management', () => {
       const record = records.find((r) => r.id === id)!;
       expect(record.keyHash).not.toBe(key);
       expect(record.keyHash).toHaveLength(64); // sha256 hex
+      expect(record.scopes).toEqual([...DEFAULT_API_KEY_SCOPES]);
+    });
+
+    it('stores explicit scopes for least-privilege keys', () => {
+      const result = createApiKey('read-only', [Permission.STREAMS_READ]);
+      expect(result.scopes).toEqual([Permission.STREAMS_READ]);
+      expect(listApiKeys()[0]!.scopes).toEqual([Permission.STREAMS_READ]);
+    });
+
+    it('rejects empty or unknown scopes', () => {
+      expect(() => createApiKey('empty', [])).toThrow('at least one permission');
+      expect(() => createApiKey('unknown', ['streams:read', 'made-up:scope'])).toThrow('unknown API key scope');
     });
 
     it('throws when name is empty', () => {
@@ -100,6 +115,13 @@ describe('API Key Management', () => {
     it('rejects empty string', () => {
       expect(isValidApiKey('')).toBe(false);
     });
+
+    it('returns the scoped key record for a matching raw key', () => {
+      const { key, id } = createApiKey('svc', [Permission.STREAMS_WRITE]);
+      const record = findApiKeyRecord(key);
+      expect(record?.id).toBe(id);
+      expect(record?.scopes).toEqual([Permission.STREAMS_WRITE]);
+    });
   });
 
   describe('rotateApiKey', () => {
@@ -117,6 +139,13 @@ describe('API Key Management', () => {
       rotateApiKey(id);
       const record = listApiKeys().find((r) => r.id === id)!;
       expect(record.rotatedAt).not.toBeNull();
+    });
+
+    it('preserves scopes while rotating the raw secret', () => {
+      const { id } = createApiKey('svc', [Permission.STREAMS_READ]);
+      const rotated = rotateApiKey(id);
+      expect(rotated.scopes).toEqual([Permission.STREAMS_READ]);
+      expect(listApiKeys().find((r) => r.id === id)!.scopes).toEqual([Permission.STREAMS_READ]);
     });
 
     it('throws for unknown id', () => {

--- a/tests/routes/admin.apiKeys.test.ts
+++ b/tests/routes/admin.apiKeys.test.ts
@@ -1,7 +1,13 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import request from 'supertest';
-import { app } from '../../src/app.js';
-import { _resetApiKeyStoreForTest } from '../../src/lib/apiKey.js';
+import express from 'express';
+import { adminRouter } from '../../src/routes/admin.js';
+import { createApiKey, _resetApiKeyStoreForTest } from '../../src/lib/apiKey.js';
+import { DEFAULT_API_KEY_SCOPES, Permission } from '../../src/lib/permissions.js';
+
+const app = express();
+app.use(express.json());
+app.use('/api/admin', adminRouter);
 
 const ADMIN_KEY = 'test-admin-key-for-apikey-routes';
 
@@ -57,6 +63,36 @@ describe('admin API key routes', () => {
     expect(res.body.name).toBe('service-a');
     expect(res.body).toHaveProperty('key'); // Raw key should be returned
     expect(res.body.key).toMatch(/^flx_/);
+    expect(res.body.scopes).toEqual([...DEFAULT_API_KEY_SCOPES]);
+  });
+
+  it('creates a least-privilege API key with explicit scopes', async () => {
+    const res = await authed(
+      request(app)
+        .post('/api/admin/api-keys')
+        .send({ name: 'read-only', scopes: [Permission.STREAMS_READ] })
+    );
+    expect(res.status).toBe(201);
+    expect(res.body.scopes).toEqual([Permission.STREAMS_READ]);
+
+    const listRes = await authed(request(app).get('/api/admin/api-keys'));
+    expect(listRes.body.apiKeys[0].scopes).toEqual([Permission.STREAMS_READ]);
+  });
+
+  it('rejects empty and unknown scopes with 400', async () => {
+    const emptyRes = await authed(
+      request(app)
+        .post('/api/admin/api-keys')
+        .send({ name: 'empty-scopes', scopes: [] })
+    );
+    expect(emptyRes.status).toBe(400);
+
+    const unknownRes = await authed(
+      request(app)
+        .post('/api/admin/api-keys')
+        .send({ name: 'bad-scope', scopes: ['streams:read', 'unknown:scope'] })
+    );
+    expect(unknownRes.status).toBe(400);
   });
 
   it('rejects creation when name is missing or invalid with 400', async () => {
@@ -84,6 +120,27 @@ describe('admin API key routes', () => {
     expect(res.body.apiKeys[0].name).toBe('service-a');
     expect(res.body.apiKeys[0]).not.toHaveProperty('key'); // Raw key must never be listed
     expect(res.body.apiKeys[0]).toHaveProperty('keyHash');
+    expect(res.body.apiKeys[0].scopes).toEqual([...DEFAULT_API_KEY_SCOPES]);
+  });
+
+  it('allows admin API-key credentials only for matching admin scopes', async () => {
+    const { key: pauseKey } = createApiKey('pause-admin', [Permission.ADMIN_PAUSE]);
+    const pauseRes = await request(app)
+      .get('/api/admin/pause')
+      .set('x-api-key', pauseKey);
+    expect(pauseRes.status).toBe(200);
+
+    const apiKeysRes = await request(app)
+      .get('/api/admin/api-keys')
+      .set('x-api-key', pauseKey);
+    expect(apiKeysRes.status).toBe(403);
+    expect(apiKeysRes.body.error.code).toBe('FORBIDDEN');
+
+    const { key: keyAdmin } = createApiKey('key-admin', [Permission.ADMIN_API_KEYS]);
+    const listRes = await request(app)
+      .get('/api/admin/api-keys')
+      .set('x-api-key', keyAdmin);
+    expect(listRes.status).toBe(200);
   });
 
   // 5. authenticated API-key deletion

--- a/tests/routes/docs.test.ts
+++ b/tests/routes/docs.test.ts
@@ -1,7 +1,10 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import request from 'supertest';
-import { app } from '../../src/app.js';
-import { resetSpecCache } from '../../src/routes/docs.js';
+import express from 'express';
+import { docsRouter, resetSpecCache } from '../../src/routes/docs.js';
+
+const app = express();
+app.use(docsRouter);
 
 beforeEach(() => {
   resetSpecCache();

--- a/tests/routes/streams-head.test.ts
+++ b/tests/routes/streams-head.test.ts
@@ -22,6 +22,9 @@ vi.mock('../../src/db/pool.js', () => ({
   PoolExhaustedError: class PoolExhaustedError extends Error {
     constructor() { super('pool exhausted'); this.name = 'PoolExhaustedError'; }
   },
+  QueryTimeoutError: class QueryTimeoutError extends Error {
+    constructor() { super('query timeout'); this.name = 'QueryTimeoutError'; }
+  },
 }));
 
 import { streamsRouter } from '../../src/routes/streams.js';

--- a/tests/routes/streams.test.ts
+++ b/tests/routes/streams.test.ts
@@ -18,6 +18,7 @@
  */
 import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
 import request from 'supertest';
+import express from 'express';
 
 // ── Mock the repository before importing the app ──────────────────────────────
 const mockGetById        = vi.fn();
@@ -41,19 +42,26 @@ vi.mock('../../src/db/pool.js', () => ({
   PoolExhaustedError:  class PoolExhaustedError extends Error {
     constructor() { super('pool exhausted'); this.name = 'PoolExhaustedError'; }
   },
+  QueryTimeoutError:  class QueryTimeoutError extends Error {
+    constructor() { super('query timeout'); this.name = 'QueryTimeoutError'; }
+  },
   DuplicateEntryError: class DuplicateEntryError extends Error {
     constructor(d?: string) { super(d ?? 'duplicate'); this.name = 'DuplicateEntryError'; }
   },
 }));
 
-import { createApp } from '../../src/app.js';
 import {
+  streamsRouter,
   _resetStreams,
+  resetStreamIdempotencyStore,
   setStreamListingDependencyState,
   setIdempotencyDependencyState,
 } from '../../src/routes/streams.js';
+import { errorHandler } from '../../src/middleware/errorHandler.js';
 import { initializeConfig } from '../../src/config/env.js';
 import { generateToken } from '../../src/lib/auth.js';
+import { createApiKey, _resetApiKeyStoreForTest } from '../../src/lib/apiKey.js';
+import { Permission } from '../../src/lib/permissions.js';
 
 // Initialize config before importing anything that needs it
 initializeConfig();
@@ -65,7 +73,10 @@ const VALID_RECIPIENT = 'GBDEVU63Y6NTHJQQZIKVTC23NWLQVP3WJ2RI2OTSJTNYOIGICST6DUX
 
 const TEST_TOKEN = generateToken({ address: VALID_SENDER, role: 'operator' });
 
-const app = createApp();
+const app = express();
+app.use(express.json());
+app.use('/api/streams', streamsRouter);
+app.use(errorHandler);
 
 // ── Fixtures ──────────────────────────────────────────────────────────────────
 
@@ -119,6 +130,8 @@ describe('streams routes', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     _resetStreams();
+    resetStreamIdempotencyStore();
+    _resetApiKeyStoreForTest();
     setStreamListingDependencyState('healthy');
     setIdempotencyDependencyState('healthy');
 
@@ -591,6 +604,59 @@ describe('streams routes', () => {
 
   // ── DELETE /api/streams/:id ───────────────────────────────────────────────
 
+  describe('API key scope enforcement', () => {
+    it('allows a read-scoped API key to list streams', async () => {
+      const { key } = createApiKey('reader', [Permission.STREAMS_READ]);
+      mockFindWithCursor.mockResolvedValue({ streams: [makeDbRecord()], hasMore: false });
+
+      const res = await request(app)
+        .get('/api/streams')
+        .set('x-api-key', key);
+
+      expect(res.status).toBe(200);
+      expect(res.body.data.streams).toHaveLength(1);
+    });
+
+    it('blocks a read-scoped API key from creating streams', async () => {
+      const { key } = createApiKey('reader', [Permission.STREAMS_READ]);
+
+      const res = await request(app)
+        .post('/api/streams')
+        .set('x-api-key', key)
+        .set('Idempotency-Key', uniqueKey('read-only-write'))
+        .send(validBody);
+
+      expect(res.status).toBe(403);
+      expect(res.body.error.code).toBe('FORBIDDEN');
+      expect(mockUpsertStream).not.toHaveBeenCalled();
+    });
+
+    it('allows a write-scoped API key to create streams', async () => {
+      const { key } = createApiKey('writer', [Permission.STREAMS_WRITE]);
+
+      const res = await request(app)
+        .post('/api/streams')
+        .set('x-api-key', key)
+        .set('Idempotency-Key', uniqueKey('write-key'))
+        .send(validBody);
+
+      expect(res.status).toBe(201);
+      expect(mockUpsertStream).toHaveBeenCalledTimes(1);
+    });
+
+    it('blocks a write-only API key from reading streams', async () => {
+      const { key } = createApiKey('writer', [Permission.STREAMS_WRITE]);
+
+      const res = await request(app)
+        .get('/api/streams')
+        .set('x-api-key', key);
+
+      expect(res.status).toBe(403);
+      expect(res.body.error.code).toBe('FORBIDDEN');
+      expect(mockFindWithCursor).not.toHaveBeenCalled();
+    });
+  });
+
   describe('DELETE /api/streams/:id', () => {
     it('cancels an active stream', async () => {
       mockGetById.mockResolvedValue(makeDbRecord({ status: 'active' }));
@@ -643,7 +709,10 @@ describe('streams routes', () => {
     it('transitions active → paused', async () => {
       mockGetById.mockResolvedValue(makeDbRecord({ status: 'active' }));
       mockUpdateStream.mockResolvedValue(makeDbRecord({ status: 'paused' }));
-      const res = await request(app).patch('/api/streams/stream-abc-0/status').send({ status: 'paused' });
+      const res = await request(app)
+        .patch('/api/streams/stream-abc-0/status')
+        .set('Authorization', `Bearer ${TEST_TOKEN}`)
+        .send({ status: 'paused' });
       expect(res.status).toBe(200);
       expect(res.body.data.status).toBe('paused');
     });
@@ -651,35 +720,53 @@ describe('streams routes', () => {
     it('transitions paused → active', async () => {
       mockGetById.mockResolvedValue(makeDbRecord({ status: 'paused' }));
       mockUpdateStream.mockResolvedValue(makeDbRecord({ status: 'active' }));
-      const res = await request(app).patch('/api/streams/stream-abc-0/status').send({ status: 'active' });
+      const res = await request(app)
+        .patch('/api/streams/stream-abc-0/status')
+        .set('Authorization', `Bearer ${TEST_TOKEN}`)
+        .send({ status: 'active' });
       expect(res.status).toBe(200);
     });
 
     it('returns 409 for invalid transition: completed → active', async () => {
       mockGetById.mockResolvedValue(makeDbRecord({ status: 'completed' }));
-      const res = await request(app).patch('/api/streams/stream-abc-0/status').send({ status: 'active' });
+      const res = await request(app)
+        .patch('/api/streams/stream-abc-0/status')
+        .set('Authorization', `Bearer ${TEST_TOKEN}`)
+        .send({ status: 'active' });
       expect(res.status).toBe(409);
       expect(res.body.error.code).toBe('CONFLICT');
     });
 
     it('returns 409 for invalid transition: cancelled → paused', async () => {
       mockGetById.mockResolvedValue(makeDbRecord({ status: 'cancelled' }));
-      expect((await request(app).patch('/api/streams/stream-abc-0/status').send({ status: 'paused' })).status).toBe(409);
+      expect((await request(app)
+        .patch('/api/streams/stream-abc-0/status')
+        .set('Authorization', `Bearer ${TEST_TOKEN}`)
+        .send({ status: 'paused' })).status).toBe(409);
     });
 
     it('returns 400 for unknown status value', async () => {
-      expect((await request(app).patch('/api/streams/stream-abc-0/status').send({ status: 'unknown-status' })).status).toBe(400);
+      expect((await request(app)
+        .patch('/api/streams/stream-abc-0/status')
+        .set('Authorization', `Bearer ${TEST_TOKEN}`)
+        .send({ status: 'unknown-status' })).status).toBe(400);
     });
 
     it('returns 404 when stream not found', async () => {
       mockGetById.mockResolvedValue(undefined);
-      expect((await request(app).patch('/api/streams/stream-nonexistent/status').send({ status: 'paused' })).status).toBe(404);
+      expect((await request(app)
+        .patch('/api/streams/stream-nonexistent/status')
+        .set('Authorization', `Bearer ${TEST_TOKEN}`)
+        .send({ status: 'paused' })).status).toBe(404);
     });
 
     it('returns 503 when pool is exhausted', async () => {
       const { PoolExhaustedError } = await import('../../src/db/pool.js');
       mockGetById.mockRejectedValue(new PoolExhaustedError());
-      expect((await request(app).patch('/api/streams/stream-abc-0/status').send({ status: 'paused' })).status).toBe(503);
+      expect((await request(app)
+        .patch('/api/streams/stream-abc-0/status')
+        .set('Authorization', `Bearer ${TEST_TOKEN}`)
+        .send({ status: 'paused' })).status).toBe(503);
     });
   });
 

--- a/tests/streams.test.ts
+++ b/tests/streams.test.ts
@@ -36,6 +36,9 @@ vi.mock('../src/db/pool.js', () => ({
   PoolExhaustedError:  class PoolExhaustedError extends Error {
     constructor() { super('pool exhausted'); this.name = 'PoolExhaustedError'; }
   },
+  QueryTimeoutError:  class QueryTimeoutError extends Error {
+    constructor() { super('query timeout'); this.name = 'QueryTimeoutError'; }
+  },
   DuplicateEntryError: class DuplicateEntryError extends Error {
     constructor(d?: string) { super(d ?? 'duplicate'); this.name = 'DuplicateEntryError'; }
   },
@@ -788,61 +791,56 @@ describe('Stream Status Transitions', () => {
     return res.body.data as { id: string; status: string };
   }
 
+  function patchStatus(id: string, body: Record<string, unknown>) {
+    return request(app)
+      .patch(`/api/streams/${id}/status`)
+      .set('Authorization', `Bearer ${testToken}`)
+      .send(body);
+  }
+
   // ── PATCH /:id/status ────────────────────────────────────────────────────
 
   describe('PATCH /api/streams/:id/status', () => {
     it('transitions active → paused', async () => {
       const { id } = await createStream();
-      const res = await request(app)
-        .patch(`/api/streams/${id}/status`)
-        .send({ status: 'paused' });
+      const res = await patchStatus(id, { status: 'paused' });
       expect(res.status).toBe(200);
       expect(res.body.data.status).toBe('paused');
     });
 
     it('transitions active → cancelled', async () => {
       const { id } = await createStream();
-      const res = await request(app)
-        .patch(`/api/streams/${id}/status`)
-        .send({ status: 'cancelled' });
+      const res = await patchStatus(id, { status: 'cancelled' });
       expect(res.status).toBe(200);
       expect(res.body.data.status).toBe('cancelled');
     });
 
     it('transitions active → completed', async () => {
       const { id } = await createStream();
-      const res = await request(app)
-        .patch(`/api/streams/${id}/status`)
-        .send({ status: 'completed' });
+      const res = await patchStatus(id, { status: 'completed' });
       expect(res.status).toBe(200);
       expect(res.body.data.status).toBe('completed');
     });
 
     it('transitions paused → active', async () => {
       const { id } = await createStream();
-      await request(app).patch(`/api/streams/${id}/status`).send({ status: 'paused' });
-      const res = await request(app)
-        .patch(`/api/streams/${id}/status`)
-        .send({ status: 'active' });
+      await patchStatus(id, { status: 'paused' });
+      const res = await patchStatus(id, { status: 'active' });
       expect(res.status).toBe(200);
       expect(res.body.data.status).toBe('active');
     });
 
     it('returns 409 for active → active (no-op invalid)', async () => {
       const { id } = await createStream();
-      const res = await request(app)
-        .patch(`/api/streams/${id}/status`)
-        .send({ status: 'active' });
+      const res = await patchStatus(id, { status: 'active' });
       expect(res.status).toBe(409);
       expect(res.body.error.code).toBe('CONFLICT');
     });
 
     it('returns 409 when transitioning from a terminal status (completed)', async () => {
       const { id } = await createStream();
-      await request(app).patch(`/api/streams/${id}/status`).send({ status: 'completed' });
-      const res = await request(app)
-        .patch(`/api/streams/${id}/status`)
-        .send({ status: 'active' });
+      await patchStatus(id, { status: 'completed' });
+      const res = await patchStatus(id, { status: 'active' });
       expect(res.status).toBe(409);
       expect(res.body.error.code).toBe('CONFLICT');
       expect(res.body.error.message).toMatch(/completed/);
@@ -850,34 +848,29 @@ describe('Stream Status Transitions', () => {
 
     it('returns 409 when transitioning from a terminal status (cancelled)', async () => {
       const { id } = await createStream();
-      await request(app).patch(`/api/streams/${id}/status`).send({ status: 'cancelled' });
-      const res = await request(app)
-        .patch(`/api/streams/${id}/status`)
-        .send({ status: 'active' });
+      await patchStatus(id, { status: 'cancelled' });
+      const res = await patchStatus(id, { status: 'active' });
       expect(res.status).toBe(409);
       expect(res.body.error.code).toBe('CONFLICT');
     });
 
     it('returns 400 for an unknown status value', async () => {
       const { id } = await createStream();
-      const res = await request(app)
-        .patch(`/api/streams/${id}/status`)
-        .send({ status: 'unknown' });
+      const res = await patchStatus(id, { status: 'unknown' });
       expect(res.status).toBe(400);
       expect(res.body.error.code).toBe('VALIDATION_ERROR');
     });
 
     it('returns 400 when status field is missing', async () => {
       const { id } = await createStream();
-      const res = await request(app)
-        .patch(`/api/streams/${id}/status`)
-        .send({});
+      const res = await patchStatus(id, {});
       expect(res.status).toBe(400);
     });
 
     it('returns 404 for unknown stream id', async () => {
       const res = await request(app)
         .patch('/api/streams/nonexistent/status')
+        .set('Authorization', `Bearer ${testToken}`)
         .send({ status: 'paused' });
       expect(res.status).toBe(404);
     });
@@ -889,9 +882,7 @@ describe('Stream Status Transitions', () => {
         ratePerSecond: '0.0000116',
       });
       const { id } = res1.body.data;
-      const res2 = await request(app)
-        .patch(`/api/streams/${id}/status`)
-        .send({ status: 'paused' });
+      const res2 = await patchStatus(id, { status: 'paused' });
       expect(res2.status).toBe(200);
       // Trailing zeros are stripped by the validator on the initial POST, so
       // the stored value is the canonical "1000000" / "0.0000116".
@@ -915,7 +906,7 @@ describe('Stream Status Transitions', () => {
 
     it('returns 409 when cancelling a completed stream', async () => {
       const { id } = await createStream();
-      await request(app).patch(`/api/streams/${id}/status`).send({ status: 'completed' });
+      await patchStatus(id, { status: 'completed' });
       const res = await request(app).delete(`/api/streams/${id}`).set('Authorization', auth);
       expect(res.status).toBe(409);
       expect(res.body.error.code).toBe('CONFLICT');
@@ -931,7 +922,7 @@ describe('Stream Status Transitions', () => {
 
     it('cancels a paused stream successfully', async () => {
       const { id } = await createStream();
-      await request(app).patch(`/api/streams/${id}/status`).send({ status: 'paused' });
+      await patchStatus(id, { status: 'paused' });
       const res = await request(app).delete(`/api/streams/${id}`).set('Authorization', auth);
       expect(res.status).toBe(200);
     });

--- a/tests/unit/middleware/auth.test.ts
+++ b/tests/unit/middleware/auth.test.ts
@@ -1,8 +1,9 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { Request, Response, NextFunction } from 'express';
-import { authenticate, requireAuth, requirePermission, Permission } from '../../../src/middleware/auth.js';
+import { authenticate, requireAuth, requirePermission, requireScope, Permission } from '../../../src/middleware/auth.js';
 import { verifyToken } from '../../../src/lib/auth.js';
 import { isRevoked } from '../../../src/redis/jwtRevocationStore.js';
+import { createApiKey, _resetApiKeyStoreForTest } from '../../../src/lib/apiKey.js';
 
 // ── Mocks ──
 
@@ -22,9 +23,12 @@ vi.mock('../../../src/utils/logger.js', () => ({
 
 // ── Helpers ──
 
-function mockReq(opts: { authHeader?: string; id?: string } = {}): Partial<Request> {
+function mockReq(opts: { authHeader?: string; id?: string; apiKey?: string } = {}): Partial<Request> {
+  const headers: Record<string, string> = {};
+  if (opts.authHeader) headers.authorization = opts.authHeader;
+  if (opts.apiKey) headers['x-api-key'] = opts.apiKey;
   return {
-    headers: opts.authHeader ? { authorization: opts.authHeader } : {},
+    headers,
     id: opts.id ?? 'req-123',
     correlationId: opts.id ?? 'req-123',
   };
@@ -55,6 +59,7 @@ function mockNext(): NextFunction {
 describe('authenticate', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    _resetApiKeyStoreForTest();
   });
 
   // ── Happy path ──
@@ -90,6 +95,59 @@ describe('authenticate', () => {
     expect(next).toHaveBeenCalled();
     expect(req.user).toBeUndefined();
     expect(verifyToken).not.toHaveBeenCalled();
+  });
+
+  it('authenticates a valid API key and attaches its scopes', async () => {
+    const { key, id } = createApiKey('svc', [Permission.STREAMS_READ]);
+    const req = mockReq({ apiKey: key }) as Request;
+    const res = mockRes() as Response;
+    const next = mockNext();
+
+    await authenticate(req, res, next);
+
+    expect(next).toHaveBeenCalled();
+    expect(req.user).toEqual(expect.objectContaining({
+      address: `api-key:${id}`,
+      role: 'service',
+      permissions: [Permission.STREAMS_READ],
+    }));
+    expect(req.apiKey).toEqual(expect.objectContaining({
+      id,
+      scopes: [Permission.STREAMS_READ],
+    }));
+    expect(verifyToken).not.toHaveBeenCalled();
+  });
+
+  it('returns 401 for an invalid API key', async () => {
+    const req = mockReq({ apiKey: 'flx_invalid' }) as Request;
+    const res = mockRes() as Response;
+    const next = mockNext();
+
+    await authenticate(req, res, next);
+
+    expect(res.statusCode).toBe(401);
+    expect((res as any).jsonBody.error.code).toBe('UNAUTHORIZED');
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it('prefers a valid Bearer JWT when both JWT and API key are present', async () => {
+    const payload = {
+      address: 'GABC...',
+      role: 'operator',
+      permissions: [Permission.STREAMS_WRITE],
+    };
+    const { key } = createApiKey('svc', [Permission.STREAMS_READ]);
+    (verifyToken as any).mockReturnValue(payload);
+
+    const req = mockReq({ authHeader: 'Bearer valid-token', apiKey: key }) as Request;
+    const res = mockRes() as Response;
+    const next = mockNext();
+
+    await authenticate(req, res, next);
+
+    expect(next).toHaveBeenCalled();
+    expect(req.user).toEqual(expect.objectContaining(payload));
+    expect(req.apiKey).toBeUndefined();
   });
 
   // ── Revocation checks ──
@@ -276,6 +334,22 @@ describe('requirePermission', () => {
     requirePermission(Permission.STREAMS_READ)(req, res, next);
 
     expect(res.statusCode).toBe(401);
+    expect(next).not.toHaveBeenCalled();
+  });
+});
+
+describe('requireScope', () => {
+  it('fails closed for an empty scope set', () => {
+    const req = {
+      user: { permissions: [] },
+    } as Request;
+    const res = mockRes() as Response;
+    const next = mockNext();
+
+    requireScope(Permission.STREAMS_READ)(req, res, next);
+
+    expect(res.statusCode).toBe(403);
+    expect((res as any).jsonBody.error.details.requiredScope).toBe(Permission.STREAMS_READ);
     expect(next).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
Closes #358.

## Summary
- add scoped permissions to API key records and creation/list/rotation responses
- authenticate `x-api-key` as a service principal with stored scopes
- enforce `streams:read` / `streams:write` on stream routes and matching `admin:*` scopes on admin/API-key routes
- document API key auth in OpenAPI and auth docs, including legacy default scopes and fail-closed behavior

## Validation
- `node.exe .\node_modules\vitest\vitest.mjs run tests\lib\auth.test.ts tests\unit\middleware\auth.test.ts tests\routes\admin.apiKeys.test.ts tests\routes\streams.test.ts tests\routes\streams-head.test.ts tests\routes\docs.test.ts tests\integration\routes\admin-ws-disconnect.test.ts --reporter=dot` (195 passed)
- `node.exe .\node_modules\eslint\bin\eslint.js ...` on touched files (0 errors; existing test fixture warnings remain)
- `git diff --check`

## Notes
- Full `tsc --noEmit` is still blocked by existing repository baseline type errors unrelated to this change, including existing webhook duplicate exports and missing optional dependencies.