### PR TITLE
fix(db): run replay index migration outside transactions

### DIFF
--- a/migrations/001_add_contract_events_replay_indexes.ts
+++ b/migrations/001_add_contract_events_replay_indexes.ts
@@ -1,4 +1,26 @@
-import { PoolClient } from 'pg';
+import type { MigrationBuilder } from 'node-pg-migrate';
+import type { PoolClient } from 'pg';
+
+type MigrationTarget = MigrationBuilder | PoolClient;
+
+function isMigrationBuilder(target: MigrationTarget): target is MigrationBuilder {
+  return typeof (target as MigrationBuilder).sql === 'function';
+}
+
+async function runSql(target: MigrationTarget, sql: string): Promise<void> {
+  if (isMigrationBuilder(target)) {
+    target.sql(sql);
+    return;
+  }
+
+  await target.query(sql);
+}
+
+function runOutsideTransaction(target: MigrationTarget): void {
+  if (isMigrationBuilder(target)) {
+    target.noTransaction();
+  }
+}
 
 /**
  * Migration: Add indexes for optimized contract event replay
@@ -13,46 +35,44 @@ import { PoolClient } from 'pg';
  * - Supporting the ORDER BY block_height, event_id pattern used in batched fetches
  */
 
-export async function up(client: PoolClient): Promise<void> {
-  console.log('Creating contract_events replay indexes...');
+export async function up(pgm: MigrationTarget): Promise<void> {
+  // CREATE INDEX CONCURRENTLY is forbidden inside a PostgreSQL transaction.
+  runOutsideTransaction(pgm);
 
   // Composite index for general replay queries
-  await client.query(`
+  await runSql(pgm, `
     CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_contract_events_contract_ledger
     ON contract_events (contract_id, ledger, block_height, event_id);
   `);
 
   // Partial index for unprocessed events (ingested_at IS NULL)
   // This is useful for tracking replay progress and identifying incomplete ingestions
-  await client.query(`
+  await runSql(pgm, `
     CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_contract_events_pending_ingestion
     ON contract_events (contract_id, ledger, block_height)
     WHERE ingested_at IS NULL;
   `);
 
   // Index on historical_events for efficient batch fetching during replay
-  await client.query(`
+  await runSql(pgm, `
     CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_historical_events_replay
     ON historical_events (contract_id, ledger, block_height, event_id);
   `);
-
-  console.log('Indexes created successfully');
 }
 
-export async function down(client: PoolClient): Promise<void> {
-  console.log('Dropping contract_events replay indexes...');
+export async function down(pgm: MigrationTarget): Promise<void> {
+  // DROP INDEX CONCURRENTLY is forbidden inside a PostgreSQL transaction.
+  runOutsideTransaction(pgm);
 
-  await client.query(`
+  await runSql(pgm, `
     DROP INDEX CONCURRENTLY IF EXISTS idx_contract_events_contract_ledger;
   `);
 
-  await client.query(`
+  await runSql(pgm, `
     DROP INDEX CONCURRENTLY IF EXISTS idx_contract_events_pending_ingestion;
   `);
 
-  await client.query(`
+  await runSql(pgm, `
     DROP INDEX CONCURRENTLY IF EXISTS idx_historical_events_replay;
   `);
-
-  console.log('Indexes dropped successfully');
 }

--- a/tests/migrate-guard.test.ts
+++ b/tests/migrate-guard.test.ts
@@ -52,6 +52,7 @@ vi.mock('pg', async (importOriginal) => {
 
 import { checkPendingMigrations, PendingMigrationsError } from '../src/db/migrate.js'
 import * as fsModule from 'fs'
+import * as replayIndexMigration from '../migrations/001_add_contract_events_replay_indexes.js'
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
@@ -197,5 +198,51 @@ describe('checkPendingMigrations', () => {
 
     await expect(checkPendingMigrations()).rejects.toThrow('query error')
     expect(pgClientMocks.end).toHaveBeenCalled()
+  })
+})
+
+describe('contract event replay index migration', () => {
+  function makeMigrationBuilder() {
+    return {
+      noTransaction: vi.fn(),
+      sql: vi.fn(),
+    } as unknown as import('node-pg-migrate').MigrationBuilder
+  }
+
+  it('creates replay indexes concurrently and preserves the pending-ingestion predicate', async () => {
+    const pgm = makeMigrationBuilder()
+
+    await replayIndexMigration.up(pgm)
+
+    expect(pgm.noTransaction).toHaveBeenCalledOnce()
+    const sql = (pgm.sql as ReturnType<typeof vi.fn>).mock.calls.map(([statement]) => String(statement)).join('\n')
+    expect(sql).toContain('CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_contract_events_contract_ledger')
+    expect(sql).toContain('CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_contract_events_pending_ingestion')
+    expect(sql).toContain('CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_historical_events_replay')
+    expect(sql).toContain('WHERE ingested_at IS NULL')
+  })
+
+  it('drops replay indexes concurrently and remains idempotent', async () => {
+    const pgm = makeMigrationBuilder()
+
+    await replayIndexMigration.down(pgm)
+
+    expect(pgm.noTransaction).toHaveBeenCalledOnce()
+    const sql = (pgm.sql as ReturnType<typeof vi.fn>).mock.calls.map(([statement]) => String(statement)).join('\n')
+    expect(sql).toContain('DROP INDEX CONCURRENTLY IF EXISTS idx_contract_events_contract_ledger')
+    expect(sql).toContain('DROP INDEX CONCURRENTLY IF EXISTS idx_contract_events_pending_ingestion')
+    expect(sql).toContain('DROP INDEX CONCURRENTLY IF EXISTS idx_historical_events_replay')
+  })
+
+  it('remains compatible with the legacy PoolClient migration runner', async () => {
+    const client = {
+      query: vi.fn().mockResolvedValue({ rows: [] }),
+    } as unknown as import('pg').PoolClient
+
+    await replayIndexMigration.up(client)
+
+    const sql = (client.query as ReturnType<typeof vi.fn>).mock.calls.map(([statement]) => String(statement)).join('\n')
+    expect(sql).toContain('CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_contract_events_contract_ledger')
+    expect(sql).toContain('WHERE ingested_at IS NULL')
   })
 })


### PR DESCRIPTION
## Summary
- convert the replay-index migration to work with node-pg-migrate's `MigrationBuilder` API while preserving the existing legacy `PoolClient` runner path
- call `pgm.noTransaction()` before `CREATE/DROP INDEX CONCURRENTLY` so node-pg-migrate does not wrap the migration in a transaction
- add migration guard coverage for concurrent create/drop SQL, the `ingested_at IS NULL` partial predicate, and legacy runner compatibility

Closes #337.

## Tests
- `corepack.cmd pnpm@8.15.9 install --frozen-lockfile --ignore-scripts`
- `node.exe .\node_modules\vitest\vitest.mjs run tests\migrate-guard.test.ts --reporter=dot` (13 tests passed)
- `node.exe --import tsx -e "import('./migrations/001_add_contract_events_replay_indexes.ts').then(async m=>{ const calls=[]; const pgm={ noTransaction(){calls.push('noTransaction')}, sql(s){calls.push(s)} }; await m.up(pgm); if(!calls[0] || calls[0] !== 'noTransaction') throw new Error('noTransaction not called first'); if(!calls.join('\\n').includes('CREATE INDEX CONCURRENTLY')) throw new Error('missing concurrent create'); console.log('migration module ok'); })"`
- `node.exe .\node_modules\eslint\bin\eslint.js migrations\001_add_contract_events_replay_indexes.ts tests\migrate-guard.test.ts`
- `git diff --check`

## Security and operations notes
- `CONCURRENTLY` remains in both up/down paths to avoid blocking writes while indexes are built or removed.
- `IF NOT EXISTS` / `IF EXISTS` and the `WHERE ingested_at IS NULL` partial-index predicate are preserved for idempotent re-runs.
- The old custom migration runner remains compatible until the project fully standardizes on node-pg-migrate.