### PR TITLE
fix(webhooks): add full and decorrelated retry jitter

### DIFF
--- a/WEBHOOK_RETRY_POLICY.md
+++ b/WEBHOOK_RETRY_POLICY.md
@@ -27,11 +27,12 @@ The Fluxora backend guarantees:
   initialBackoffMs: 1000,            // First retry after 1 second
   backoffMultiplier: 2,              // Exponential backoff multiplier
   maxBackoffMs: 60000,               // Cap backoff at 60 seconds
-  jitterPercent: 10,                 // ±10% jitter to prevent thundering herd
+  jitterPercent: 10,                 // Set to 0 to disable jitter
   timeoutMs: 30000,                  // 30 second timeout per attempt
   retryableStatusCodes: [408, 429, 500, 502, 503, 504],
   backoffStrategy: 'exponential',    // exponential | linear | fixed
   jitterAlgorithm: 'full',           // full | equal | decorrelated
+  previousDelayMs: 2000,             // Optional state for decorrelated jitter
   deadLetterAfterMs: 3600000,        // Send to DLQ after 1 hour (optional)
   circuitBreakerThreshold: 10,       // Open circuit after 10 failures (optional)
   circuitBreakerResetMs: 300000      // Reset circuit after 5 minutes (optional)
@@ -57,14 +58,16 @@ The Fluxora backend guarantees:
 #### Full Jitter (Default)
 - Random delay between 0 and calculated backoff
 - Prevents thundering herd effectively
+- Honors maxBackoffMs because the raw backoff is capped before jitter
 
 #### Equal Jitter
 - Delay = (backoff/2) + random(0, backoff/2)
 - Balances load spreading and promptness
 
 #### Decorrelated Jitter
-- Delay = random(0, backoff * 3)
+- Delay = random(initialBackoffMs, min(maxBackoffMs, previousDelayMs * 3))
 - Adapts to varying load conditions
+- generateRetrySchedule() carries previousDelayMs forward between attempts; direct calculateNextRetryTime() callers can pass previousDelayMs when they need deterministic decorrelated chaining.
 
 ### Backoff Schedule
 

--- a/src/webhooks/retry.test.ts
+++ b/src/webhooks/retry.test.ts
@@ -95,22 +95,55 @@ test('calculateNextRetryTime: applies jitter within bounds', () => {
   };
 
   // Run multiple times to verify jitter is applied
-  const retries = Array.from({ length: 10 }, () =>
-    calculateNextRetryTime(0, policy, now),
-  );
+  const retries = Array.from({ length: 10 }, () => calculateNextRetryTime(0, policy, now));
 
-  // All should be within ±10% of 1000ms
-  const minExpected = now + 900;
-  const maxExpected = now + 1100;
+  // Full jitter schedules within the full [0, raw backoff] window.
+  const minExpected = now;
+  const maxExpected = now + 1000;
 
   for (const retry of retries) {
-    assert.ok(retry >= minExpected && retry <= maxExpected,
-      `Retry ${retry} outside bounds [${minExpected}, ${maxExpected}]`);
+    assert.ok(
+      retry >= minExpected && retry <= maxExpected,
+      `Retry ${retry} outside bounds [${minExpected}, ${maxExpected}]`
+    );
   }
 
   // Should have some variation (not all the same)
   const uniqueRetries = new Set(retries);
   assert.ok(uniqueRetries.size > 1, 'Jitter should produce variation');
+});
+
+test('calculateNextRetryTime: supports deterministic full jitter', () => {
+  const now = 1000000;
+  const policy = {
+    ...DEFAULT_RETRY_POLICY,
+    initialBackoffMs: 1000,
+    backoffMultiplier: 2,
+    maxBackoffMs: 60000,
+    jitterAlgorithm: 'full' as const,
+    random: () => 0.25,
+  };
+
+  const retry = calculateNextRetryTime(1, policy, now);
+
+  assert.equal(retry, now + 500);
+});
+
+test('calculateNextRetryTime: decorrelated jitter uses previous delay state', () => {
+  const now = 1000000;
+  const policy = {
+    ...DEFAULT_RETRY_POLICY,
+    initialBackoffMs: 1000,
+    backoffMultiplier: 2,
+    maxBackoffMs: 5000,
+    jitterAlgorithm: 'decorrelated' as const,
+    previousDelayMs: 2000,
+    random: () => 0.5,
+  };
+
+  const retry = calculateNextRetryTime(2, policy, now);
+
+  assert.equal(retry, now + 3000);
 });
 
 test('isRetryableStatusCode: retries on 5xx errors', () => {

--- a/src/webhooks/retry.ts
+++ b/src/webhooks/retry.ts
@@ -25,6 +25,10 @@ export type JitterAlgorithm = 'full' | 'equal' | 'decorrelated';
 export interface EnhancedRetryPolicy extends WebhookRetryPolicy {
   backoffStrategy?: BackoffStrategy;
   jitterAlgorithm?: JitterAlgorithm;
+  /** Injected RNG for deterministic retry tests; should return a value in [0, 1]. */
+  random?: () => number;
+  /** Previous scheduled delay used by decorrelated jitter. */
+  previousDelayMs?: number;
   deadLetterAfterMs?: number;
   circuitBreakerThreshold?: number;
   circuitBreakerResetMs?: number;
@@ -61,11 +65,13 @@ export interface WebhookOutboxRetryPlan {
 // ---------------------------------------------------------------------------
 
 /** Calculate raw backoff delay (before jitter) for a given attempt number. */
-export function calculateBackoffDelay(
-  attemptNumber: number,
-  policy: EnhancedRetryPolicy,
-): number {
-  const { backoffStrategy = 'exponential', initialBackoffMs, backoffMultiplier, maxBackoffMs } = policy;
+export function calculateBackoffDelay(attemptNumber: number, policy: EnhancedRetryPolicy): number {
+  const {
+    backoffStrategy = 'exponential',
+    initialBackoffMs,
+    backoffMultiplier,
+    maxBackoffMs,
+  } = policy;
 
   let baseDelay: number;
   switch (backoffStrategy) {
@@ -84,25 +90,34 @@ export function calculateBackoffDelay(
   return Math.min(baseDelay, maxBackoffMs);
 }
 
+function nextRandom(policy: EnhancedRetryPolicy): number {
+  const value = (policy.random ?? Math.random)();
+  return Math.min(1, Math.max(0, value));
+}
+
 /** Apply jitter to a delay value. */
 export function applyJitter(delayMs: number, policy: EnhancedRetryPolicy): number {
   const { jitterPercent = 10, jitterAlgorithm = 'full' } = policy;
-  const jitterRange = delayMs * (jitterPercent / 100);
+  if (jitterPercent === 0) return delayMs;
+
+  const random = nextRandom(policy);
 
   switch (jitterAlgorithm) {
     case 'equal': {
       const half = delayMs / 2;
-      return half + Math.random() * half;
+      return half + random * half;
     }
-    case 'decorrelated':
-      return Math.random() * delayMs * 3;
+    case 'decorrelated': {
+      const lower = policy.initialBackoffMs;
+      const previousDelay = policy.previousDelayMs ?? delayMs;
+      const upper = Math.min(policy.maxBackoffMs, Math.max(lower, previousDelay * 3));
+      return lower + random * (upper - lower);
+    }
     case 'full':
     default:
-      return Math.max(0, delayMs - jitterRange / 2 + Math.random() * jitterRange);
+      return random * delayMs;
   }
 }
-
-
 
 /** Determine if a status code is retryable with enhanced logic. */
 /**
@@ -128,66 +143,10 @@ export function applyJitter(delayMs: number, policy: EnhancedRetryPolicy): numbe
  */
 export function isRetryableStatusCode(
   statusCode: number | undefined,
-  policy: EnhancedRetryPolicy = DEFAULT_RETRY_POLICY,
+  policy: EnhancedRetryPolicy = DEFAULT_RETRY_POLICY
 ): boolean {
   if (statusCode === undefined) return true;
   return policy.retryableStatusCodes.includes(statusCode);
-}
-
-/** Return the absolute timestamp for the next retry attempt. */
-export function calculateNextRetryTime(
-  attemptNumber: number,
-  policy: EnhancedRetryPolicy,
-  now: number = Date.now(),
-): number {
-  const delayMs = applyJitter(calculateBackoffDelay(attemptNumber, policy), policy);
-  return now + delayMs;
-}
-
-/** Generate retry metadata for every configured attempt. */
-export function generateRetrySchedule(
-  policy: EnhancedRetryPolicy,
-  now: number = Date.now(),
-): RetrySchedule[] {
-  return Array.from({ length: policy.maxAttempts }, (_, index) => {
-    const attemptNumber = index + 1;
-    const delayMs = applyJitter(calculateBackoffDelay(attemptNumber, policy), policy);
-
-    return {
-      attemptNumber,
-      delayMs,
-      retryAt: now + delayMs,
-    };
-  });
-}
-
-/** Attach retry metadata to an outbox payload and return the next retry time. */
-export function scheduleWebhookOutboxRetry(input: WebhookOutboxRetryInput): WebhookOutboxRetryPlan {
-  const policy = input.policy ?? DEFAULT_RETRY_POLICY;
-  const nextAttemptNumber = input.attemptNumber + 1;
-
-  if (nextAttemptNumber > policy.maxAttempts) {
-    return {
-      shouldRetry: false,
-      attemptNumber: input.attemptNumber,
-      retryAt: null,
-      payload: input.payload,
-    };
-  }
-
-  const payload =
-    typeof input.payload === 'object' && input.payload !== null && !Array.isArray(input.payload)
-      ? { ...(input.payload as Record<string, unknown>), _webhookRetry: { attemptNumber: nextAttemptNumber } }
-      : { _webhookRetry: { attemptNumber: nextAttemptNumber } };
-
-  return {
-    shouldRetry: true,
-    attemptNumber: nextAttemptNumber,
-    retryAt: new Date(calculateNextRetryTime(input.attemptNumber, policy, input.now)),
-    payload,
-  };
-  const retryable = policy.retryableStatusCodes ?? DEFAULT_RETRY_POLICY.retryableStatusCodes;
-  return retryable.includes(statusCode);
 }
 
 /**
@@ -197,7 +156,7 @@ export function scheduleWebhookOutboxRetry(input: WebhookOutboxRetryInput): Webh
 export function calculateNextRetryTime(
   attemptNumber: number,
   policy: EnhancedRetryPolicy = DEFAULT_RETRY_POLICY,
-  now: number = Date.now(),
+  now: number = Date.now()
 ): number {
   if (attemptNumber >= policy.maxAttempts) return 0;
   const raw = calculateBackoffDelay(attemptNumber, policy);
@@ -210,10 +169,15 @@ export function calculateNextRetryTime(
  */
 export function generateRetrySchedule(
   policy: EnhancedRetryPolicy = DEFAULT_RETRY_POLICY,
-  now: number = Date.now(),
+  now: number = Date.now()
 ): RetrySchedule[] {
+  let previousDelayMs = policy.previousDelayMs;
+
   return Array.from({ length: policy.maxAttempts }, (_, i) => {
-    const delayMs = Math.round(applyJitter(calculateBackoffDelay(i, policy), policy));
+    const delayMs = Math.round(
+      applyJitter(calculateBackoffDelay(i, policy), { ...policy, previousDelayMs })
+    );
+    previousDelayMs = delayMs;
     return { attemptNumber: i + 1, delayMs, retryAt: now + delayMs };
   });
 }
@@ -223,7 +187,7 @@ export function shouldRetry(
   attempt: WebhookDeliveryAttempt,
   attemptNumber: number,
   policy: EnhancedRetryPolicy = DEFAULT_RETRY_POLICY,
-  consecutiveFailures: number = 0,
+  consecutiveFailures: number = 0
 ): boolean {
   if (attemptNumber >= policy.maxAttempts) return false;
 
@@ -240,7 +204,7 @@ export function shouldRetry(
 export function shouldSendToDLQ(
   attemptNumber: number,
   policy: EnhancedRetryPolicy = DEFAULT_RETRY_POLICY,
-  createdAt: number = Date.now(),
+  createdAt: number = Date.now()
 ): boolean {
   if (attemptNumber >= policy.maxAttempts) return true;
 
@@ -254,7 +218,7 @@ export function shouldSendToDLQ(
 /** Return the absolute timestamp at which the circuit breaker should reset. */
 export function calculateCircuitBreakerResetTime(
   policy: EnhancedRetryPolicy = DEFAULT_RETRY_POLICY,
-  now: number = Date.now(),
+  now: number = Date.now()
 ): number {
   return policy.circuitBreakerResetMs ? now + policy.circuitBreakerResetMs : 0;
 }
@@ -269,7 +233,7 @@ export const HALF_OPEN_CONTENTION_DEFERRAL_MS = 1_000;
 export function resolveCircuitBreakerDeferral(
   breaker: Pick<WebhookCircuitBreakerCheckResult, 'state' | 'resetAt'>,
   policy: EnhancedRetryPolicy = DEFAULT_RETRY_POLICY,
-  now: number = Date.now(),
+  now: number = Date.now()
 ): Date {
   if (breaker.resetAt !== null && breaker.resetAt > now) {
     return new Date(breaker.resetAt);
@@ -284,9 +248,14 @@ export function resolveCircuitBreakerDeferral(
 /** Return true when a failed attempt should increment the circuit-breaker failure count. */
 export function countsTowardCircuitBreaker(
   attempt: WebhookDeliveryAttempt,
-  policy: EnhancedRetryPolicy = DEFAULT_RETRY_POLICY,
+  policy: EnhancedRetryPolicy = DEFAULT_RETRY_POLICY
 ): boolean {
-  if (attempt.statusCode !== undefined && attempt.statusCode >= 200 && attempt.statusCode < 300 && !attempt.error) {
+  if (
+    attempt.statusCode !== undefined &&
+    attempt.statusCode >= 200 &&
+    attempt.statusCode < 300 &&
+    !attempt.error
+  ) {
     return false;
   }
   if (attempt.statusCode === undefined) return true;
@@ -304,7 +273,8 @@ export function formatRetryPolicy(policy: EnhancedRetryPolicy): string {
   if (policy.backoffStrategy) extras.push(`strategy=${policy.backoffStrategy}`);
   if (policy.jitterAlgorithm) extras.push(`jitter=${policy.jitterAlgorithm}`);
   if (policy.deadLetterAfterMs) extras.push(`dlq_after=${policy.deadLetterAfterMs}ms`);
-  if (policy.circuitBreakerThreshold) extras.push(`circuit_breaker=${policy.circuitBreakerThreshold}`);
+  if (policy.circuitBreakerThreshold)
+    extras.push(`circuit_breaker=${policy.circuitBreakerThreshold}`);
 
   return extras.length > 0 ? `${base}, ${extras.join(', ')}` : base;
 }
@@ -357,7 +327,7 @@ export async function checkWebhookDeliveryGate(
   consumerUrl: string,
   policy: EnhancedRetryPolicy = DEFAULT_RETRY_POLICY,
   deps: WebhookDeliveryGateDeps = {},
-  now: number = Date.now(),
+  now: number = Date.now()
 ): Promise<WebhookDeliveryGateResult> {
   const circuitBreakerStore = deps.circuitBreakerStore ?? getWebhookCircuitBreakerStore();
 
@@ -396,7 +366,7 @@ export async function checkWebhookDeliveryGate(
 export async function attemptWebhookDeliveryWithRateLimit(
   input: WebhookOutboxRetryInput,
   deliver: () => Promise<WebhookDeliveryAttempt>,
-  deps: WebhookDeliveryGateDeps = {},
+  deps: WebhookDeliveryGateDeps = {}
 ): Promise<WebhookOutboxRetryPlan & { attempt?: WebhookDeliveryAttempt }> {
   const policy = input.policy ?? DEFAULT_RETRY_POLICY;
   const now = input.now ?? Date.now();
@@ -424,14 +394,14 @@ export async function attemptWebhookDeliveryWithRateLimit(
   if (success) {
     const breakerRecord = await circuitBreakerStore.recordSuccess(
       input.consumerUrl,
-      policy as CircuitBreakerPolicy,
+      policy as CircuitBreakerPolicy
     );
     consecutiveFailures = breakerRecord.consecutiveFailures;
   } else if (countsTowardCircuitBreaker(attempt, policy)) {
     const breakerRecord = await circuitBreakerStore.recordFailure(
       input.consumerUrl,
       policy as CircuitBreakerPolicy,
-      now,
+      now
     );
     consecutiveFailures = breakerRecord.consecutiveFailures;
   }


### PR DESCRIPTION
Closes #343.

## Summary
- remove the stale duplicate retry helper block that prevented the retry tests from loading cleanly
- add full jitter support for webhook retry scheduling with an injectable RNG for deterministic tests
- add decorrelated jitter support using previous-delay state and the max-backoff cap
- keep `jitterPercent: 0` as the no-jitter escape hatch for deterministic scheduling
- update the webhook retry policy docs for full, equal, and decorrelated jitter semantics

## Validation
- `npx vitest run src/webhooks/retry.test.ts tests/webhooks.test.ts tests/webhooks/service.dispatcher.test.ts tests/webhooks/circuitBreaker.store.test.ts` (72 tests passed)
- `npx eslint src/webhooks/retry.ts src/webhooks/retry.test.ts` (passes; Node emits the existing module-type warning for `eslint.config.js`)
- `npx prettier --check src/webhooks/retry.ts src/webhooks/retry.test.ts`
- `git diff --check`

## Build note
- `npm run build` still fails on existing syntax errors in `src/openapi/spec.ts` starting at line 294. This branch does not modify `src/openapi/spec.ts` (`git diff --name-only origin/main -- src/openapi/spec.ts` is empty).