### PR TITLE
feat(auth): persist API keys with salted lookup

### DIFF
--- a/docs/api/admin-endpoints.md
+++ b/docs/api/admin-endpoints.md
@@ -50,3 +50,30 @@ Security notes:
 - `POST /api/admin/api-keys`
 - `POST /api/admin/api-keys/:id/rotate`
 - `DELETE /api/admin/api-keys/:id`
+
+## API key management
+
+### `POST /api/admin/api-keys`
+
+Creates a DB-backed API key record and returns the raw key once:
+
+```json
+{
+  "id": "ck...",
+  "name": "service-a",
+  "key": "flx_...",
+  "prefix": "flx_1234",
+  "createdAt": "2026-06-22T00:00:00.000Z"
+}
+```
+
+Security behavior:
+
+- The raw key is never stored and is not returned by list responses.
+- Stored hashes use a per-key salt plus `API_KEY_PEPPER`.
+- Validation uses an indexed peppered `lookup_hash` before constant-time comparison on the candidate row.
+- `API_KEY_CREATED`, `API_KEY_ROTATED`, and `API_KEY_REVOKED` are written to `audit_logs`.
+
+### `GET /api/admin/api-keys`
+
+Lists records for operators. Responses include `id`, `name`, `keyHash`, `prefix`, timestamps, and `active`, but never include raw keys, salts, or lookup hashes.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -10,6 +10,7 @@ Secret values are never included in validation messages.
 | --- | --- | --- |
 | `DATABASE_URL` | URL | PostgreSQL connection string. |
 | `JWT_SECRET` | string | Minimum 32 characters. Used to sign API JWTs. |
+| `API_KEY_PEPPER` | string | Minimum 32 characters. Required in production for DB-backed API key hashing. |
 | `INDEXER_WORKER_TOKEN` | string | Minimum 32 characters. Required by internal indexer routes. |
 
 ## Optional variables and defaults
@@ -34,6 +35,7 @@ Secret values are never included in validation messages.
 | `STELLAR_RPC_RETRY_DELAY` | integer ms | `1000` |
 | `JWT_EXPIRES_IN` | string | `24h` |
 | `API_KEYS` | comma-separated string | Empty, except `test-api-key` in tests |
+| `API_KEY_PEPPER` | string | unset outside production |
 | `ADMIN_API_KEY` | string | unset |
 | `MAX_REQUEST_SIZE` | bytes string, supports `b`, `kb`, `mb`, `gb` | `1mb` |
 | `MAX_JSON_DEPTH` | integer, 1-1000 | `20` |
@@ -83,3 +85,9 @@ Secret values are never included in validation messages.
 | `FLUXORA_SHUTDOWN` | boolean | unset; internal graceful shutdown flag |
 
 Booleans accept `true`, `false`, `1`, and `0`.
+
+## API key storage
+
+Admin-created API keys are stored in PostgreSQL in the `api_keys` table. The raw key is returned once during create/rotate and is never persisted. Stored rows contain a per-key salt, a peppered HMAC key hash, and a peppered `lookup_hash` derived from the display prefix so validation can use the `api_keys_active_lookup_hash_idx` index instead of scanning every key.
+
+`API_KEY_PEPPER` must be a deployment secret of at least 32 characters. It is required in production and is treated as a secret in configuration validation messages.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -22,7 +22,7 @@ Administrative and operational endpoints require credentials depending on their 
 
 To ensure deterministic behavior and prevent test-to-test side effects, in-process state is initialized and purged in `beforeEach`/`afterEach` hooks:
 - **Pause & Reindex State**: Cleared using `_resetForTest()` from `src/state/adminState.ts`.
-- **API Key Records**: Cleared using `_resetApiKeyStoreForTest()` from `src/lib/apiKey.ts`.
+- **API Key Records**: Route/unit suites inject a repository test double and clear it with `_resetApiKeyStoreForTest()` from `src/lib/apiKey.ts`; production records live in PostgreSQL.
 - **DLQ Entries**: Cleared using `_resetDlq()` from `src/routes/dlq.ts`.
 
 ## Supertest Integration
@@ -37,6 +37,8 @@ const res = await request(app)
   .get('/api/admin/pause')
   .set('Authorization', `Bearer \${process.env.ADMIN_API_KEY}`);
 ```
+
+`admin.apiKeys.test.ts` mounts `adminRouter` in a small Express app and mocks the API-key repository. This keeps the API-key route suite focused on DB-backed hashing, audit behavior, and response shape even when unrelated application-level modules have baseline failures.
 
 ---
 

--- a/migrations/1774715400000_api-keys.ts
+++ b/migrations/1774715400000_api-keys.ts
@@ -1,0 +1,34 @@
+import { ColumnDefinitions, MigrationBuilder } from 'node-pg-migrate';
+
+export const shorthands: ColumnDefinitions | undefined = undefined;
+
+export async function up(pgm: MigrationBuilder): Promise<void> {
+  pgm.createTable('api_keys', {
+    id:          { type: 'text', primaryKey: true },
+    name:        { type: 'text', notNull: true },
+    key_hash:    { type: 'char(64)', notNull: true },
+    key_salt:    { type: 'char(32)', notNull: true },
+    lookup_hash: { type: 'char(64)', notNull: true },
+    prefix:      { type: 'text', notNull: true },
+    created_at:  { type: 'timestamp with time zone', notNull: true, default: pgm.func('current_timestamp') },
+    rotated_at:  { type: 'timestamp with time zone' },
+    revoked_at:  { type: 'timestamp with time zone' },
+  });
+
+  pgm.addConstraint('api_keys', 'api_keys_name_not_empty', "CHECK (length(btrim(name)) > 0)");
+  pgm.addConstraint('api_keys', 'api_keys_prefix_length', "CHECK (length(prefix) = 8)");
+  pgm.addConstraint('api_keys', 'api_keys_key_hash_hex', "CHECK (key_hash ~ '^[0-9a-f]{64}$')");
+  pgm.addConstraint('api_keys', 'api_keys_key_salt_hex', "CHECK (key_salt ~ '^[0-9a-f]{32}$')");
+  pgm.addConstraint('api_keys', 'api_keys_lookup_hash_hex', "CHECK (lookup_hash ~ '^[0-9a-f]{64}$')");
+
+  pgm.createIndex('api_keys', 'lookup_hash', {
+    name: 'api_keys_active_lookup_hash_idx',
+    where: 'revoked_at IS NULL',
+  });
+  pgm.createIndex('api_keys', 'created_at');
+  pgm.createIndex('api_keys', 'prefix');
+}
+
+export async function down(pgm: MigrationBuilder): Promise<void> {
+  pgm.dropTable('api_keys');
+}

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -3,7 +3,6 @@ import { type StellarNetwork, STELLAR_NETWORKS, type ContractAddresses } from '.
 import {
   getPinnedAddressNetwork,
   isValidStellarContractAddress,
-  STELLAR_CONTRACT_ALLOWLIST,
   STELLAR_NETWORK_PASSPHRASES,
   type PinnedStellarAddressKind,
   type PinnedStellarNetwork,
@@ -27,6 +26,7 @@ const SECRET_ENV_NAMES = new Set([
   'ADMIN_API_TOKEN',
   'ADMIN_API_KEY',
   'API_KEYS',
+  'API_KEY_PEPPER',
   'FLUXORA_WEBHOOK_SECRET',
   'FLUXORA_WEBHOOK_SECRET_PREVIOUS',
 ]);
@@ -204,6 +204,10 @@ export const EnvSchema = z.object({
   ),
   JWT_EXPIRES_IN: z.string().min(1, 'JWT_EXPIRES_IN cannot be empty').default('24h'),
   API_KEYS: z.string().optional(),
+  API_KEY_PEPPER: z.preprocess(
+    (value) => (value === '' ? undefined : value),
+    z.string().min(32, 'API_KEY_PEPPER must be at least 32 characters').optional(),
+  ),
   INDEXER_WORKER_TOKEN: z.string().min(32, 'INDEXER_WORKER_TOKEN must be at least 32 characters'),
   ADMIN_API_KEY: optionalString('ADMIN_API_KEY'),
 
@@ -289,6 +293,14 @@ export const EnvSchema = z.object({
     });
   }
 
+  if (env.NODE_ENV === 'production' && env.API_KEY_PEPPER === undefined) {
+    ctx.addIssue({
+      code: 'custom',
+      path: ['API_KEY_PEPPER'],
+      message: 'API_KEY_PEPPER is required in production',
+    });
+  }
+
   validatePinnedAddress(ctx, stellarNetwork, 'contract', 'STELLAR_CONTRACT_ADDRESS', env.STELLAR_CONTRACT_ADDRESS);
   validatePinnedAddress(ctx, stellarNetwork, 'token', 'STELLAR_TOKEN_ADDRESS', env.STELLAR_TOKEN_ADDRESS);
 });
@@ -331,6 +343,7 @@ export interface Config {
   pgcryptoKeyPrevious?: string | undefined;
   jwtExpiresIn: string;
   apiKeys: string[];
+  apiKeyPepper?: string | undefined;
   indexerWorkerToken: string;
 
   maxRequestSizeBytes: number;
@@ -475,6 +488,7 @@ function toConfig(env: ParsedEnv): Config {
       .split(',')
       .map((key) => key.trim())
       .filter((key) => key.length > 0),
+    apiKeyPepper: env.API_KEY_PEPPER,
     indexerWorkerToken: env.INDEXER_WORKER_TOKEN,
 
     maxRequestSizeBytes: env.MAX_REQUEST_SIZE,

--- a/src/db/repositories/apiKeyRepository.ts
+++ b/src/db/repositories/apiKeyRepository.ts
@@ -1,0 +1,162 @@
+import { getPool, query } from '../pool.js';
+import type { ApiKeyRecord, ApiKeyStoredRecord } from '../types.js';
+
+interface ApiKeyDbRow extends Record<string, unknown> {
+  id: string;
+  name: string;
+  key_hash: string;
+  key_salt: string;
+  lookup_hash: string;
+  prefix: string;
+  created_at: Date | string;
+  rotated_at: Date | string | null;
+  revoked_at: Date | string | null;
+}
+
+export interface PersistApiKeyInput {
+  id: string;
+  name: string;
+  keyHash: string;
+  keySalt: string;
+  lookupHash: string;
+  prefix: string;
+  createdAt: string;
+  rotatedAt: string | null;
+}
+
+export interface RotateApiKeyInput {
+  keyHash: string;
+  keySalt: string;
+  lookupHash: string;
+  prefix: string;
+  rotatedAt: string;
+}
+
+function toIso(value: Date | string | null): string | null {
+  if (value === null) return null;
+  return value instanceof Date ? value.toISOString() : new Date(value).toISOString();
+}
+
+function rowToStoredRecord(row: ApiKeyDbRow): ApiKeyStoredRecord {
+  const revokedAt = toIso(row.revoked_at);
+  return {
+    id: row.id,
+    name: row.name,
+    keyHash: row.key_hash,
+    keySalt: row.key_salt,
+    lookupHash: row.lookup_hash,
+    prefix: row.prefix,
+    createdAt: toIso(row.created_at)!,
+    rotatedAt: toIso(row.rotated_at),
+    revokedAt,
+    active: revokedAt === null,
+  };
+}
+
+function publicRecord(record: ApiKeyStoredRecord): ApiKeyRecord {
+  return {
+    id: record.id,
+    name: record.name,
+    keyHash: record.keyHash,
+    prefix: record.prefix,
+    createdAt: record.createdAt,
+    rotatedAt: record.rotatedAt,
+    revokedAt: record.revokedAt,
+    active: record.active,
+  };
+}
+
+export const apiKeyRepository = {
+  async create(input: PersistApiKeyInput): Promise<ApiKeyRecord> {
+    const result = await query<ApiKeyDbRow>(
+      getPool(),
+      `INSERT INTO api_keys (
+         id, name, key_hash, key_salt, lookup_hash, prefix,
+         created_at, rotated_at, revoked_at
+       )
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, NULL)
+       RETURNING id, name, key_hash, key_salt, lookup_hash, prefix, created_at, rotated_at, revoked_at`,
+      [
+        input.id,
+        input.name,
+        input.keyHash,
+        input.keySalt,
+        input.lookupHash,
+        input.prefix,
+        input.createdAt,
+        input.rotatedAt,
+      ],
+    );
+
+    return publicRecord(rowToStoredRecord(result.rows[0]!));
+  },
+
+  async findById(id: string): Promise<ApiKeyRecord | undefined> {
+    const result = await query<ApiKeyDbRow>(
+      getPool(),
+      `SELECT id, name, key_hash, key_salt, lookup_hash, prefix, created_at, rotated_at, revoked_at
+       FROM api_keys
+       WHERE id = $1`,
+      [id],
+    );
+
+    return result.rows[0] ? publicRecord(rowToStoredRecord(result.rows[0])) : undefined;
+  },
+
+  async findActiveByLookupHash(lookupHash: string): Promise<ApiKeyStoredRecord[]> {
+    const result = await query<ApiKeyDbRow>(
+      getPool(),
+      `SELECT id, name, key_hash, key_salt, lookup_hash, prefix, created_at, rotated_at, revoked_at
+       FROM api_keys
+       WHERE lookup_hash = $1 AND revoked_at IS NULL`,
+      [lookupHash],
+    );
+
+    return result.rows.map((row) => rowToStoredRecord(row));
+  },
+
+  async list(): Promise<ApiKeyRecord[]> {
+    const result = await query<ApiKeyDbRow>(
+      getPool(),
+      `SELECT id, name, key_hash, key_salt, lookup_hash, prefix, created_at, rotated_at, revoked_at
+       FROM api_keys
+       ORDER BY created_at ASC, id ASC`,
+    );
+
+    return result.rows.map((row) => publicRecord(rowToStoredRecord(row)));
+  },
+
+  async rotate(id: string, input: RotateApiKeyInput): Promise<ApiKeyRecord | undefined> {
+    const result = await query<ApiKeyDbRow>(
+      getPool(),
+      `UPDATE api_keys
+       SET key_hash = $2,
+           key_salt = $3,
+           lookup_hash = $4,
+           prefix = $5,
+           rotated_at = $6
+       WHERE id = $1 AND revoked_at IS NULL
+       RETURNING id, name, key_hash, key_salt, lookup_hash, prefix, created_at, rotated_at, revoked_at`,
+      [id, input.keyHash, input.keySalt, input.lookupHash, input.prefix, input.rotatedAt],
+    );
+
+    return result.rows[0] ? publicRecord(rowToStoredRecord(result.rows[0])) : undefined;
+  },
+
+  async revoke(id: string, revokedAt: string): Promise<ApiKeyRecord | undefined> {
+    const result = await query<ApiKeyDbRow>(
+      getPool(),
+      `UPDATE api_keys
+       SET revoked_at = $2
+       WHERE id = $1
+       RETURNING id, name, key_hash, key_salt, lookup_hash, prefix, created_at, rotated_at, revoked_at`,
+      [id, revokedAt],
+    );
+
+    return result.rows[0] ? publicRecord(rowToStoredRecord(result.rows[0])) : undefined;
+  },
+
+  async deleteAllForTest(): Promise<void> {
+    await query(getPool(), 'DELETE FROM api_keys');
+  },
+};

--- a/src/db/types.ts
+++ b/src/db/types.ts
@@ -179,8 +179,17 @@ export interface ApiKeyRecord {
   createdAt: string;
   /** ISO-8601 last-rotated timestamp, or null if never rotated */
   rotatedAt: string | null;
+  /** ISO-8601 revocation timestamp, or null if still usable */
+  revokedAt: string | null;
   /** Whether the key is still active */
   active: boolean;
+}
+
+export interface ApiKeyStoredRecord extends ApiKeyRecord {
+  /** Per-key random salt used by the stored key hash */
+  keySalt: string;
+  /** Pepper-keyed lookup hash used for indexed validation */
+  lookupHash: string;
 }
 
 /**

--- a/src/lib/apiKey.ts
+++ b/src/lib/apiKey.ts
@@ -1,116 +1,189 @@
 import { createId } from '@paralleldrive/cuid2';
-import { createHash, timingSafeEqual } from 'crypto';
-import type { ApiKeyRecord, ApiKeyCreated } from '../db/types.js';
+import { createHmac, randomBytes, timingSafeEqual } from 'crypto';
+import type { ApiKeyCreated, ApiKeyRecord, ApiKeyStoredRecord } from '../db/types.js';
+import { apiKeyRepository } from '../db/repositories/apiKeyRepository.js';
 
-// ---------------------------------------------------------------------------
-// In-memory store (replace with DB-backed store when persistence is needed)
-// ---------------------------------------------------------------------------
-const store = new Map<string, ApiKeyRecord>();
+const API_KEY_PREFIX = 'flx_';
+const RAW_KEY_BYTES = 32;
+const DISPLAY_PREFIX_LENGTH = 8;
+const SALT_BYTES = 16;
+const HMAC_ALGORITHM = 'sha256';
+const TEST_PEPPER = 'test-api-key-pepper-for-deterministic-unit-tests';
 
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
+export interface ApiKeyStore {
+  create(input: {
+    id: string;
+    name: string;
+    keyHash: string;
+    keySalt: string;
+    lookupHash: string;
+    prefix: string;
+    createdAt: string;
+    rotatedAt: string | null;
+  }): Promise<ApiKeyRecord>;
+  findById(id: string): Promise<ApiKeyRecord | undefined>;
+  findActiveByLookupHash(lookupHash: string): Promise<ApiKeyStoredRecord[]>;
+  list(): Promise<ApiKeyRecord[]>;
+  rotate(id: string, input: {
+    keyHash: string;
+    keySalt: string;
+    lookupHash: string;
+    prefix: string;
+    rotatedAt: string;
+  }): Promise<ApiKeyRecord | undefined>;
+  revoke(id: string, revokedAt: string): Promise<ApiKeyRecord | undefined>;
+  deleteAllForTest(): Promise<void>;
+}
 
-function sha256hex(value: string): string {
-  return createHash('sha256').update(value).digest('hex');
+let store: ApiKeyStore = apiKeyRepository;
+
+function hmacHex(pepper: string, ...parts: string[]): string {
+  const hmac = createHmac(HMAC_ALGORITHM, pepper);
+  for (const part of parts) {
+    hmac.update(part);
+    hmac.update('\0');
+  }
+  return hmac.digest('hex');
+}
+
+function resolvePepper(): string {
+  const pepper = process.env.API_KEY_PEPPER;
+  if (pepper && pepper.length >= 32) return pepper;
+  if (process.env.NODE_ENV === 'test') return TEST_PEPPER;
+  throw new Error('API_KEY_PEPPER must be at least 32 characters');
 }
 
 function generateRawKey(): string {
-  // 32 random bytes → 64-char hex string
-  const { randomBytes } = require('crypto') as typeof import('crypto');
-  return `flx_${randomBytes(32).toString('hex')}`;
+  return `${API_KEY_PREFIX}${randomBytes(RAW_KEY_BYTES).toString('hex')}`;
 }
 
-// ---------------------------------------------------------------------------
-// Public API
-// ---------------------------------------------------------------------------
+function generateSalt(): string {
+  return randomBytes(SALT_BYTES).toString('hex');
+}
 
 /**
- * Creates a new API key. Returns the record plus the raw key (shown once).
+ * Build the salted, peppered credential hash stored in Postgres.
+ *
+ * The per-row salt prevents equal raw keys from producing equal stored hashes.
+ * The server-side pepper keeps leaked DB rows from being directly reusable for
+ * offline precomputation unless the deployment secret is also compromised.
  */
-export function createApiKey(name: string): ApiKeyCreated {
+export function hashApiKeyForStorage(rawKey: string, salt: string, pepper = resolvePepper()): string {
+  return hmacHex(pepper, 'api-key:v1:storage', salt, rawKey);
+}
+
+/**
+ * Build the indexed lookup hash from the short display prefix.
+ *
+ * Validation uses this value to fetch a tiny candidate set instead of scanning
+ * all active keys. The DB index stores a pepper-keyed hash, not the raw lookup
+ * material, so it does not expose the whole credential or the pepper.
+ */
+export function hashApiKeyLookupPrefix(prefix: string, pepper = resolvePepper()): string {
+  return hmacHex(pepper, 'api-key:v1:lookup', prefix);
+}
+
+function deriveKeyMaterial(rawKey: string): { keyHash: string; keySalt: string; lookupHash: string; prefix: string } {
+  const keySalt = generateSalt();
+  const prefix = rawKey.slice(0, DISPLAY_PREFIX_LENGTH);
+  return {
+    keyHash: hashApiKeyForStorage(rawKey, keySalt),
+    keySalt,
+    lookupHash: hashApiKeyLookupPrefix(prefix),
+    prefix,
+  };
+}
+
+function isConstantTimeEqualHex(a: string, b: string): boolean {
+  try {
+    const aBuf = Buffer.from(a, 'hex');
+    const bBuf = Buffer.from(b, 'hex');
+    return aBuf.length === bBuf.length && timingSafeEqual(aBuf, bBuf);
+  } catch {
+    return false;
+  }
+}
+
+function assertValidName(name: string): string {
   if (!name || typeof name !== 'string' || !name.trim()) {
     throw new Error('name is required');
   }
+  return name.trim();
+}
 
-  const raw = generateRawKey();
-  const id = createId();
-  const now = new Date().toISOString();
+export function setApiKeyStoreForTest(nextStore: ApiKeyStore): void {
+  store = nextStore;
+}
 
-  const record: ApiKeyRecord = {
-    id,
-    name: name.trim(),
-    keyHash: sha256hex(raw),
-    prefix: raw.slice(0, 8),
-    createdAt: now,
-    rotatedAt: null,
-    active: true,
-  };
-
-  store.set(id, record);
-
-  return { id, name: record.name, key: raw, prefix: record.prefix, createdAt: now };
+export function resetApiKeyStore(): void {
+  store = apiKeyRepository;
 }
 
 /**
- * Rotates an existing key: invalidates the old hash and issues a new raw key.
- * Returns the new raw key (shown once).
+ * Creates a new API key. Returns the record plus the raw key, shown once.
  */
-export function rotateApiKey(id: string): ApiKeyCreated {
-  const record = store.get(id);
-  if (!record) throw new Error(`API key not found: ${id}`);
-  if (!record.active) throw new Error(`API key is revoked: ${id}`);
+export async function createApiKey(name: string): Promise<ApiKeyCreated> {
+  const trimmedName = assertValidName(name);
+  const raw = generateRawKey();
+  const id = createId();
+  const now = new Date().toISOString();
+  const material = deriveKeyMaterial(raw);
+
+  const record = await store.create({
+    id,
+    name: trimmedName,
+    ...material,
+    createdAt: now,
+    rotatedAt: null,
+  });
+
+  return { id: record.id, name: record.name, key: raw, prefix: record.prefix, createdAt: record.createdAt };
+}
+
+/**
+ * Rotates an existing key and immediately invalidates the old raw key.
+ */
+export async function rotateApiKey(id: string): Promise<ApiKeyCreated> {
+  const existing = await store.findById(id);
+  if (!existing) throw new Error(`API key not found: ${id}`);
+  if (!existing.active) throw new Error(`API key is revoked: ${id}`);
 
   const raw = generateRawKey();
   const now = new Date().toISOString();
+  const material = deriveKeyMaterial(raw);
+  const rotated = await store.rotate(id, { ...material, rotatedAt: now });
+  if (!rotated) throw new Error(`API key is revoked: ${id}`);
 
-  const updated: ApiKeyRecord = {
-    ...record,
-    keyHash: sha256hex(raw),
-    prefix: raw.slice(0, 8),
-    rotatedAt: now,
-  };
-
-  store.set(id, updated);
-
-  return { id, name: record.name, key: raw, prefix: updated.prefix, createdAt: record.createdAt };
+  return { id, name: rotated.name, key: raw, prefix: rotated.prefix, createdAt: rotated.createdAt };
 }
 
 /**
  * Revokes an API key so it can no longer authenticate requests.
  */
-export function revokeApiKey(id: string): void {
-  const record = store.get(id);
+export async function revokeApiKey(id: string): Promise<void> {
+  const record = await store.revoke(id, new Date().toISOString());
   if (!record) throw new Error(`API key not found: ${id}`);
-
-  store.set(id, { ...record, active: false });
 }
 
 /**
- * Returns all stored key records (hashes only — raw keys are never stored).
+ * Returns all stored key records. Raw keys, salts, and lookup hashes are never returned.
  */
-export function listApiKeys(): ApiKeyRecord[] {
-  return Array.from(store.values());
+export async function listApiKeys(): Promise<ApiKeyRecord[]> {
+  return store.list();
 }
 
 /**
- * Validates a raw API key against the stored hashes using constant-time comparison.
+ * Validates a raw API key via indexed lookup plus constant-time candidate comparison.
  */
-export function isValidApiKey(rawKey: string): boolean {
+export async function isValidApiKey(rawKey: string): Promise<boolean> {
   if (!rawKey) return false;
 
-  const hash = sha256hex(rawKey);
-  const hashBuf = Buffer.from(hash, 'hex');
-
-  for (const record of store.values()) {
-    if (!record.active) continue;
-    try {
-      const storedBuf = Buffer.from(record.keyHash, 'hex');
-      if (storedBuf.length === hashBuf.length && timingSafeEqual(storedBuf, hashBuf)) {
-        return true;
-      }
-    } catch {
-      // length mismatch — skip
+  const prefix = rawKey.slice(0, DISPLAY_PREFIX_LENGTH);
+  const candidates = await store.findActiveByLookupHash(hashApiKeyLookupPrefix(prefix));
+  for (const record of candidates) {
+    const candidateHash = hashApiKeyForStorage(rawKey, record.keySalt);
+    if (isConstantTimeEqualHex(record.keyHash, candidateHash)) {
+      return true;
     }
   }
 
@@ -128,7 +201,7 @@ export function getApiKeyFromRequest(
   return key;
 }
 
-/** Exposed for tests only — clears the in-memory store. */
-export function _resetApiKeyStoreForTest(): void {
-  store.clear();
+/** Exposed for tests only. */
+export async function _resetApiKeyStoreForTest(): Promise<void> {
+  await store.deleteAllForTest();
 }

--- a/src/routes/admin.ts
+++ b/src/routes/admin.ts
@@ -9,6 +9,7 @@ import {
 } from '../state/adminState.js';
 import { createApiKey, rotateApiKey, revokeApiKey, listApiKeys } from '../lib/apiKey.js';
 import { recordAuditEvent, recordAuditEventToDb } from '../lib/auditLog.js';
+import { asyncHandler } from '../middleware/errorHandler.js';
 import { getStreamHub } from '../ws/hub.js';
 
 export const adminRouter = Router();
@@ -167,7 +168,7 @@ adminRouter.post('/ws/disconnect', async (req, res) => {
       closeCode: 4000,
       closeReason: 'admin-forced-disconnect',
     });
-  } catch (err) {
+  } catch {
     res.status(503).json({
       error: 'Unable to persist audit log entry. Try again later.',
       disconnectedCount,
@@ -188,9 +189,9 @@ adminRouter.post('/ws/disconnect', async (req, res) => {
  * GET /api/admin/api-keys
  * Lists all API key records (hashes only — raw keys are never returned).
  */
-adminRouter.get('/api-keys', (_req, res) => {
-  res.json({ apiKeys: listApiKeys() });
-});
+adminRouter.get('/api-keys', asyncHandler(async (_req, res) => {
+  res.json({ apiKeys: await listApiKeys() });
+}));
 
 /**
  * POST /api/admin/api-keys
@@ -198,15 +199,15 @@ adminRouter.get('/api-keys', (_req, res) => {
  *
  * Body: { "name": "my-service" }
  */
-adminRouter.post('/api-keys', (req, res) => {
+adminRouter.post('/api-keys', asyncHandler(async (req, res) => {
   const { name } = req.body ?? {};
   if (!name || typeof name !== 'string') {
     res.status(400).json({ error: 'name (string) is required.' });
     return;
   }
   try {
-    const created = createApiKey(name);
-    recordAuditEvent(
+    const created = await createApiKey(name);
+    await recordAuditEventToDb(
       'API_KEY_CREATED',
       'api_key',
       created.id,
@@ -220,17 +221,17 @@ adminRouter.post('/api-keys', (req, res) => {
   } catch (err) {
     res.status(400).json({ error: err instanceof Error ? err.message : String(err) });
   }
-});
+}));
 
 /**
  * POST /api/admin/api-keys/:id/rotate
  * Issues a new raw key for an existing key record. The old key is immediately
  * invalidated. The new raw key is returned exactly once.
  */
-adminRouter.post('/api-keys/:id/rotate', (req, res) => {
+adminRouter.post('/api-keys/:id/rotate', asyncHandler(async (req, res) => {
   try {
-    const rotated = rotateApiKey(req.params.id);
-    recordAuditEvent(
+    const rotated = await rotateApiKey(req.params.id);
+    await recordAuditEventToDb(
       'API_KEY_ROTATED',
       'api_key',
       rotated.id,
@@ -246,16 +247,16 @@ adminRouter.post('/api-keys/:id/rotate', (req, res) => {
     const status = msg.includes('not found') ? 404 : 400;
     res.status(status).json({ error: msg });
   }
-});
+}));
 
 /**
  * DELETE /api/admin/api-keys/:id
  * Revokes an API key. Revoked keys cannot authenticate requests.
  */
-adminRouter.delete('/api-keys/:id', (req, res) => {
+adminRouter.delete('/api-keys/:id', asyncHandler(async (req, res) => {
   try {
-    revokeApiKey(req.params.id);
-    recordAuditEvent(
+    await revokeApiKey(req.params.id);
+    await recordAuditEventToDb(
       'API_KEY_REVOKED',
       'api_key',
       req.params.id,
@@ -267,4 +268,4 @@ adminRouter.delete('/api-keys/:id', (req, res) => {
     const status = msg.includes('not found') ? 404 : 400;
     res.status(status).json({ error: msg });
   }
-});
+}));

--- a/tests/config/apiKeyPepper.test.ts
+++ b/tests/config/apiKeyPepper.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { ConfigError, loadConfig, resetConfig } from '../../src/config/env.js';
+
+const originalEnv = { ...process.env };
+
+function restoreEnv(): void {
+  Object.keys(process.env).forEach((key) => delete process.env[key]);
+  Object.assign(process.env, originalEnv);
+  resetConfig();
+}
+
+function setBaseEnv(): void {
+  process.env.DATABASE_URL = 'postgresql://localhost/fluxora';
+  process.env.JWT_SECRET = 'a'.repeat(32);
+  process.env.INDEXER_WORKER_TOKEN = 'b'.repeat(32);
+  process.env.STELLAR_NETWORK = 'testnet';
+  process.env.STELLAR_CONTRACT_ADDRESS = 'CASTMR2YNF5IXHFNX3H6B4ICCMSDKRSXNB4YVG5MXXHN74ABCIRTISIC';
+  process.env.STELLAR_TOKEN_ADDRESS = 'CBFFW3D5R2P3BQOS4P2AKFRHHBEVU234RWPK7QGR4LZQIFJGG5EFTAK6';
+}
+
+describe('API_KEY_PEPPER configuration', () => {
+  afterEach(restoreEnv);
+
+  it('rejects too-short API_KEY_PEPPER', () => {
+    restoreEnv();
+    setBaseEnv();
+    process.env.NODE_ENV = 'development';
+    process.env.API_KEY_PEPPER = 'short';
+
+    expect(() => loadConfig()).toThrow(ConfigError);
+  });
+
+  it('requires API_KEY_PEPPER in production', () => {
+    restoreEnv();
+    setBaseEnv();
+    process.env.NODE_ENV = 'production';
+    delete process.env.API_KEY_PEPPER;
+
+    expect(() => loadConfig()).toThrow(ConfigError);
+  });
+
+  it('exposes API_KEY_PEPPER when configured', () => {
+    restoreEnv();
+    setBaseEnv();
+    process.env.NODE_ENV = 'development';
+    process.env.API_KEY_PEPPER = 'p'.repeat(32);
+
+    expect(loadConfig().apiKeyPepper).toBe('p'.repeat(32));
+  });
+});

--- a/tests/db/apiKeyRepository.test.ts
+++ b/tests/db/apiKeyRepository.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import type pg from 'pg';
+import { apiKeyRepository } from '../../src/db/repositories/apiKeyRepository.js';
+import { setPool } from '../../src/db/pool.js';
+
+function makePool(rows: Record<string, unknown>[] = []): pg.Pool {
+  return {
+    waitingCount: 0,
+    totalCount: 0,
+    idleCount: 0,
+    query: vi.fn().mockResolvedValue({
+      rows,
+      rowCount: rows.length,
+      command: 'SELECT',
+      oid: 0,
+      fields: [],
+    }),
+  } as unknown as pg.Pool;
+}
+
+describe('apiKeyRepository', () => {
+  afterEach(() => {
+    setPool(null);
+  });
+
+  it('looks up active keys by indexed lookup_hash rather than scanning all rows', async () => {
+    const pool = makePool([]);
+    setPool(pool);
+
+    await apiKeyRepository.findActiveByLookupHash('a'.repeat(64));
+
+    expect(pool.query).toHaveBeenCalledTimes(1);
+    const [sql, params] = (pool.query as ReturnType<typeof vi.fn>).mock.calls[0]!;
+    expect(sql).toContain('WHERE lookup_hash = $1 AND revoked_at IS NULL');
+    expect(sql).not.toMatch(/SELECT \*/);
+    expect(params).toEqual(['a'.repeat(64)]);
+  });
+
+  it('omits key_salt and lookup_hash from public list records', async () => {
+    const pool = makePool([
+      {
+        id: 'key-1',
+        name: 'service-a',
+        key_hash: 'b'.repeat(64),
+        key_salt: 'c'.repeat(32),
+        lookup_hash: 'd'.repeat(64),
+        prefix: 'flx_abcd',
+        created_at: new Date('2026-06-22T00:00:00.000Z'),
+        rotated_at: null,
+        revoked_at: null,
+      },
+    ]);
+    setPool(pool);
+
+    const records = await apiKeyRepository.list();
+
+    expect(records).toEqual([
+      {
+        id: 'key-1',
+        name: 'service-a',
+        keyHash: 'b'.repeat(64),
+        prefix: 'flx_abcd',
+        createdAt: '2026-06-22T00:00:00.000Z',
+        rotatedAt: null,
+        revokedAt: null,
+        active: true,
+      },
+    ]);
+    expect(records[0]).not.toHaveProperty('keySalt');
+    expect(records[0]).not.toHaveProperty('lookupHash');
+  });
+});

--- a/tests/lib/auth.test.ts
+++ b/tests/lib/auth.test.ts
@@ -1,6 +1,8 @@
 import { describe, it, expect, beforeEach, beforeAll } from 'vitest';
 import { generateToken, verifyToken, UserPayload } from '../../src/lib/auth.js';
 import { initializeConfig } from '../../src/config/env.js';
+import type { ApiKeyRecord, ApiKeyStoredRecord } from '../../src/db/types.js';
+import type { ApiKeyStore } from '../../src/lib/apiKey.js';
 import {
   createApiKey,
   rotateApiKey,
@@ -8,13 +10,64 @@ import {
   listApiKeys,
   isValidApiKey,
   _resetApiKeyStoreForTest,
+  hashApiKeyLookupPrefix,
+  setApiKeyStoreForTest,
 } from '../../src/lib/apiKey.js';
 
-// ─── JWT ──────────────────────────────────────────────────────────────────────
+function publicRecord(record: ApiKeyStoredRecord): ApiKeyRecord {
+  return {
+    id: record.id,
+    name: record.name,
+    keyHash: record.keyHash,
+    prefix: record.prefix,
+    createdAt: record.createdAt,
+    rotatedAt: record.rotatedAt,
+    revokedAt: record.revokedAt,
+    active: record.active,
+  };
+}
 
+function createMemoryApiKeyStore(): ApiKeyStore & { records: Map<string, ApiKeyStoredRecord> } {
+  const records = new Map<string, ApiKeyStoredRecord>();
+  return {
+    records,
+    async create(input) {
+      const record: ApiKeyStoredRecord = { ...input, revokedAt: null, active: true };
+      records.set(record.id, record);
+      return publicRecord(record);
+    },
+    async findById(id) {
+      const record = records.get(id);
+      return record ? publicRecord(record) : undefined;
+    },
+    async findActiveByLookupHash(lookupHash) {
+      return [...records.values()].filter((record) => record.active && record.lookupHash === lookupHash);
+    },
+    async list() {
+      return [...records.values()].map(publicRecord);
+    },
+    async rotate(id, input) {
+      const current = records.get(id);
+      if (!current || !current.active) return undefined;
+      const next = { ...current, ...input };
+      records.set(id, next);
+      return publicRecord(next);
+    },
+    async revoke(id, revokedAt) {
+      const current = records.get(id);
+      if (!current) return undefined;
+      const next = { ...current, revokedAt, active: false };
+      records.set(id, next);
+      return publicRecord(next);
+    },
+    async deleteAllForTest() {
+      records.clear();
+    },
+  };
+}
+
+// JWT
 describe('Auth Module', () => {
-  // generateToken/verifyToken consult the loaded Config for jwtSecret /
-  // jwtExpiresIn, so we must initialise the env-config before exercising them.
   beforeAll(() => {
     process.env.NODE_ENV = 'test';
     process.env.JWT_SECRET = 'a-very-long-secret-key-for-testing-only-12345';
@@ -50,108 +103,118 @@ describe('Auth Module', () => {
   });
 });
 
-// ─── API Key Management ───────────────────────────────────────────────────────
-
+// API Key Management
 describe('API Key Management', () => {
-  beforeEach(() => {
-    _resetApiKeyStoreForTest();
+  let memoryStore: ReturnType<typeof createMemoryApiKeyStore>;
+
+  beforeEach(async () => {
+    process.env.NODE_ENV = 'test';
+    process.env.API_KEY_PEPPER = 'test-pepper-for-api-key-unit-tests-12345';
+    memoryStore = createMemoryApiKeyStore();
+    setApiKeyStoreForTest(memoryStore);
+    await _resetApiKeyStoreForTest();
   });
 
   describe('createApiKey', () => {
-    it('returns a raw key and record metadata', () => {
-      const result = createApiKey('my-service');
+    it('returns a raw key and record metadata', async () => {
+      const result = await createApiKey('my-service');
       expect(result.key).toMatch(/^flx_[0-9a-f]{64}$/);
       expect(result.name).toBe('my-service');
       expect(result.id).toBeTruthy();
       expect(result.prefix).toBe(result.key.slice(0, 8));
     });
 
-    it('stores the key as a hash (raw key not in store)', () => {
-      const { key, id } = createApiKey('svc');
-      const records = listApiKeys();
+    it('stores the key as a salted peppered hash without raw key material', async () => {
+      const { key, id } = await createApiKey('svc');
+      const records = await listApiKeys();
       const record = records.find((r) => r.id === id)!;
+      const internal = memoryStore.records.get(id)!;
+
       expect(record.keyHash).not.toBe(key);
-      expect(record.keyHash).toHaveLength(64); // sha256 hex
+      expect(record.keyHash).toHaveLength(64);
+      expect(internal.keySalt).toHaveLength(32);
+      expect(internal.lookupHash).toBe(hashApiKeyLookupPrefix(key.slice(0, 8)));
     });
 
-    it('throws when name is empty', () => {
-      expect(() => createApiKey('')).toThrow('name is required');
+    it('throws when name is empty', async () => {
+      await expect(createApiKey('')).rejects.toThrow('name is required');
     });
 
-    it('multiple keys are independent', () => {
-      const a = createApiKey('a');
-      const b = createApiKey('b');
+    it('multiple keys are independent', async () => {
+      const a = await createApiKey('a');
+      const b = await createApiKey('b');
       expect(a.id).not.toBe(b.id);
       expect(a.key).not.toBe(b.key);
     });
   });
 
   describe('isValidApiKey', () => {
-    it('accepts a freshly created key', () => {
-      const { key } = createApiKey('svc');
-      expect(isValidApiKey(key)).toBe(true);
+    it('accepts a freshly created key', async () => {
+      const { key } = await createApiKey('svc');
+      await expect(isValidApiKey(key)).resolves.toBe(true);
     });
 
-    it('rejects an unknown key', () => {
-      createApiKey('svc');
-      expect(isValidApiKey('flx_notakey')).toBe(false);
+    it('rejects an unknown key without scanning unrelated prefixes', async () => {
+      await createApiKey('svc');
+      await expect(isValidApiKey('flx_notakey')).resolves.toBe(false);
     });
 
-    it('rejects empty string', () => {
-      expect(isValidApiKey('')).toBe(false);
+    it('rejects empty string', async () => {
+      await expect(isValidApiKey('')).resolves.toBe(false);
     });
   });
 
   describe('rotateApiKey', () => {
-    it('issues a new key and invalidates the old one', () => {
-      const { key: oldKey, id } = createApiKey('svc');
-      const { key: newKey } = rotateApiKey(id);
+    it('issues a new key and invalidates the old one', async () => {
+      const { key: oldKey, id } = await createApiKey('svc');
+      const { key: newKey } = await rotateApiKey(id);
 
       expect(newKey).not.toBe(oldKey);
-      expect(isValidApiKey(oldKey)).toBe(false);
-      expect(isValidApiKey(newKey)).toBe(true);
+      await expect(isValidApiKey(oldKey)).resolves.toBe(false);
+      await expect(isValidApiKey(newKey)).resolves.toBe(true);
     });
 
-    it('updates rotatedAt timestamp', () => {
-      const { id } = createApiKey('svc');
-      rotateApiKey(id);
-      const record = listApiKeys().find((r) => r.id === id)!;
+    it('updates rotatedAt timestamp', async () => {
+      const { id } = await createApiKey('svc');
+      await rotateApiKey(id);
+      const record = (await listApiKeys()).find((r) => r.id === id)!;
       expect(record.rotatedAt).not.toBeNull();
     });
 
-    it('throws for unknown id', () => {
-      expect(() => rotateApiKey('nonexistent')).toThrow('not found');
+    it('throws for unknown id', async () => {
+      await expect(rotateApiKey('nonexistent')).rejects.toThrow('not found');
     });
 
-    it('throws when key is already revoked', () => {
-      const { id } = createApiKey('svc');
-      revokeApiKey(id);
-      expect(() => rotateApiKey(id)).toThrow('revoked');
+    it('throws when key is already revoked', async () => {
+      const { id } = await createApiKey('svc');
+      await revokeApiKey(id);
+      await expect(rotateApiKey(id)).rejects.toThrow('revoked');
     });
   });
 
   describe('revokeApiKey', () => {
-    it('marks key inactive and rejects further auth', () => {
-      const { key, id } = createApiKey('svc');
-      revokeApiKey(id);
+    it('marks key inactive and rejects further auth', async () => {
+      const { key, id } = await createApiKey('svc');
+      await revokeApiKey(id);
 
-      expect(isValidApiKey(key)).toBe(false);
-      const record = listApiKeys().find((r) => r.id === id)!;
+      await expect(isValidApiKey(key)).resolves.toBe(false);
+      const record = (await listApiKeys()).find((r) => r.id === id)!;
       expect(record.active).toBe(false);
+      expect(record.revokedAt).not.toBeNull();
     });
 
-    it('throws for unknown id', () => {
-      expect(() => revokeApiKey('nonexistent')).toThrow('not found');
+    it('throws for unknown id', async () => {
+      await expect(revokeApiKey('nonexistent')).rejects.toThrow('not found');
     });
   });
 
   describe('listApiKeys', () => {
-    it('returns all records including revoked ones', () => {
-      const { id: id1 } = createApiKey('a');
-      const { id: id2 } = createApiKey('b');
-      revokeApiKey(id2);
+    it('returns all records including revoked ones', async () => {
+      const { id: id1 } = await createApiKey('a');
+      const { id: id2 } = await createApiKey('b');
+      await revokeApiKey(id2);
 
-      const list = listApiKeys();
+      const list = await listApiKeys();
       expect(list).toHaveLength(2);
       expect(list.find((r) => r.id === id1)!.active).toBe(true);
       expect(list.find((r) => r.id === id2)!.active).toBe(false);

--- a/tests/routes/admin.apiKeys.test.ts
+++ b/tests/routes/admin.apiKeys.test.ts
@@ -1,7 +1,87 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import express from 'express';
 import request from 'supertest';
-import { app } from '../../src/app.js';
-import { _resetApiKeyStoreForTest } from '../../src/lib/apiKey.js';
+import type { ApiKeyRecord, ApiKeyStoredRecord } from '../../src/db/types.js';
+import type { ApiKeyStore } from '../../src/lib/apiKey.js';
+
+function publicRecord(record: ApiKeyStoredRecord): ApiKeyRecord {
+  return {
+    id: record.id,
+    name: record.name,
+    keyHash: record.keyHash,
+    prefix: record.prefix,
+    createdAt: record.createdAt,
+    rotatedAt: record.rotatedAt,
+    revokedAt: record.revokedAt,
+    active: record.active,
+  };
+}
+
+const repositoryMock = vi.hoisted(() => {
+  const records = new Map<string, ApiKeyStoredRecord>();
+  const recordAuditEventToDb = vi.fn().mockResolvedValue({
+    seq: 1,
+    timestamp: '2026-06-22T00:00:00.000Z',
+    action: 'API_KEY_CREATED',
+    resourceType: 'api_key',
+    resourceId: 'key-1',
+  });
+  const repo: ApiKeyStore & { records: Map<string, ApiKeyStoredRecord> } = {
+    records,
+    async create(input) {
+      const record: ApiKeyStoredRecord = { ...input, revokedAt: null, active: true };
+      records.set(record.id, record);
+      return publicRecord(record);
+    },
+    async findById(id) {
+      const record = records.get(id);
+      return record ? publicRecord(record) : undefined;
+    },
+    async findActiveByLookupHash(lookupHash) {
+      return [...records.values()].filter((record) => record.active && record.lookupHash === lookupHash);
+    },
+    async list() {
+      return [...records.values()].map(publicRecord);
+    },
+    async rotate(id, input) {
+      const current = records.get(id);
+      if (!current || !current.active) return undefined;
+      const next = { ...current, ...input };
+      records.set(id, next);
+      return publicRecord(next);
+    },
+    async revoke(id, revokedAt) {
+      const current = records.get(id);
+      if (!current) return undefined;
+      const next = { ...current, revokedAt, active: false };
+      records.set(id, next);
+      return publicRecord(next);
+    },
+    async deleteAllForTest() {
+      records.clear();
+    },
+  };
+  return { repo, recordAuditEventToDb };
+});
+
+vi.mock('../../src/db/repositories/apiKeyRepository.js', () => ({
+  apiKeyRepository: repositoryMock.repo,
+}));
+
+vi.mock('../../src/lib/auditLog.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../src/lib/auditLog.js')>();
+  return {
+    ...actual,
+    recordAuditEventToDb: repositoryMock.recordAuditEventToDb,
+  };
+});
+
+const { adminRouter } = await import('../../src/routes/admin.js');
+const { _resetApiKeyStoreForTest } = await import('../../src/lib/apiKey.js');
+
+const app = express();
+app.use(express.json());
+app.use('/api/admin', adminRouter);
 
 const ADMIN_KEY = 'test-admin-key-for-apikey-routes';
 
@@ -11,11 +91,15 @@ function authed(req: request.Test): request.Test {
 
 describe('admin API key routes', () => {
   let originalKey: string | undefined;
+  let originalPepper: string | undefined;
 
-  beforeEach(() => {
+  beforeEach(async () => {
     originalKey = process.env.ADMIN_API_KEY;
+    originalPepper = process.env.API_KEY_PEPPER;
     process.env.ADMIN_API_KEY = ADMIN_KEY;
-    _resetApiKeyStoreForTest();
+    process.env.API_KEY_PEPPER = 'test-pepper-for-admin-api-key-routes-12345';
+    repositoryMock.recordAuditEventToDb.mockClear();
+    await _resetApiKeyStoreForTest();
   });
 
   afterEach(() => {
@@ -24,9 +108,13 @@ describe('admin API key routes', () => {
     } else {
       delete process.env.ADMIN_API_KEY;
     }
+    if (originalPepper !== undefined) {
+      process.env.API_KEY_PEPPER = originalPepper;
+    } else {
+      delete process.env.API_KEY_PEPPER;
+    }
   });
 
-  // 1. unauthorized requests → 401
   it('rejects unauthenticated GET to API keys list with 401', async () => {
     const res = await request(app).get('/api/admin/api-keys');
     expect(res.status).toBe(401);
@@ -37,7 +125,6 @@ describe('admin API key routes', () => {
     expect(res.status).toBe(401);
   });
 
-  // 2. invalid credentials → 403
   it('rejects GET with bad credentials to API keys list with 403', async () => {
     const res = await request(app)
       .get('/api/admin/api-keys')
@@ -45,36 +132,40 @@ describe('admin API key routes', () => {
     expect(res.status).toBe(403);
   });
 
-  // 3. authenticated API-key creation
   it('creates an API key with 201 when authenticated', async () => {
     const res = await authed(
       request(app)
         .post('/api/admin/api-keys')
-        .send({ name: 'service-a' })
+        .send({ name: 'service-a' }),
     );
     expect(res.status).toBe(201);
     expect(res.body).toHaveProperty('id');
     expect(res.body.name).toBe('service-a');
-    expect(res.body).toHaveProperty('key'); // Raw key should be returned
+    expect(res.body).toHaveProperty('key');
     expect(res.body.key).toMatch(/^flx_/);
+    expect(repositoryMock.recordAuditEventToDb).toHaveBeenCalledWith(
+      'API_KEY_CREATED',
+      'api_key',
+      res.body.id,
+      undefined,
+      { prefix: res.body.prefix, name: 'service-a' },
+    );
   });
 
   it('rejects creation when name is missing or invalid with 400', async () => {
     const res = await authed(
       request(app)
         .post('/api/admin/api-keys')
-        .send({})
+        .send({}),
     );
     expect(res.status).toBe(400);
   });
 
-  // 4. authenticated API-key listing
-  it('lists API keys when authenticated', async () => {
-    // First seed a key
+  it('lists API keys without raw keys, salts, or lookup hashes', async () => {
     await authed(
       request(app)
         .post('/api/admin/api-keys')
-        .send({ name: 'service-a' })
+        .send({ name: 'service-a' }),
     );
 
     const res = await authed(request(app).get('/api/admin/api-keys'));
@@ -82,57 +173,82 @@ describe('admin API key routes', () => {
     expect(res.body).toHaveProperty('apiKeys');
     expect(res.body.apiKeys).toHaveLength(1);
     expect(res.body.apiKeys[0].name).toBe('service-a');
-    expect(res.body.apiKeys[0]).not.toHaveProperty('key'); // Raw key must never be listed
+    expect(res.body.apiKeys[0]).not.toHaveProperty('key');
+    expect(res.body.apiKeys[0]).not.toHaveProperty('keySalt');
+    expect(res.body.apiKeys[0]).not.toHaveProperty('lookupHash');
     expect(res.body.apiKeys[0]).toHaveProperty('keyHash');
   });
 
-  // 5. authenticated API-key deletion
   it('revokes an API key with 204 when authenticated', async () => {
     const createRes = await authed(
       request(app)
         .post('/api/admin/api-keys')
-        .send({ name: 'service-a' })
+        .send({ name: 'service-a' }),
     );
     const keyId = createRes.body.id;
 
-    // Delete (revoke) key
     const deleteRes = await authed(
-      request(app).delete(`/api/admin/api-keys/${keyId}`)
+      request(app).delete(`/api/admin/api-keys/${keyId}`),
     );
     expect(deleteRes.status).toBe(204);
 
-    // Verify it is deactivated in listing
     const listRes = await authed(request(app).get('/api/admin/api-keys'));
     expect(listRes.body.apiKeys[0].active).toBe(false);
+    expect(listRes.body.apiKeys[0].revokedAt).not.toBeNull();
+    expect(repositoryMock.recordAuditEventToDb).toHaveBeenCalledWith(
+      'API_KEY_REVOKED',
+      'api_key',
+      keyId,
+      undefined,
+    );
+  });
+
+  it('rotates an API key and writes a durable audit row', async () => {
+    const createRes = await authed(
+      request(app)
+        .post('/api/admin/api-keys')
+        .send({ name: 'service-a' }),
+    );
+
+    const rotateRes = await authed(
+      request(app).post(`/api/admin/api-keys/${createRes.body.id}/rotate`),
+    );
+
+    expect(rotateRes.status).toBe(200);
+    expect(rotateRes.body.key).toMatch(/^flx_/);
+    expect(rotateRes.body.key).not.toBe(createRes.body.key);
+    expect(repositoryMock.recordAuditEventToDb).toHaveBeenCalledWith(
+      'API_KEY_ROTATED',
+      'api_key',
+      createRes.body.id,
+      undefined,
+      { prefix: rotateRes.body.prefix, name: 'service-a' },
+    );
   });
 
   it('returns 404 when revoking non-existent API key', async () => {
     const res = await authed(
-      request(app).delete('/api/admin/api-keys/does-not-exist')
+      request(app).delete('/api/admin/api-keys/does-not-exist'),
     );
     expect(res.status).toBe(404);
   });
 
-  // 6. duplicate API-key name handling
   it('handles duplicate API-key name gracefully', async () => {
-    // Create first key
     const res1 = await authed(
       request(app)
         .post('/api/admin/api-keys')
-        .send({ name: 'service-a' })
+        .send({ name: 'service-a' }),
     );
     expect(res1.status).toBe(201);
 
-    // Create second key with duplicate name
     const res2 = await authed(
       request(app)
         .post('/api/admin/api-keys')
-        .send({ name: 'service-a' })
+        .send({ name: 'service-a' }),
     );
     expect(res2.status).toBe(201);
     expect(res2.body.id).not.toBe(res1.body.id);
 
-    // Verify both are present in the list
     const listRes = await authed(request(app).get('/api/admin/api-keys'));
     expect(listRes.body.apiKeys).toHaveLength(2);
     expect(listRes.body.apiKeys[0].name).toBe('service-a');

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -19,6 +19,8 @@ process.env.DATABASE_URL =
   process.env.DATABASE_URL ?? 'postgresql://localhost/fluxora_test';
 process.env.JWT_SECRET =
   process.env.JWT_SECRET ?? 'a-very-long-secret-key-for-testing-only-12345';
+process.env.API_KEY_PEPPER =
+  process.env.API_KEY_PEPPER ?? 'api-key-pepper-for-testing-only-123456';
 process.env.INDEXER_WORKER_TOKEN =
   process.env.INDEXER_WORKER_TOKEN ?? 'indexer-worker-token-for-testing-only-12345';
 process.env.STELLAR_NETWORK = process.env.STELLAR_NETWORK ?? 'testnet';


### PR DESCRIPTION
Closes #332.

## Summary
- replace the process-local API key Map with a Postgres-backed `api_keys` repository and migration
- store only salted, peppered HMAC hashes plus an indexed peppered `lookup_hash` for prefix-based candidate lookup
- keep raw keys returned once on create/rotate, hide salts and lookup hashes from list responses, and preserve constant-time comparison on candidate rows
- require `API_KEY_PEPPER` in production and document the storage/security model
- write durable audit log rows for create/rotate/revoke API key operations

## Validation
- `node.exe .\\node_modules\\vitest\\vitest.mjs run tests\\lib\\auth.test.ts tests\\routes\\admin.apiKeys.test.ts tests\\db\\apiKeyRepository.test.ts tests\\config\\apiKeyPepper.test.ts --reporter=dot` (33 passed)
- `node.exe .\\node_modules\\eslint\\bin\\eslint.js src\\lib\\apiKey.ts src\\db\\repositories\\apiKeyRepository.ts src\\db\\types.ts src\\routes\\admin.ts tests\\lib\\auth.test.ts tests\\routes\\admin.apiKeys.test.ts tests\\db\\apiKeyRepository.test.ts src\\config\\env.ts tests\\config\\apiKeyPepper.test.ts tests\\setup.ts` (0 errors; existing module-type warning only)
- `node.exe --import tsx -e "const m = await import('./migrations/1774715400000_api-keys.ts'); if (typeof m.up !== 'function' || typeof m.down !== 'function') throw new Error('missing migration exports'); console.log('migration exports ok')"`
- `git diff --check`

## Notes
- Full `tsc --noEmit --pretty false` is still blocked by the existing repository baseline syntax error in `src/openapi/spec.ts` around line 294; filtering the output for the touched files produced no matching errors.
- Ordinary HTTPS `git push` could not connect to `github.com:443` from the local environment, so the fork branch was created through GitHub Git Data API using Git Credential Manager authorization. The remote commit tree matches the local commit tree.