### PR TITLE
feat(tracing): trace SSE fan-out dispatch

### DIFF
--- a/docs/TRACING.md
+++ b/docs/TRACING.md
@@ -23,6 +23,16 @@ The tracing system tracks:
 5. **Stream State Transitions** — Status changes and audit context
 6. **Error Classifications** — Categorized errors (database, auth, api, validation, unknown)
 
+### SSE Fan-out Dispatch
+
+Live Server-Sent Events delivery is traced with a bounded `sse.dispatch` span for each emitted stream update. The span records:
+
+- `sse.stream_id`
+- `sse.event_id`
+- `sse.subscriber_count`
+
+Per-subscriber identifiers are intentionally not recorded to avoid high-cardinality trace data. The SSE frame also includes a comment line in the form `: correlation-id <id>` before the `data:` line so clients and operators can correlate a delivered event with request logs without changing the JSON event payload.
+
 ### Observable Guarantees
 
 - **Request correlation**: Every request is linked to a unique correlation ID from X-Correlation-ID header

--- a/src/routes/streams.ts
+++ b/src/routes/streams.ts
@@ -133,6 +133,12 @@ const AMOUNT_FIELDS = ['depositAmount', 'ratePerSecond'] as const;
 const CACHEABLE_STREAM_HEADERS = 'public, max-age=300, stale-while-revalidate=60';
 const NO_STORE_STREAM_HEADERS = 'private, no-store';
 const SSE_HEARTBEAT_INTERVAL_MS = 30_000;
+const SAFE_SSE_CORRELATION_ID = /^[\x21-\x7E]{1,200}$/;
+
+function formatSseCorrelationComment(correlationId: string | undefined): string {
+  if (!correlationId || !SAFE_SSE_CORRELATION_ID.test(correlationId)) return '';
+  return `: correlation-id ${correlationId}\n`;
+}
 
 // ── Dependency state (injectable for tests) ───────────────────────────────────
 
@@ -1028,6 +1034,7 @@ streamsRouter.get(
                 const written = writeSse(
                   `id: ${event.eventId}\n` +
                   `event: ${SSE_STREAM_UPDATE_EVENT}\n` +
+                  formatSseCorrelationComment(req.correlationId) +
                   `data: ${JSON.stringify({
                     type: 'stream_update',
                     streamId: id,
@@ -1073,15 +1080,17 @@ streamsRouter.get(
     // 6. Subscribe to Real-Time Updates.
     const listener = (event: StreamUpdateEvent) => {
       if (event.streamId === id) {
+        const eventCorrelationId = req.correlationId || event.correlationId;
         writeSse(
           `id: ${event.eventId}\n` +
           `event: ${SSE_STREAM_UPDATE_EVENT}\n` +
+          formatSseCorrelationComment(eventCorrelationId) +
           `data: ${JSON.stringify({
             type: 'stream_update',
             streamId: event.streamId,
             eventId: event.eventId,
             payload: event.payload,
-            correlationId: req.correlationId || event.correlationId,
+            correlationId: eventCorrelationId,
           })}\n\n`,
         );
       }

--- a/src/streams/sseEmitter.ts
+++ b/src/streams/sseEmitter.ts
@@ -1,5 +1,6 @@
 import { EventEmitter } from 'node:events';
 import type { StreamEventRecord } from '../db/types.js';
+import { traceSseDispatch } from '../tracing/hooks.js';
 
 export const SSE_STREAM_UPDATE_EVENT = 'stream_update';
 
@@ -34,17 +35,19 @@ function dispatchLiveSseEvent(event: LiveSseStreamUpdateEvent): void {
   if (!event || typeof event.streamId !== 'string') return;
 
   const subscribers = liveSubscribersByStreamId.get(event.streamId);
-  if (!subscribers || subscribers.size === 0) return;
+  traceSseDispatch(event.streamId, event.eventId, subscribers?.size ?? 0, event.correlationId, () => {
+    if (!subscribers || subscribers.size === 0) return;
 
-  // Snapshot before iterating so a subscriber can disconnect during delivery
-  // without mutating the Set currently being traversed.
-  for (const subscriber of Array.from(subscribers)) {
-    try {
-      subscriber(event);
-    } catch {
-      // Isolate one failing connection from the rest of the stream fan-out.
+    // Snapshot before iterating so a subscriber can disconnect during delivery
+    // without mutating the Set currently being traversed.
+    for (const subscriber of Array.from(subscribers)) {
+      try {
+        subscriber(event);
+      } catch {
+        // Isolate one failing connection from the rest of the stream fan-out.
+      }
     }
-  }
+  });
 }
 
 function isDispatchAttached(): boolean {

--- a/src/tracing/hooks.ts
+++ b/src/tracing/hooks.ts
@@ -533,6 +533,43 @@ export async function traceWebhookDispatch<T>(
 }
 
 /**
+ * Wrap one Server-Sent Events fan-out in a tracing span.
+ *
+ * The span uses bounded attributes only: stream ID, event ID, and subscriber
+ * count. Per-subscriber IDs are intentionally omitted to avoid high-cardinality
+ * trace data.
+ */
+export function traceSseDispatch<T>(
+  streamId: string,
+  eventId: string,
+  subscriberCount: number,
+  correlationId: string | undefined,
+  fn: () => T,
+): T {
+  const tracer = getTracer();
+  const span = tracer.startSpan({
+    traceId: correlationId || getCorrelationIdFromContext(),
+    serviceName: 'fluxora-api',
+    tags: {
+      'span.name': 'sse.dispatch',
+      'sse.stream_id': streamId,
+      'sse.event_id': eventId,
+      'sse.subscriber_count': subscriberCount,
+    },
+  });
+
+  try {
+    const result = fn();
+    tracer.endSpan(span, 'ok');
+    return result;
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    tracer.endSpan(span, 'error', message);
+    throw err;
+  }
+}
+
+/**
  * Record a WebSocket broadcast event on the active OTel span (if any).
  * Does not create a new span — attaches an event to the current context.
  */
@@ -626,4 +663,3 @@ export function enrichActiveSpanWithStream(
     // ignore active span errors
   }
 }
-

--- a/tests/routes/streams-sse.test.ts
+++ b/tests/routes/streams-sse.test.ts
@@ -444,9 +444,16 @@ describe('GET /api/streams/:id/events (SSE Endpoint)', () => {
 
   it('streams live events via sseEventBus', async () => {
     mockGetById.mockResolvedValue(makeDbRecord({ id: 'stream-123' }));
+    const correlationId = '11111111-1111-4111-8111-111111111111';
 
     const resPromise = new Promise<string>((resolve) => {
-      const req = http.get(`http://127.0.0.1:${port}/api/streams/stream-123/events`, (res) => {
+      const req = http.get({
+        hostname: '127.0.0.1',
+        port,
+        path: '/api/streams/stream-123/events',
+        agent: false,
+        headers: { 'x-correlation-id': correlationId },
+      }, (res) => {
         let data = '';
         res.on('data', (chunk) => {
           data += chunk.toString();
@@ -469,6 +476,7 @@ describe('GET /api/streams/:id/events (SSE Endpoint)', () => {
     const output = await resPromise;
     expect(output).toContain('id: evt-live-001');
     expect(output).toContain('event: stream_update');
+    expect(output).toContain(`: correlation-id ${correlationId}`);
     expect(output).toContain('cancelled');
   });
 

--- a/tests/tracing/hooks.test.ts
+++ b/tests/tracing/hooks.test.ts
@@ -19,6 +19,7 @@ import {
   initializeTracer,
   getTracer,
   resetTracer,
+  traceSseDispatch,
 } from '../../src/tracing/hooks.js';
 import {
   SpanBuffer,
@@ -26,10 +27,21 @@ import {
   ErrorClassifier,
   createBuiltInHooks,
 } from '../../src/tracing/builtin.js';
+import {
+  _resetSseSubscriptionsForTest,
+  SSE_STREAM_UPDATE_EVENT,
+  sseEventBus,
+  subscribeToSseStream,
+} from '../../src/streams/sseEmitter.js';
 
 describe('Distributed Tracing Hooks', () => {
   beforeEach(() => {
     resetTracer();
+  });
+
+  afterEach(() => {
+    _resetSseSubscriptionsForTest();
+    sseEventBus.removeAllListeners(SSE_STREAM_UPDATE_EVENT);
   });
 
   describe('Tracer creation and configuration', () => {
@@ -126,6 +138,90 @@ describe('Distributed Tracing Hooks', () => {
 
       tracer.endSpan(span, 'ok');
       expect(span.endTimeMs).toBeUndefined(); // Not recorded
+    });
+
+    it('wraps SSE fan-out in a bounded dispatch span', () => {
+      const onSpanEnd = vi.fn();
+      initializeTracer({
+        enabled: true,
+        hooks: { onSpanEnd },
+      });
+
+      const result = traceSseDispatch('stream-123', 'evt-123', 3, 'corr-123', () => 'delivered');
+
+      expect(result).toBe('delivered');
+      expect(onSpanEnd).toHaveBeenCalledWith(
+        expect.objectContaining({
+          status: 'ok',
+          context: expect.objectContaining({
+            traceId: 'corr-123',
+            tags: expect.objectContaining({
+              'span.name': 'sse.dispatch',
+              'sse.stream_id': 'stream-123',
+              'sse.event_id': 'evt-123',
+              'sse.subscriber_count': 3,
+            }),
+          }),
+        })
+      );
+    });
+
+    it('closes the SSE dispatch span when fan-out throws', () => {
+      const onSpanEnd = vi.fn();
+      initializeTracer({
+        enabled: true,
+        hooks: { onSpanEnd },
+      });
+
+      expect(() =>
+        traceSseDispatch('stream-123', 'evt-err', 1, 'corr-err', () => {
+          throw new Error('subscriber write failed');
+        })
+      ).toThrow('subscriber write failed');
+
+      expect(onSpanEnd).toHaveBeenCalledWith(
+        expect.objectContaining({
+          status: 'error',
+          statusMessage: 'subscriber write failed',
+        })
+      );
+    });
+
+    it('emits an SSE dispatch span from the shared event bus fan-out', () => {
+      const onSpanEnd = vi.fn();
+      const subscriber = vi.fn();
+      initializeTracer({
+        enabled: true,
+        hooks: { onSpanEnd },
+      });
+
+      const unsubscribe = subscribeToSseStream('stream-123', subscriber);
+      sseEventBus.emit(SSE_STREAM_UPDATE_EVENT, {
+        streamId: 'stream-123',
+        eventId: 'evt-bus',
+        payload: { status: 'active' },
+        correlationId: 'corr-bus',
+      });
+
+      expect(subscriber).toHaveBeenCalledWith(
+        expect.objectContaining({ eventId: 'evt-bus' })
+      );
+      expect(onSpanEnd).toHaveBeenCalledWith(
+        expect.objectContaining({
+          status: 'ok',
+          context: expect.objectContaining({
+            traceId: 'corr-bus',
+            tags: expect.objectContaining({
+              'span.name': 'sse.dispatch',
+              'sse.stream_id': 'stream-123',
+              'sse.event_id': 'evt-bus',
+              'sse.subscriber_count': 1,
+            }),
+          }),
+        })
+      );
+
+      unsubscribe();
     });
   });
 


### PR DESCRIPTION
## Summary
- add `traceSseDispatch()` with bounded stream/event/subscriber-count attributes
- wrap shared SSE event-bus fan-out in the dispatch span while preserving subscriber isolation
- include a safe `: correlation-id ...` comment in emitted SSE frames for replayed and live events
- document the SSE trace-propagation contract and add regression coverage

## Validation
- `pnpm exec vitest run tests/tracing/hooks.test.ts`
- `git diff --check`

## Notes
- `pnpm exec vitest run tests/routes/streams-sse.test.ts` is currently blocked before this test runs by existing duplicate exports in `src/webhooks/retry.ts` (`calculateNextRetryTime`, `generateRetrySchedule`, `scheduleWebhookOutboxRetry`).
- `pnpm exec eslint ...` is currently blocked by existing lint errors in `src/routes/streams.ts` and `src/tracing/hooks.ts`; new tracing coverage itself passes.

Closes #362