### PR TITLE
feat(db): partition contract events retention

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,8 +39,9 @@ pnpm run migrate
 
 This creates:
 - `historical_events` table (source data)
-- `contract_events` table (replay destination)
-- Optimized indexes for replay queries
+- `contract_events` table (ledger-partitioned replay destination)
+- Optimized parent and per-partition indexes for replay queries
+- Partition helper routines and guarded retention operations
 
 ## 🏃 Running the Service
 
@@ -141,6 +142,16 @@ The test suite includes:
 | `DATABASE_URL` | - | PostgreSQL connection string (required) |
 | `REPLAY_BATCH_SIZE` | 1000 | Number of events per batch insert |
 | `PORT` | 3000 | HTTP server port |
+
+### Contract Event Retention
+
+`contract_events` is partitioned by ledger. Create upcoming partitions with:
+
+```sql
+SELECT ensure_contract_events_partition(1000000, 1100000);
+```
+
+Retention is exposed through `enforceContractEventsRetention()` from `src/scripts/db-ops.ts`. It defaults to dry-run, live detach requires `confirm: true`, and destructive drop also requires `backupConfirmed: true`.
 
 ### Batch Size Tuning
 

--- a/docs/indexer.md
+++ b/docs/indexer.md
@@ -8,6 +8,8 @@ The contract event indexer provides efficient replay of historical blockchain ev
 
 - **Batch Insert Processing**: Events are inserted in configurable batches to minimize database round-trips
 - **Optimized Indexes**: Composite and partial indexes for fast replay queries
+- **Ledger Partitions**: `contract_events` is range-partitioned by ledger for bounded replay scans and cheaper maintenance
+- **Retention Guardrails**: Partition retention defaults to dry-run and requires explicit confirmation before detach/drop
 - **Progress Tracking**: Real-time progress monitoring with estimated completion times
 - **Duplicate Handling**: Automatic deduplication using `ON CONFLICT DO NOTHING`
 - **Transaction Safety**: Full ACID compliance with automatic rollback on errors
@@ -165,21 +167,42 @@ Destination table for replayed events.
 
 ```sql
 CREATE TABLE contract_events (
-  event_id VARCHAR(255) PRIMARY KEY,
+  event_id VARCHAR(255) NOT NULL,
   contract_id VARCHAR(255) NOT NULL,
   ledger INTEGER NOT NULL,
-  event_type VARCHAR(100) NOT NULL,
-  event_data JSONB NOT NULL,
-  block_height BIGINT NOT NULL,
-  transaction_hash VARCHAR(255) NOT NULL,
+  event_type VARCHAR(100),
+  event_data JSONB,
+  block_height BIGINT,
+  transaction_hash VARCHAR(255),
+  topic TEXT,
+  tx_hash TEXT,
+  tx_index INTEGER,
+  operation_index INTEGER,
+  event_index INTEGER,
+  payload JSONB,
+  happened_at TIMESTAMPTZ,
+  ledger_hash TEXT,
   ingested_at TIMESTAMP,
-  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
-);
+  ingestion_state TEXT GENERATED ALWAYS AS (
+    CASE WHEN ingested_at IS NULL THEN 'pending' ELSE 'ingested' END
+  ) STORED,
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  PRIMARY KEY (ledger, event_id)
+) PARTITION BY RANGE (ledger);
 ```
+
+`ingested_at` is the ingestion lifecycle marker:
+
+- `NULL` means the event is pending downstream ingestion.
+- A timestamp means the event has been ingested.
+- The lifecycle trigger prevents updates that clear `ingested_at` or move it to an earlier timestamp.
+- `ingestion_state` is generated from `ingested_at` so operators can filter `pending` versus `ingested` without duplicating state.
+
+Fresh databases create `contract_events` as a ledger range-partitioned table with a default partition. Existing non-partitioned databases receive a `contract_events_partitioned` shadow table and the `ensure_contract_events_partition(start_ledger, end_ledger)` helper so operators can backfill in batches and swap during a controlled maintenance window.
 
 ### Indexes
 
-The following indexes are created by migration `001_add_contract_events_replay_indexes`:
+The following indexes are created on the parent table and by the partition helper on each range partition:
 
 #### 1. Composite Index for Replay Queries
 ```sql
@@ -220,6 +243,32 @@ ON historical_events (contract_id, ledger, block_height, event_id);
 **Purpose**: Speeds up batch fetching from the source table during replay operations.
 
 **Note**: All indexes are created with `CONCURRENTLY` to avoid locking the table during index creation.
+
+### Partition Operations
+
+Create the next ledger partition before a replay enters that range:
+
+```sql
+SELECT ensure_contract_events_partition(1000000, 1100000);
+```
+
+Recommended rotation:
+
+1. Keep a default partition so unexpected ledger ranges do not fail ingestion.
+2. Create the next range partition before replay jobs cross the boundary.
+3. Backfill legacy rows into `contract_events_partitioned` in ledger windows, then swap names in a maintenance window.
+4. Run retention in dry-run mode first, review the partition list, then detach old partitions after backup verification.
+
+Retention is provided by `enforceContractEventsRetention()` from `src/scripts/db-ops.ts`. It defaults to dry-run:
+
+```typescript
+await enforceContractEventsRetention({
+  databaseUrl: process.env.DATABASE_URL!,
+  retainLedgers: 500000,
+});
+```
+
+Live detach requires `dryRun: false` and `confirm: true`. Permanent drop additionally requires `backupConfirmed: true`; detach is preferred for routine operations because it preserves the partition table for S3 backup or manual re-attachment.
 
 ## Performance Characteristics
 
@@ -335,6 +384,7 @@ pnpm run migrate
 This will:
 1. Create the initial schema (tables)
 2. Add replay optimization indexes
+3. Install contract event partition helpers and retention guardrails
 
 ### Production Checklist
 
@@ -379,7 +429,7 @@ WHERE contract_id = 'contract-abc-123' AND ledger = 1;
 1. Reduce `REPLAY_BATCH_SIZE`
 2. Add more database resources (CPU, memory)
 3. Run replay during off-peak hours
-4. Consider partitioning large replays by block range
+4. Create the next ledger partition before large replays cross a range boundary
 
 ### High Memory Usage
 
@@ -397,7 +447,8 @@ WHERE contract_id = 'contract-abc-123' AND ledger = 1;
 **Solutions**:
 1. Run `ANALYZE contract_events;` to update statistics
 2. Check index usage with `EXPLAIN ANALYZE`
-3. Consider vacuuming the table: `VACUUM ANALYZE contract_events;`
+3. Run `VACUUM ANALYZE contract_events;` or target the affected ledger partition
+4. Verify old partitions are detached or dropped according to the retention policy
 
 ### Concurrent Replay Error
 

--- a/docs/observability/postgres-vacuum-runbook.md
+++ b/docs/observability/postgres-vacuum-runbook.md
@@ -149,6 +149,17 @@ ALTER TABLE streams SET (
 
 Apply the same settings to `contract_events`, `audit_logs`, and `webhook_outbox` as needed.
 
+For `contract_events`, prefer targeting the hot ledger partition when the parent
+table is partitioned:
+
+```sql
+VACUUM ANALYZE contract_events_ledger_1000000_1100000;
+```
+
+If bloat is concentrated in old closed ranges, run the retention helper in
+dry-run mode first and detach old partitions only after backup verification.
+Permanent drops require an explicit backup confirmation in the ops helper.
+
 ### 5. Check current autovacuum settings for a table
 
 ```sql
@@ -156,6 +167,31 @@ SELECT relname, reloptions
 FROM pg_class
 WHERE relname IN ('streams', 'contract_events', 'audit_logs', 'webhook_outbox');
 ```
+
+### 6. Review contract event partitions
+
+```sql
+SELECT
+  child.relname AS partition_name,
+  pg_get_expr(child.relpartbound, child.oid) AS bounds,
+  child.reltuples::bigint AS estimated_rows
+FROM pg_inherits
+JOIN pg_class parent ON parent.oid = pg_inherits.inhparent
+JOIN pg_class child ON child.oid = pg_inherits.inhrelid
+WHERE parent.relname = 'contract_events'
+ORDER BY partition_name;
+```
+
+Create the next partition before replay crosses a ledger boundary:
+
+```sql
+SELECT ensure_contract_events_partition(1100000, 1200000);
+```
+
+Use `enforceContractEventsRetention()` from `src/scripts/db-ops.ts` for
+retention. The default is dry-run/off; live detach requires `confirm: true`.
+Use `mode: "drop"` only after S3 or snapshot backup verification and
+`backupConfirmed: true`.
 
 ---
 

--- a/migrations/000_initial_schema.ts
+++ b/migrations/000_initial_schema.ts
@@ -24,16 +24,33 @@ export async function up(client: PoolClient): Promise<void> {
   // Contract events table (replay destination)
   await client.query(`
     CREATE TABLE IF NOT EXISTS contract_events (
-      event_id VARCHAR(255) PRIMARY KEY,
+      event_id VARCHAR(255) NOT NULL,
       contract_id VARCHAR(255) NOT NULL,
       ledger INTEGER NOT NULL,
-      event_type VARCHAR(100) NOT NULL,
-      event_data JSONB NOT NULL,
-      block_height BIGINT NOT NULL,
-      transaction_hash VARCHAR(255) NOT NULL,
+      event_type VARCHAR(100),
+      event_data JSONB,
+      block_height BIGINT,
+      transaction_hash VARCHAR(255),
+      topic TEXT,
+      tx_hash TEXT,
+      tx_index INTEGER,
+      operation_index INTEGER,
+      event_index INTEGER,
+      payload JSONB,
+      happened_at TIMESTAMPTZ,
+      ledger_hash TEXT,
       ingested_at TIMESTAMP,
-      created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
-    );
+      ingestion_state TEXT GENERATED ALWAYS AS (
+        CASE WHEN ingested_at IS NULL THEN 'pending' ELSE 'ingested' END
+      ) STORED,
+      created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+      PRIMARY KEY (ledger, event_id)
+    ) PARTITION BY RANGE (ledger);
+  `);
+
+  await client.query(`
+    CREATE TABLE IF NOT EXISTS contract_events_default
+      PARTITION OF contract_events DEFAULT;
   `);
 
   console.log('Initial schema created successfully');
@@ -42,7 +59,7 @@ export async function up(client: PoolClient): Promise<void> {
 export async function down(client: PoolClient): Promise<void> {
   console.log('Dropping initial schema...');
 
-  await client.query(`DROP TABLE IF EXISTS contract_events;`);
+  await client.query(`DROP TABLE IF EXISTS contract_events CASCADE;`);
   await client.query(`DROP TABLE IF EXISTS historical_events;`);
 
   console.log('Initial schema dropped successfully');

--- a/migrations/001_add_contract_events_replay_indexes.ts
+++ b/migrations/001_add_contract_events_replay_indexes.ts
@@ -11,6 +11,12 @@ import { PoolClient } from 'pg';
  * - Reducing table scan time for contract_id + ledger lookups
  * - Enabling efficient identification of events pending ingestion
  * - Supporting the ORDER BY block_height, event_id pattern used in batched fetches
+ *
+ * Note: fresh schemas create contract_events as a partitioned table. PostgreSQL
+ * does not allow CREATE INDEX CONCURRENTLY directly on a partitioned parent, so
+ * these parent indexes intentionally use regular CREATE INDEX IF NOT EXISTS.
+ * Per-partition creation/rotation is handled by
+ * ensure_contract_events_partition() in migration 003.
  */
 
 export async function up(client: PoolClient): Promise<void> {
@@ -18,21 +24,21 @@ export async function up(client: PoolClient): Promise<void> {
 
   // Composite index for general replay queries
   await client.query(`
-    CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_contract_events_contract_ledger
+    CREATE INDEX IF NOT EXISTS idx_contract_events_contract_ledger
     ON contract_events (contract_id, ledger, block_height, event_id);
   `);
 
   // Partial index for unprocessed events (ingested_at IS NULL)
   // This is useful for tracking replay progress and identifying incomplete ingestions
   await client.query(`
-    CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_contract_events_pending_ingestion
+    CREATE INDEX IF NOT EXISTS idx_contract_events_pending_ingestion
     ON contract_events (contract_id, ledger, block_height)
     WHERE ingested_at IS NULL;
   `);
 
   // Index on historical_events for efficient batch fetching during replay
   await client.query(`
-    CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_historical_events_replay
+    CREATE INDEX IF NOT EXISTS idx_historical_events_replay
     ON historical_events (contract_id, ledger, block_height, event_id);
   `);
 
@@ -43,15 +49,15 @@ export async function down(client: PoolClient): Promise<void> {
   console.log('Dropping contract_events replay indexes...');
 
   await client.query(`
-    DROP INDEX CONCURRENTLY IF EXISTS idx_contract_events_contract_ledger;
+    DROP INDEX IF EXISTS idx_contract_events_contract_ledger;
   `);
 
   await client.query(`
-    DROP INDEX CONCURRENTLY IF EXISTS idx_contract_events_pending_ingestion;
+    DROP INDEX IF EXISTS idx_contract_events_pending_ingestion;
   `);
 
   await client.query(`
-    DROP INDEX CONCURRENTLY IF EXISTS idx_historical_events_replay;
+    DROP INDEX IF EXISTS idx_historical_events_replay;
   `);
 
   console.log('Indexes dropped successfully');

--- a/migrations/003_contract_events_partitioning_retention.ts
+++ b/migrations/003_contract_events_partitioning_retention.ts
@@ -1,0 +1,290 @@
+import { PoolClient } from 'pg';
+
+type MigrationTarget = PoolClient | { sql: (statement: string) => void };
+
+function isPoolClient(target: MigrationTarget): target is PoolClient {
+  return typeof (target as PoolClient).query === 'function';
+}
+
+async function runSql(target: MigrationTarget, statement: string): Promise<void> {
+  if (isPoolClient(target)) {
+    await target.query(statement);
+    return;
+  }
+
+  target.sql(statement);
+}
+
+/**
+ * Add partition-management and ingestion-state enforcement for contract_events.
+ *
+ * Fresh deployments should create `contract_events` as a ledger range-partitioned
+ * table. Existing non-partitioned deployments get a shadow
+ * `contract_events_partitioned` table and helper routines so operators can
+ * backfill and swap during a controlled maintenance window instead of taking a
+ * long table lock inside this migration.
+ */
+export async function up(target: MigrationTarget): Promise<void> {
+  await runSql(target, `
+    DO $$
+    DECLARE
+      contract_events_kind "char";
+    BEGIN
+      SELECT c.relkind
+        INTO contract_events_kind
+        FROM pg_class c
+        JOIN pg_namespace n ON n.oid = c.relnamespace
+       WHERE n.nspname = 'public'
+         AND c.relname = 'contract_events';
+
+      IF contract_events_kind IS NULL THEN
+        CREATE TABLE contract_events (
+          event_id VARCHAR(255) NOT NULL,
+          contract_id VARCHAR(255) NOT NULL,
+          ledger INTEGER NOT NULL CHECK (ledger >= 0),
+          event_type VARCHAR(100),
+          event_data JSONB,
+          block_height BIGINT,
+          transaction_hash VARCHAR(255),
+          topic TEXT,
+          tx_hash TEXT,
+          tx_index INTEGER,
+          operation_index INTEGER,
+          event_index INTEGER,
+          payload JSONB,
+          happened_at TIMESTAMPTZ,
+          ledger_hash TEXT,
+          ingested_at TIMESTAMPTZ,
+          ingestion_state TEXT GENERATED ALWAYS AS (
+            CASE WHEN ingested_at IS NULL THEN 'pending' ELSE 'ingested' END
+          ) STORED,
+          created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+          PRIMARY KEY (ledger, event_id)
+        ) PARTITION BY RANGE (ledger);
+
+        CREATE TABLE contract_events_default
+          PARTITION OF contract_events DEFAULT;
+      ELSIF contract_events_kind = 'p' THEN
+        NULL;
+      ELSE
+        CREATE TABLE IF NOT EXISTS contract_events_partitioned (
+          event_id VARCHAR(255) NOT NULL,
+          contract_id VARCHAR(255) NOT NULL,
+          ledger INTEGER NOT NULL CHECK (ledger >= 0),
+          event_type VARCHAR(100),
+          event_data JSONB,
+          block_height BIGINT,
+          transaction_hash VARCHAR(255),
+          topic TEXT,
+          tx_hash TEXT,
+          tx_index INTEGER,
+          operation_index INTEGER,
+          event_index INTEGER,
+          payload JSONB,
+          happened_at TIMESTAMPTZ,
+          ledger_hash TEXT,
+          ingested_at TIMESTAMPTZ,
+          ingestion_state TEXT GENERATED ALWAYS AS (
+            CASE WHEN ingested_at IS NULL THEN 'pending' ELSE 'ingested' END
+          ) STORED,
+          created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+          PRIMARY KEY (ledger, event_id)
+        ) PARTITION BY RANGE (ledger);
+
+        CREATE TABLE IF NOT EXISTS contract_events_partitioned_default
+          PARTITION OF contract_events_partitioned DEFAULT;
+      END IF;
+    END
+    $$;
+  `);
+
+  await runSql(target, `
+    CREATE OR REPLACE FUNCTION enforce_contract_events_ingested_at_lifecycle()
+    RETURNS trigger
+    LANGUAGE plpgsql
+    AS $$
+    BEGIN
+      IF TG_OP = 'UPDATE' THEN
+        IF OLD.ingested_at IS NOT NULL AND NEW.ingested_at IS NULL THEN
+          RAISE EXCEPTION 'contract_events.ingested_at cannot move from ingested back to pending';
+        END IF;
+
+        IF OLD.ingested_at IS NOT NULL
+           AND NEW.ingested_at IS NOT NULL
+           AND NEW.ingested_at < OLD.ingested_at THEN
+          RAISE EXCEPTION 'contract_events.ingested_at cannot move backwards';
+        END IF;
+      END IF;
+
+      RETURN NEW;
+    END;
+    $$;
+  `);
+
+  await runSql(target, `
+    DO $$
+    BEGIN
+      IF to_regclass('public.contract_events') IS NOT NULL THEN
+        ALTER TABLE contract_events
+          ADD COLUMN IF NOT EXISTS event_type VARCHAR(100),
+          ADD COLUMN IF NOT EXISTS event_data JSONB,
+          ADD COLUMN IF NOT EXISTS block_height BIGINT,
+          ADD COLUMN IF NOT EXISTS transaction_hash VARCHAR(255),
+          ADD COLUMN IF NOT EXISTS topic TEXT,
+          ADD COLUMN IF NOT EXISTS tx_hash TEXT,
+          ADD COLUMN IF NOT EXISTS tx_index INTEGER,
+          ADD COLUMN IF NOT EXISTS operation_index INTEGER,
+          ADD COLUMN IF NOT EXISTS event_index INTEGER,
+          ADD COLUMN IF NOT EXISTS payload JSONB,
+          ADD COLUMN IF NOT EXISTS happened_at TIMESTAMPTZ,
+          ADD COLUMN IF NOT EXISTS ledger_hash TEXT,
+          ADD COLUMN IF NOT EXISTS created_at TIMESTAMPTZ DEFAULT now();
+
+        ALTER TABLE contract_events
+          ADD COLUMN IF NOT EXISTS ingestion_state TEXT GENERATED ALWAYS AS (
+            CASE WHEN ingested_at IS NULL THEN 'pending' ELSE 'ingested' END
+          ) STORED;
+
+        IF EXISTS (
+          SELECT 1
+            FROM information_schema.columns
+           WHERE table_schema = 'public'
+             AND table_name = 'contract_events'
+             AND column_name = 'created_at'
+        ) THEN
+          ALTER TABLE contract_events
+            ADD CONSTRAINT contract_events_ingested_at_not_before_create
+            CHECK (ingested_at IS NULL OR created_at IS NULL OR ingested_at >= created_at)
+            NOT VALID;
+        END IF;
+
+        DROP TRIGGER IF EXISTS trg_contract_events_ingested_at_lifecycle
+          ON contract_events;
+        CREATE TRIGGER trg_contract_events_ingested_at_lifecycle
+          BEFORE UPDATE OF ingested_at ON contract_events
+          FOR EACH ROW
+          EXECUTE FUNCTION enforce_contract_events_ingested_at_lifecycle();
+      END IF;
+    END
+    $$;
+  `);
+
+  await runSql(target, `
+    CREATE OR REPLACE FUNCTION ensure_contract_events_partition(
+      start_ledger INTEGER,
+      end_ledger INTEGER
+    )
+    RETURNS TEXT
+    LANGUAGE plpgsql
+    AS $$
+    DECLARE
+      active_parent TEXT;
+      partition_name TEXT;
+      suffix TEXT;
+    BEGIN
+      IF start_ledger IS NULL OR end_ledger IS NULL OR start_ledger < 0 OR end_ledger <= start_ledger THEN
+        RAISE EXCEPTION 'invalid contract_events partition range [% , %)', start_ledger, end_ledger;
+      END IF;
+
+      SELECT CASE
+               WHEN c.relkind = 'p' THEN 'contract_events'
+               WHEN to_regclass('public.contract_events_partitioned') IS NOT NULL THEN 'contract_events_partitioned'
+               ELSE NULL
+             END
+        INTO active_parent
+        FROM pg_class c
+        JOIN pg_namespace n ON n.oid = c.relnamespace
+       WHERE n.nspname = 'public'
+         AND c.relname = 'contract_events';
+
+      IF active_parent IS NULL THEN
+        RAISE EXCEPTION 'contract_events partition parent is not available';
+      END IF;
+
+      suffix := start_ledger::TEXT || '_' || end_ledger::TEXT;
+      partition_name := active_parent || '_ledger_' || suffix;
+
+      EXECUTE format(
+        'CREATE TABLE IF NOT EXISTS %I PARTITION OF %I FOR VALUES FROM (%s) TO (%s)',
+        partition_name,
+        active_parent,
+        start_ledger,
+        end_ledger
+      );
+
+      EXECUTE format(
+        'CREATE INDEX IF NOT EXISTS %I ON %I (contract_id, ledger, block_height, event_id)',
+        'idx_ce_' || suffix || '_contract_ledger',
+        partition_name
+      );
+
+      EXECUTE format(
+        'CREATE INDEX IF NOT EXISTS %I ON %I (contract_id, ledger, block_height) WHERE ingested_at IS NULL',
+        'idx_ce_' || suffix || '_pending_ingestion',
+        partition_name
+      );
+
+      EXECUTE format(
+        'CREATE INDEX IF NOT EXISTS %I ON %I (happened_at, ledger) WHERE happened_at IS NOT NULL',
+        'idx_ce_' || suffix || '_happened_at',
+        partition_name
+      );
+
+      RETURN partition_name;
+    END;
+    $$;
+  `);
+
+  await runSql(target, `
+    DO $$
+    BEGIN
+      IF to_regclass('public.contract_events') IS NOT NULL THEN
+        CREATE INDEX IF NOT EXISTS idx_contract_events_contract_ledger
+          ON contract_events (contract_id, ledger, block_height, event_id);
+
+        CREATE INDEX IF NOT EXISTS idx_contract_events_pending_ingestion
+          ON contract_events (contract_id, ledger, block_height)
+          WHERE ingested_at IS NULL;
+
+        CREATE INDEX IF NOT EXISTS idx_contract_events_happened_at_ledger
+          ON contract_events (happened_at, ledger)
+          WHERE happened_at IS NOT NULL;
+      END IF;
+
+      IF to_regclass('public.contract_events_partitioned') IS NOT NULL THEN
+        CREATE INDEX IF NOT EXISTS idx_contract_events_partitioned_contract_ledger
+          ON contract_events_partitioned (contract_id, ledger, block_height, event_id);
+
+        CREATE INDEX IF NOT EXISTS idx_contract_events_partitioned_pending_ingestion
+          ON contract_events_partitioned (contract_id, ledger, block_height)
+          WHERE ingested_at IS NULL;
+
+        CREATE INDEX IF NOT EXISTS idx_contract_events_partitioned_happened_at_ledger
+          ON contract_events_partitioned (happened_at, ledger)
+          WHERE happened_at IS NOT NULL;
+      END IF;
+    END
+    $$;
+  `);
+}
+
+export async function down(target: MigrationTarget): Promise<void> {
+  await runSql(target, `
+    DO $$
+    BEGIN
+      IF to_regclass('public.contract_events') IS NOT NULL THEN
+        DROP TRIGGER IF EXISTS trg_contract_events_ingested_at_lifecycle
+          ON contract_events;
+        ALTER TABLE contract_events
+          DROP CONSTRAINT IF EXISTS contract_events_ingested_at_not_before_create;
+      END IF;
+    END
+    $$;
+  `);
+
+  await runSql(target, `
+    DROP FUNCTION IF EXISTS ensure_contract_events_partition(INTEGER, INTEGER);
+    DROP FUNCTION IF EXISTS enforce_contract_events_ingested_at_lifecycle();
+    DROP TABLE IF EXISTS contract_events_partitioned CASCADE;
+  `);
+}

--- a/migrations/1774715131962_streams-table.ts
+++ b/migrations/1774715131962_streams-table.ts
@@ -41,31 +41,47 @@ export async function up(pgm: MigrationBuilder): Promise<void> {
   pgm.createIndex('streams', 'contract_id');
   pgm.createIndex('streams', 'created_at');
 
-  // Contract events table for the indexer service
-  pgm.createTable('contract_events', {
-    event_id: { type: 'text', primaryKey: true },
-    ledger: { type: 'integer', notNull: true },
-    contract_id: { type: 'text', notNull: true },
-    topic: { type: 'text', notNull: true },
-    tx_hash: { type: 'text', notNull: true },
-    tx_index: { type: 'integer', notNull: true },
-    operation_index: { type: 'integer', notNull: true },
-    event_index: { type: 'integer', notNull: true },
-    payload: { type: 'jsonb', notNull: true },
-    happened_at: { type: 'timestamp with time zone', notNull: true },
-    ingested_at: {
-      type: 'timestamp with time zone',
-      notNull: true,
-      default: pgm.func('current_timestamp'),
-    },
-  });
+  // Contract events table for the indexer service. Keep this in sync with
+  // migrations/000_initial_schema.ts: the table is partitioned by ledger and
+  // includes nullable columns for both legacy replay rows and typed indexer rows.
+  pgm.sql(`
+    CREATE TABLE IF NOT EXISTS contract_events (
+      event_id VARCHAR(255) NOT NULL,
+      contract_id VARCHAR(255) NOT NULL,
+      ledger INTEGER NOT NULL CHECK (ledger >= 0),
+      event_type VARCHAR(100),
+      event_data JSONB,
+      block_height BIGINT,
+      transaction_hash VARCHAR(255),
+      topic TEXT,
+      tx_hash TEXT,
+      tx_index INTEGER,
+      operation_index INTEGER,
+      event_index INTEGER,
+      payload JSONB,
+      happened_at TIMESTAMPTZ,
+      ledger_hash TEXT,
+      ingested_at TIMESTAMPTZ,
+      ingestion_state TEXT GENERATED ALWAYS AS (
+        CASE WHEN ingested_at IS NULL THEN 'pending' ELSE 'ingested' END
+      ) STORED,
+      created_at TIMESTAMPTZ NOT NULL DEFAULT current_timestamp,
+      PRIMARY KEY (ledger, event_id)
+    ) PARTITION BY RANGE (ledger);
 
-  pgm.createIndex('contract_events', 'contract_id');
-  pgm.createIndex('contract_events', 'tx_hash');
-  pgm.createIndex('contract_events', 'happened_at');
+    CREATE TABLE IF NOT EXISTS contract_events_default
+      PARTITION OF contract_events DEFAULT;
+
+    CREATE INDEX IF NOT EXISTS idx_contract_events_contract_id
+      ON contract_events (contract_id);
+    CREATE INDEX IF NOT EXISTS idx_contract_events_tx_hash
+      ON contract_events (tx_hash);
+    CREATE INDEX IF NOT EXISTS idx_contract_events_happened_at
+      ON contract_events (happened_at);
+  `);
 }
 
 export async function down(pgm: MigrationBuilder): Promise<void> {
-  pgm.dropTable('contract_events');
+  pgm.sql('DROP TABLE IF EXISTS contract_events CASCADE;');
   pgm.dropTable('streams');
 }

--- a/migrations/run.ts
+++ b/migrations/run.ts
@@ -2,11 +2,13 @@ import { db } from '../src/db/client';
 import * as migration000 from './000_initial_schema';
 import * as migration001 from './001_add_contract_events_replay_indexes';
 import * as migration002 from './002_create_replay_cursors';
+import * as migration003 from './003_contract_events_partitioning_retention';
 
 const migrations = [
   { name: '000_initial_schema', module: migration000 },
   { name: '001_add_contract_events_replay_indexes', module: migration001 },
   { name: '002_create_replay_cursors', module: migration002 },
+  { name: '003_contract_events_partitioning_retention', module: migration003 },
 ];
 
 

--- a/src/indexer/service.ts
+++ b/src/indexer/service.ts
@@ -222,7 +222,7 @@ export class ReplayCursorRepository {
  * for each batch:
  *   acquire connection
  *   BEGIN
- *     INSERT … ON CONFLICT (event_id) DO NOTHING   ← idempotent
+ *     INSERT … ON CONFLICT DO NOTHING             ← idempotent
  *     UPDATE replay_cursors SET last_committed_offset = …  ← atomic with data
  *   COMMIT
  *   release connection
@@ -233,7 +233,7 @@ export class ReplayCursorRepository {
  * The cursor offset is updated inside the same transaction as the batch
  * INSERT.  After a crash, a re-run reads `last_committed_offset` from the
  * `replay_cursors` table and resumes from exactly that point.  Because every
- * INSERT uses `ON CONFLICT (event_id) DO NOTHING`, rows from any partially
+ * INSERT uses `ON CONFLICT DO NOTHING`, rows from any partially
  * replayed batch that was rolled back will simply be re-inserted on the next
  * attempt without producing duplicates.
  *
@@ -322,7 +322,6 @@ export class IndexerService {
 
       let offset = cursor.last_committed_offset;
       let batchIndex = 0;
-      let lastBatchRowCount = 0;
 
       // 5. Per-batch loop — each iteration uses a fresh connection.
       while (offset < totalRows) {
@@ -350,7 +349,6 @@ export class IndexerService {
         const newOffset = offset + batchResult.rowsFetched;
         offset = newOffset;
         batchIndex++;
-        lastBatchRowCount = batchResult.rowsFetched;
 
         // Update in-memory progress.
         replayState.updateProgress(batchResult.rowsFetched, newOffset);
@@ -475,7 +473,7 @@ export class IndexerService {
     cursorId: string,
     request: ReplayRequest,
     offset: number,
-    batchIndex: number,
+    _batchIndex: number,
   ): Promise<{ rowsFetched: number }> {
     const client = await this.pool.connect();
     try {
@@ -645,8 +643,8 @@ export class IndexerService {
   /**
    * Batch INSERT events into `contract_events` using a multi-row VALUES list.
    *
-   * `ON CONFLICT (event_id) DO NOTHING` ensures idempotency: re-running a
-   * partially completed replay never produces duplicate rows.
+   * `ON CONFLICT DO NOTHING` keeps idempotency compatible with both the
+   * legacy `event_id` key and the partitioned `(ledger, event_id)` key.
    * Uses positional parameters — no user values are string-interpolated.
    */
   private async batchInsertEvents(
@@ -684,7 +682,7 @@ export class IndexerService {
         block_height,
         transaction_hash
       ) VALUES ${valuePlaceholders.join(', ')}
-      ON CONFLICT (event_id) DO NOTHING
+      ON CONFLICT DO NOTHING
     `;
 
     await client.query(query, values);

--- a/src/indexer/store.ts
+++ b/src/indexer/store.ts
@@ -207,7 +207,7 @@ export class PostgresContractEventStore implements ContractEventStore {
         tx_index, operation_index, event_index, payload, happened_at, ledger_hash
       )
       VALUES ${placeholders.join(', ')}
-      ON CONFLICT (event_id) DO NOTHING
+      ON CONFLICT DO NOTHING
       RETURNING event_id
     `;
 

--- a/src/scripts/contract-events-retention.ts
+++ b/src/scripts/contract-events-retention.ts
@@ -1,0 +1,262 @@
+import pg from 'pg';
+import type { DbOperationResult } from './db-ops.js';
+
+export type ContractEventsRetentionMode = 'detach' | 'drop';
+
+export interface ContractEventsRetentionOptions {
+  databaseUrl: string;
+  retainLedgers: number;
+  currentLedger?: number;
+  dryRun?: boolean;
+  confirm?: boolean;
+  backupConfirmed?: boolean;
+  mode?: ContractEventsRetentionMode;
+  parentTable?: 'contract_events' | 'contract_events_partitioned';
+}
+
+export interface ContractEventsRetentionPartition {
+  name: string;
+  startLedger: number;
+  endLedger: number;
+  rowEstimate: number;
+}
+
+export interface ContractEventsRetentionResult extends DbOperationResult {
+  dryRun: boolean;
+  mode: ContractEventsRetentionMode;
+  currentLedger: number;
+  cutoffLedger: number;
+  partitions: ContractEventsRetentionPartition[];
+  executedPartitions: string[];
+}
+
+function validateDatabaseUrl(url: string): { valid: boolean; reason?: string } {
+  if (!url || url.trim() === '') {
+    return { valid: false, reason: 'DATABASE_URL is required but was not provided.' };
+  }
+  if (!/^postgre(?:s|sql):\/\//i.test(url)) {
+    return { valid: false, reason: 'DATABASE_URL must be a valid PostgreSQL connection string.' };
+  }
+  return { valid: true };
+}
+
+function quoteIdentifier(identifier: string): string {
+  return `"${identifier.replace(/"/g, '""')}"`;
+}
+
+function redactDatabaseUrl(message: string): string {
+  return message.replace(/postgres(?:ql)?:\/\/[^@\s]+@/gi, 'postgres://***@');
+}
+
+function failureResult(
+  message: string,
+  options: {
+    dryRun: boolean;
+    mode: ContractEventsRetentionMode;
+    error?: string;
+  },
+): ContractEventsRetentionResult {
+  return {
+    success: false,
+    message,
+    ...(options.error ? { error: options.error } : {}),
+    dryRun: options.dryRun,
+    mode: options.mode,
+    currentLedger: 0,
+    cutoffLedger: 0,
+    partitions: [],
+    executedPartitions: [],
+  };
+}
+
+async function queryCurrentLedger(client: pg.Client, parentTable: string): Promise<number> {
+  const result = await client.query<{ current_ledger: string | number | null }>(
+    `SELECT COALESCE(MAX(ledger), 0) AS current_ledger FROM ${quoteIdentifier(parentTable)}`,
+  );
+  return Number(result.rows[0]?.current_ledger ?? 0);
+}
+
+async function queryPartitions(
+  client: pg.Client,
+  parentTable: string,
+): Promise<ContractEventsRetentionPartition[]> {
+  const result = await client.query<{
+    partition_name: string;
+    start_ledger: string | number;
+    end_ledger: string | number;
+    row_estimate: string | number;
+  }>(
+    `
+      SELECT
+        child.relname AS partition_name,
+        ((regexp_match(pg_get_expr(child.relpartbound, child.oid), 'FROM \\(([0-9]+)\\) TO \\(([0-9]+)\\)'))[1])::integer AS start_ledger,
+        ((regexp_match(pg_get_expr(child.relpartbound, child.oid), 'FROM \\(([0-9]+)\\) TO \\(([0-9]+)\\)'))[2])::integer AS end_ledger,
+        GREATEST(child.reltuples, 0)::bigint AS row_estimate
+      FROM pg_inherits
+      JOIN pg_class parent ON parent.oid = pg_inherits.inhparent
+      JOIN pg_namespace namespace ON namespace.oid = parent.relnamespace
+      JOIN pg_class child ON child.oid = pg_inherits.inhrelid
+      WHERE namespace.nspname = 'public'
+        AND parent.relname = $1
+        AND pg_get_expr(child.relpartbound, child.oid) <> 'DEFAULT'
+      ORDER BY start_ledger ASC
+    `,
+    [parentTable],
+  );
+
+  return result.rows.map((row) => ({
+    name: row.partition_name,
+    startLedger: Number(row.start_ledger),
+    endLedger: Number(row.end_ledger),
+    rowEstimate: Number(row.row_estimate),
+  }));
+}
+
+async function auditRetentionAction(
+  client: pg.Client,
+  partition: ContractEventsRetentionPartition,
+  parentTable: string,
+  mode: ContractEventsRetentionMode,
+  currentLedger: number,
+  cutoffLedger: number,
+): Promise<void> {
+  const tableCheck = await client.query<{ audit_table: string | null }>(
+    "SELECT to_regclass('public.audit_logs')::text AS audit_table",
+  );
+  if (!tableCheck.rows[0]?.audit_table) {
+    return;
+  }
+
+  await client.query(
+    `
+      INSERT INTO audit_logs
+        (seq, timestamp, action, resource_type, resource_id, correlation_id, meta)
+      SELECT
+        COALESCE(MAX(seq), 0) + 1,
+        now()::text,
+        $1,
+        'contract_events_partition',
+        $2,
+        NULL,
+        $3::jsonb
+      FROM audit_logs
+    `,
+    [
+      mode === 'drop'
+        ? 'CONTRACT_EVENTS_PARTITION_DROP'
+        : 'CONTRACT_EVENTS_PARTITION_DETACH',
+      partition.name,
+      JSON.stringify({
+        parentTable,
+        currentLedger,
+        cutoffLedger,
+        startLedger: partition.startLedger,
+        endLedger: partition.endLedger,
+        rowEstimate: partition.rowEstimate,
+      }),
+    ],
+  );
+}
+
+/**
+ * Enforce ledger-range retention for partitioned contract_events.
+ *
+ * The default is a dry run. Live runs require `confirm: true`, and permanent
+ * drops additionally require `backupConfirmed: true`. Prefer `mode: "detach"`
+ * for routine operations so the old partition remains available for backup or
+ * manual re-attachment.
+ */
+export async function enforceContractEventsRetention(
+  options: ContractEventsRetentionOptions,
+): Promise<ContractEventsRetentionResult> {
+  const dryRun = options.dryRun ?? true;
+  const mode = options.mode ?? 'detach';
+  const parentTable = options.parentTable ?? 'contract_events';
+  const common = { dryRun, mode };
+
+  const urlCheck = validateDatabaseUrl(options.databaseUrl);
+  if (!urlCheck.valid) {
+    return failureResult(urlCheck.reason!, common);
+  }
+
+  if (!Number.isInteger(options.retainLedgers) || options.retainLedgers <= 0) {
+    return failureResult('retainLedgers must be a positive integer.', common);
+  }
+
+  if (!['contract_events', 'contract_events_partitioned'].includes(parentTable)) {
+    return failureResult('parentTable must be contract_events or contract_events_partitioned.', common);
+  }
+
+  if (!dryRun && !options.confirm) {
+    return failureResult('Live contract_events retention requires confirm: true.', common);
+  }
+
+  if (!dryRun && mode === 'drop' && !options.backupConfirmed) {
+    return failureResult('Dropping contract_events partitions requires backupConfirmed: true.', common);
+  }
+
+  const client = new pg.Client({ connectionString: options.databaseUrl });
+
+  try {
+    await client.connect();
+
+    const currentLedger = options.currentLedger ?? (await queryCurrentLedger(client, parentTable));
+    const cutoffLedger = Math.max(0, currentLedger - options.retainLedgers + 1);
+    const partitions = (await queryPartitions(client, parentTable))
+      .filter((partition) => partition.endLedger <= cutoffLedger);
+
+    if (dryRun || partitions.length === 0) {
+      return {
+        success: true,
+        message: dryRun
+          ? `Dry run: ${partitions.length} contract_events partition(s) eligible for ${mode}.`
+          : 'No contract_events partitions are eligible for retention.',
+        dryRun,
+        mode,
+        currentLedger,
+        cutoffLedger,
+        partitions,
+        executedPartitions: [],
+      };
+    }
+
+    const executedPartitions: string[] = [];
+    await client.query('BEGIN');
+    try {
+      for (const partition of partitions) {
+        const partitionName = quoteIdentifier(partition.name);
+        const parentName = quoteIdentifier(parentTable);
+        if (mode === 'drop') {
+          await client.query(`DROP TABLE ${partitionName}`);
+        } else {
+          await client.query(`ALTER TABLE ${parentName} DETACH PARTITION ${partitionName}`);
+        }
+        await auditRetentionAction(client, partition, parentTable, mode, currentLedger, cutoffLedger);
+        executedPartitions.push(partition.name);
+      }
+      await client.query('COMMIT');
+    } catch (error: unknown) {
+      await client.query('ROLLBACK');
+      throw error;
+    }
+
+    return {
+      success: true,
+      message: `${mode} completed for ${executedPartitions.length} contract_events partition(s).`,
+      dryRun,
+      mode,
+      currentLedger,
+      cutoffLedger,
+      partitions,
+      executedPartitions,
+    };
+  } catch (error: unknown) {
+    const err = error as { message?: string };
+    return failureResult('Contract events retention failed', {
+      ...common,
+      error: redactDatabaseUrl(err.message ?? 'Unknown database error'),
+    });
+  } finally {
+    await client.end().catch(() => undefined);
+  }
+}

--- a/src/scripts/db-ops.ts
+++ b/src/scripts/db-ops.ts
@@ -25,6 +25,14 @@ import { pipeline } from 'stream/promises'
 import { promisify } from 'util'
 import { PassThrough, Readable } from 'stream'
 
+export {
+  enforceContractEventsRetention,
+  type ContractEventsRetentionMode,
+  type ContractEventsRetentionOptions,
+  type ContractEventsRetentionPartition,
+  type ContractEventsRetentionResult,
+} from './contract-events-retention.js'
+
 const execFileAsync = promisify(execFile)
 
 // ── Result type ───────────────────────────────────────────────────────────────

--- a/tests/contract-events-partitioning-migration.test.ts
+++ b/tests/contract-events-partitioning-migration.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it, vi } from 'vitest';
+import { up, down } from '../migrations/003_contract_events_partitioning_retention.js';
+
+function makeMigrationBuilder() {
+  const statements: string[] = [];
+  return {
+    statements,
+    builder: {
+      sql: vi.fn((statement: string) => {
+        statements.push(statement);
+      }),
+    },
+  };
+}
+
+describe('003_contract_events_partitioning_retention migration', () => {
+  it('creates a partitioned contract_events path and a shadow table for safe backfill', async () => {
+    const { builder, statements } = makeMigrationBuilder();
+
+    await up(builder);
+    const sql = statements.join('\n');
+
+    expect(sql).toContain('PARTITION BY RANGE (ledger)');
+    expect(sql).toContain('contract_events_partitioned');
+    expect(sql).toContain('PARTITION OF contract_events DEFAULT');
+    expect(sql).toContain('PRIMARY KEY (ledger, event_id)');
+  });
+
+  it('defines and attaches the ingested_at lifecycle trigger', async () => {
+    const { builder, statements } = makeMigrationBuilder();
+
+    await up(builder);
+    const sql = statements.join('\n');
+
+    expect(sql).toContain('enforce_contract_events_ingested_at_lifecycle');
+    expect(sql).toContain('cannot move from ingested back to pending');
+    expect(sql).toContain('cannot move backwards');
+    expect(sql).toContain('trg_contract_events_ingested_at_lifecycle');
+    expect(sql).toContain('ingestion_state TEXT GENERATED ALWAYS AS');
+  });
+
+  it('defines partition creation routine and per-partition indexes', async () => {
+    const { builder, statements } = makeMigrationBuilder();
+
+    await up(builder);
+    const sql = statements.join('\n');
+
+    expect(sql).toContain('ensure_contract_events_partition');
+    expect(sql).toContain('CREATE TABLE IF NOT EXISTS %I PARTITION OF %I');
+    expect(sql).toContain('pending_ingestion');
+    expect(sql).toContain('happened_at');
+  });
+
+  it('down removes helpers and shadow partition table without dropping canonical data', async () => {
+    const { builder, statements } = makeMigrationBuilder();
+
+    await down(builder);
+    const sql = statements.join('\n');
+
+    expect(sql).toContain('DROP FUNCTION IF EXISTS ensure_contract_events_partition');
+    expect(sql).toContain('DROP TABLE IF EXISTS contract_events_partitioned CASCADE');
+    expect(sql).not.toContain('DROP TABLE IF EXISTS contract_events CASCADE');
+  });
+});

--- a/tests/contract-events-retention.test.ts
+++ b/tests/contract-events-retention.test.ts
@@ -1,0 +1,190 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const pgClientMocks = {
+  connect: vi.fn(),
+  end: vi.fn(),
+  query: vi.fn(),
+};
+
+vi.mock('pg', () => {
+  function MockClient() {
+    return pgClientMocks;
+  }
+  return { default: { Client: MockClient } };
+});
+
+import { enforceContractEventsRetention } from '../src/scripts/db-ops.js';
+
+const DATABASE_URL = 'postgres://user:secret@localhost:5432/fluxora';
+
+function mockCurrentLedger(value = 10_000): void {
+  pgClientMocks.query.mockResolvedValueOnce({
+    rows: [{ current_ledger: value }],
+  });
+}
+
+function mockPartitions(): void {
+  pgClientMocks.query.mockResolvedValueOnce({
+    rows: [
+      {
+        partition_name: 'contract_events_ledger_0_1000',
+        start_ledger: 0,
+        end_ledger: 1000,
+        row_estimate: 123,
+      },
+      {
+        partition_name: 'contract_events_ledger_9000_10000',
+        start_ledger: 9000,
+        end_ledger: 10000,
+        row_estimate: 456,
+      },
+    ],
+  });
+}
+
+describe('enforceContractEventsRetention', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    pgClientMocks.connect.mockResolvedValue(undefined);
+    pgClientMocks.end.mockResolvedValue(undefined);
+    pgClientMocks.query.mockReset();
+  });
+
+  it('rejects non-postgres URLs before connecting', async () => {
+    const result = await enforceContractEventsRetention({
+      databaseUrl: 'mysql://localhost/db',
+      retainLedgers: 1000,
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.message).toContain('PostgreSQL');
+    expect(pgClientMocks.connect).not.toHaveBeenCalled();
+  });
+
+  it('rejects invalid retention windows before connecting', async () => {
+    const result = await enforceContractEventsRetention({
+      databaseUrl: DATABASE_URL,
+      retainLedgers: 0,
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.message).toContain('positive integer');
+    expect(pgClientMocks.connect).not.toHaveBeenCalled();
+  });
+
+  it('defaults to dry-run and reports only partitions ending before the cutoff ledger', async () => {
+    mockCurrentLedger(10_000);
+    mockPartitions();
+
+    const result = await enforceContractEventsRetention({
+      databaseUrl: DATABASE_URL,
+      retainLedgers: 5000,
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.dryRun).toBe(true);
+    expect(result.cutoffLedger).toBe(5001);
+    expect(result.partitions.map((partition) => partition.name)).toEqual([
+      'contract_events_ledger_0_1000',
+    ]);
+    expect(result.executedPartitions).toEqual([]);
+    expect(pgClientMocks.query).not.toHaveBeenCalledWith('BEGIN');
+  });
+
+  it('requires confirm true for live detach operations', async () => {
+    const result = await enforceContractEventsRetention({
+      databaseUrl: DATABASE_URL,
+      retainLedgers: 5000,
+      dryRun: false,
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.message).toContain('confirm');
+    expect(pgClientMocks.connect).not.toHaveBeenCalled();
+  });
+
+  it('requires backup confirmation before dropping partitions', async () => {
+    const result = await enforceContractEventsRetention({
+      databaseUrl: DATABASE_URL,
+      retainLedgers: 5000,
+      dryRun: false,
+      confirm: true,
+      mode: 'drop',
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.message).toContain('backupConfirmed');
+    expect(pgClientMocks.connect).not.toHaveBeenCalled();
+  });
+
+  it('detaches eligible partitions and writes audit rows when confirmed', async () => {
+    mockCurrentLedger(10_000);
+    mockPartitions();
+    pgClientMocks.query
+      .mockResolvedValueOnce({ rows: [] }) // BEGIN
+      .mockResolvedValueOnce({ rows: [] }) // DETACH
+      .mockResolvedValueOnce({ rows: [{ audit_table: 'audit_logs' }] })
+      .mockResolvedValueOnce({ rows: [] }) // audit insert
+      .mockResolvedValueOnce({ rows: [] }); // COMMIT
+
+    const result = await enforceContractEventsRetention({
+      databaseUrl: DATABASE_URL,
+      retainLedgers: 5000,
+      dryRun: false,
+      confirm: true,
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.executedPartitions).toEqual(['contract_events_ledger_0_1000']);
+    expect(pgClientMocks.query).toHaveBeenCalledWith('BEGIN');
+    expect(pgClientMocks.query).toHaveBeenCalledWith(
+      'ALTER TABLE "contract_events" DETACH PARTITION "contract_events_ledger_0_1000"',
+    );
+    expect(pgClientMocks.query).toHaveBeenCalledWith('COMMIT');
+  });
+
+  it('drops only when mode is drop and backupConfirmed is true', async () => {
+    mockCurrentLedger(10_000);
+    mockPartitions();
+    pgClientMocks.query
+      .mockResolvedValueOnce({ rows: [] }) // BEGIN
+      .mockResolvedValueOnce({ rows: [] }) // DROP
+      .mockResolvedValueOnce({ rows: [{ audit_table: null }] })
+      .mockResolvedValueOnce({ rows: [] }); // COMMIT
+
+    const result = await enforceContractEventsRetention({
+      databaseUrl: DATABASE_URL,
+      retainLedgers: 5000,
+      dryRun: false,
+      confirm: true,
+      backupConfirmed: true,
+      mode: 'drop',
+    });
+
+    expect(result.success).toBe(true);
+    expect(pgClientMocks.query).toHaveBeenCalledWith(
+      'DROP TABLE "contract_events_ledger_0_1000"',
+    );
+  });
+
+  it('rolls back and redacts DATABASE_URL credentials when execution fails', async () => {
+    mockCurrentLedger(10_000);
+    mockPartitions();
+    pgClientMocks.query
+      .mockResolvedValueOnce({ rows: [] }) // BEGIN
+      .mockRejectedValueOnce(new Error(`connection failed for ${DATABASE_URL}`))
+      .mockResolvedValueOnce({ rows: [] }); // ROLLBACK
+
+    const result = await enforceContractEventsRetention({
+      databaseUrl: DATABASE_URL,
+      retainLedgers: 5000,
+      dryRun: false,
+      confirm: true,
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('postgres://***@localhost');
+    expect(result.error).not.toContain('secret');
+    expect(pgClientMocks.query).toHaveBeenCalledWith('ROLLBACK');
+  });
+});

--- a/tests/indexer-replay.test.ts
+++ b/tests/indexer-replay.test.ts
@@ -235,7 +235,7 @@ describe('IndexerService — max-range guard', () => {
   it('allows a range exactly at the limit', async () => {
     // Set up zero-event replay so it exits immediately
     const cursorRepo = makeCursorRepo({
-      create: vi.fn(async (_c, cid, ledger, fb, tb, total) => ({
+      create: vi.fn(async (_c, cid, ledger, fb, tb) => ({
         id: 'c1',
         contract_id: cid,
         ledger,
@@ -529,9 +529,7 @@ describe('IndexerService — crash-resume semantics', () => {
     });
 
     // This batch client throws during INSERT
-    let callCount = 0;
     const failingBatchClient = makeClient(async (sql) => {
-      callCount++;
       if (sql.trim() === 'BEGIN') return { rows: [] };
       if (sql.includes('FROM historical_events')) return { rows: [makeEvent('e1'), makeEvent('e2')] };
       if (sql.includes('INSERT INTO contract_events')) throw new Error('simulated DB failure');
@@ -587,7 +585,7 @@ describe('IndexerService — crash-resume semantics', () => {
     // Every INSERT must carry ON CONFLICT DO NOTHING
     expect(insertSqls.length).toBeGreaterThan(0);
     for (const sql of insertSqls) {
-      expect(sql).toContain('ON CONFLICT (event_id) DO NOTHING');
+      expect(sql).toContain('ON CONFLICT DO NOTHING');
     }
   });
 });

--- a/tests/indexer-store.stale-cursor.test.ts
+++ b/tests/indexer-store.stale-cursor.test.ts
@@ -71,4 +71,19 @@ describe('ContractEventStore stale cursor handling', () => {
     expect(queries[1]?.values).toEqual([100, 'e1']);
     expect(queries[2]?.sql).toContain('event_id > $2');
   });
+
+  it('keeps Postgres insert idempotency compatible with partitioned keys', async () => {
+    let insertSql = '';
+    const store = new PostgresContractEventStore({
+      query: async <T>(sql: string) => {
+        insertSql = sql;
+        return { rows: [{ event_id: 'e1' }] as T[], rowCount: 1 };
+      },
+    });
+
+    await store.insertMany([makeRecord('e1', 100)]);
+
+    expect(insertSql).toContain('ON CONFLICT DO NOTHING');
+    expect(insertSql).not.toContain('ON CONFLICT (event_id)');
+  });
 });

--- a/tsconfig.eslint.json
+++ b/tsconfig.eslint.json
@@ -4,6 +4,6 @@
     "rootDir": ".",
     "noEmit": true
   },
-  "include": ["src/**/*", "tests/**/*", "eslint.config.js", "vitest.config.ts"],
+  "include": ["src/**/*", "tests/**/*", "migrations/**/*", "eslint.config.js", "vitest.config.ts"],
   "exclude": []
 }


### PR DESCRIPTION
## Summary
- add ledger-range partitioning for `contract_events`, including a default partition for fresh installs and a shadow `contract_events_partitioned` path for lock-aware legacy backfills
- define the `ingested_at` lifecycle with generated `ingestion_state`, a monotonic update trigger, partition helper routine, and parent/per-partition indexes
- add guarded retention operations exported from `src/scripts/db-ops.ts`: dry-run by default, explicit confirmation for live detach, and backup confirmation before destructive drops
- document partition rotation, retention, vacuum targeting, and operational guardrails

Fixes #334.

## Validation
- `corepack.cmd pnpm@8.15.9 install --frozen-lockfile --ignore-scripts`
- `node.exe .\node_modules\vitest\vitest.mjs run tests\contract-events-retention.test.ts tests\contract-events-partitioning-migration.test.ts tests\indexer-replay.test.ts tests\indexer-store.stale-cursor.test.ts tests\db-ops.test.ts tests\unit\metrics\vacuumCollector.test.ts --reporter=dot` - 91 passed, 2 skipped
- `node.exe .\node_modules\eslint\bin\eslint.js migrations\000_initial_schema.ts migrations\001_add_contract_events_replay_indexes.ts migrations\003_contract_events_partitioning_retention.ts migrations\1774715131962_streams-table.ts migrations\run.ts src\indexer\service.ts src\indexer\store.ts src\scripts\db-ops.ts src\scripts\contract-events-retention.ts tests\contract-events-retention.test.ts tests\contract-events-partitioning-migration.test.ts tests\indexer-replay.test.ts tests\indexer-store.stale-cursor.test.ts`
- `node.exe --import tsx -e "const mods=['./migrations/000_initial_schema.ts','./migrations/001_add_contract_events_replay_indexes.ts','./migrations/003_contract_events_partitioning_retention.ts']; for (const p of mods) { const m = await import(p); if (typeof m.up !== 'function' || typeof m.down !== 'function') throw new Error(p + ' missing exports'); } console.log('migration exports ok')"`
- `git diff --check`
- touched-scope TypeScript filter for the changed migration/indexer/script/test paths produced no matching errors; full `tsc` remains blocked by existing repository-wide baseline issues outside this change set

## Security / operations notes
- retention defaults to dry-run and reports candidate partitions without modifying data
- live retention requires `confirm: true`; `mode: "drop"` additionally requires `backupConfirmed: true`
- detach is the default live action so old partitions remain available for backup or manual re-attachment
- retention actions write audit rows when `audit_logs` exists and redact connection strings in errors
