### PR TITLE
fix(validation): enforce Stellar decimal bounds

### DIFF
--- a/src/validation/schemas.ts
+++ b/src/validation/schemas.ts
@@ -10,6 +10,7 @@
  * @module validation/schemas
  */
 import { z } from 'zod';
+import { MAX_DECIMAL_INTEGER_PART, STELLAR_DECIMALS } from '../serialization/decimal.js';
 
 /** Regex for valid decimal strings: optional sign, digits, optional fraction */
 export const DECIMAL_STRING_REGEX = /^[+-]?\d+(\.\d+)?$/;
@@ -17,11 +18,33 @@ export const DECIMAL_STRING_REGEX = /^[+-]?\d+(\.\d+)?$/;
 /** Regex for valid Stellar public keys: G followed by 55 base32 characters */
 export const STELLAR_PUBLIC_KEY_REGEX = /^G[A-Z2-7]{55}$/;
 
-/** Reusable decimal-string field schema */
+function decimalParts(value: string): { integerPart: string; fractionalPart: string } {
+  const [integerPart = '', fractionalPart = ''] = value.replace(/^[+-]/, '').split('.');
+  return { integerPart, fractionalPart };
+}
+
+function hasIntegerPartWithinStellarBounds(value: string): boolean {
+  if (!DECIMAL_STRING_REGEX.test(value)) return true;
+  const { integerPart } = decimalParts(value);
+  return BigInt(integerPart) <= MAX_DECIMAL_INTEGER_PART;
+}
+
+function hasStellarFractionalPrecision(value: string): boolean {
+  if (!DECIMAL_STRING_REGEX.test(value)) return true;
+  const { fractionalPart } = decimalParts(value);
+  return fractionalPart.length <= STELLAR_DECIMALS;
+}
+
+/** Reusable decimal-string field schema bounded to Stellar amount representation. */
 function decimalStringField(fieldName: string) {
   return z
     .string({ error: `${fieldName} must be a decimal string, not a number` })
-    .regex(DECIMAL_STRING_REGEX, `${fieldName} must be a valid decimal string (e.g. "100", "0.0000116")`);
+    .regex(DECIMAL_STRING_REGEX, `${fieldName} must be a valid decimal string (e.g. "100", "0.0000116")`)
+    .refine(hasIntegerPartWithinStellarBounds, `${fieldName} exceeds maximum supported Stellar magnitude`)
+    .refine(
+      hasStellarFractionalPrecision,
+      `${fieldName} cannot have more than ${STELLAR_DECIMALS} fractional digits`,
+    );
 }
 
 /** Reusable Stellar public key field schema */

--- a/tests/validation-edge-cases.test.ts
+++ b/tests/validation-edge-cases.test.ts
@@ -24,7 +24,7 @@ import {
     validateJsonDepth,
     validateRequestSize,
 } from '../src/config/validation';
-import { StreamBatchCreateSchema } from '../src/validation/schemas';
+import { CreateStreamSchema, StreamBatchCreateSchema } from '../src/validation/schemas';
 
 const VALID_SENDER = 'GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN7';
 const VALID_RECIPIENT = 'GBDEVU63Y6NTHJQQZIKVTC23NWLQVP3WJ2RI2OTSJTNYOIGICST6DUXR';
@@ -375,6 +375,47 @@ describe('Validation Edge Cases & Failure Modes', () => {
             if (oversized.success) return;
 
             expect(oversized.error.issues.some((issue) => issue.message.includes('Maximum of 100'))).toBe(true);
+        });
+
+        it('rejects decimal strings above the Stellar magnitude at the API boundary', () => {
+            const result = CreateStreamSchema.safeParse({
+                sender: VALID_SENDER,
+                recipient: VALID_RECIPIENT,
+                depositAmount: '9223372036854775808',
+            });
+
+            expect(result.success).toBe(false);
+            if (result.success) return;
+
+            expect(result.error.issues[0]?.path).toEqual(['depositAmount']);
+            expect(result.error.issues[0]?.message).toContain('maximum supported Stellar magnitude');
+        });
+
+        it('rejects decimal strings with more than Stellar precision fractional digits', () => {
+            const result = StreamBatchCreateSchema.safeParse({
+                streams: [
+                    makeBatchStream(0, { rate_per_second: '0.00000001' }),
+                ],
+            });
+
+            expect(result.success).toBe(false);
+            if (result.success) return;
+
+            expect(result.error.issues[0]?.path).toEqual(['streams', 0, 'rate_per_second']);
+            expect(result.error.issues[0]?.message).toContain('more than 7 fractional digits');
+        });
+
+        it('accepts maximum in-range Stellar magnitude and precision', () => {
+            const result = StreamBatchCreateSchema.safeParse({
+                streams: [
+                    makeBatchStream(0, {
+                        amount: '9223372036854775807.9999999',
+                        streamed_amount: '0.0000001',
+                    }),
+                ],
+            });
+
+            expect(result.success).toBe(true);
         });
     });
 


### PR DESCRIPTION
## Summary
- bound reusable decimal string validation to the existing Stellar integer magnitude and fractional precision constants
- keep invalid-format decimals on the existing regex validation path before range checks
- add API-boundary regression coverage for over-magnitude, excess fractional precision, and max in-range values

## Validation
- `pnpm exec vitest run tests/validation-edge-cases.test.ts tests/decimal.test.ts`
- `pnpm exec eslint src/validation/schemas.ts tests/validation-edge-cases.test.ts` (0 errors; existing no-explicit-any warnings in the test file)
- `git diff --check`

## Notes
- `pnpm exec tsc --noEmit` is currently blocked by existing syntax errors in `src/openapi/spec.ts` around the cursor description string, before this change is type-checked.

Closes #366