### PR TITLE
feat(metrics): add JWT verify + API-key lookup latency histograms (closes #361)

### DIFF
--- a/docs/observability.md
+++ b/docs/observability.md
@@ -170,3 +170,95 @@ See the platform-specific guides:
 
 - [Datadog](integrations/datadog.md) — Agent log pipeline, JSON parsing, attribute remapping
 - [Elastic / ECS](integrations/elastic.md) — Filebeat config, ECS field mapping, index template
+
+---
+
+## Authentication Latency Histograms
+
+Auth runs on every protected request path. When the JWT verifier, revocation-store lookup, or API-key store becomes a bottleneck, these histograms give a distribution view (p50/p95/p99) and a split by success/failure — without leaking credential material.
+
+### Metrics
+
+| Metric Name | Type | Labels | Description |
+|-------------|------|--------|-------------|
+| `fluxora_auth_jwt_verify_duration_seconds` | Histogram | `outcome` (`success` \| `failure`) | Time spent in `verifyToken()` (the cryptographic verify only — does NOT include revocation check or schema parse). Recorded by `src/middleware/auth.ts`. |
+| `fluxora_auth_apikey_lookup_duration_seconds` | Histogram | `outcome` (`success` \| `failure`) | Time spent in API-key lookups. Recorded by `src/lib/apiKey.ts::isValidApiKey` and `src/middleware/adminAuth.ts::requireAdminAuth`. |
+
+### Bucket layout
+
+The bucket boundaries are intentionally bounded and tuned for each call site:
+
+```text
+fluxora_auth_jwt_verify_duration_seconds:        0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1
+fluxora_auth_apikey_lookup_duration_seconds:     0.0001, 0.0005, 0.001, 0.0025, 0.005, 0.01, 0.025, 0.05
+```
+
+Range rationale:
+
+- JWT verify buckets span 1 ms → 1 s. The measurement covers `verifyToken()` alone; the trailing revocation-check and schema-parse steps are intentionally excluded so an `outcome=success` observation reflects only successful cryptographic verification. A 401 caused by a downstream revocation hit or token-schema mismatch will appear as `outcome=success` on this histogram and is observable separately through the HTTP error-rate counter.
+- API-key lookup buckets span 100 µs → 50 ms because the in-memory store does a SHA-256 + `timingSafeEqual`, but a future DB-backed store (tracked separately) would shift the distribution to the millisecond range.
+
+### Security & label-cardinality guarantees
+
+The label set is intentionally restricted to a single `outcome` label. The metrics must **never** carry credential material. The following labels are forbidden both now and in future iterations:
+
+- `jti`, `kid`, `sub`, `subject`
+- `keyId`, `prefix`, `keyHash`, raw-key substrings
+- `address` / account ids derived from the token
+- `userId` / `principalId`
+
+Tests in `tests/metrics/businessMetrics.test.ts` explicitly assert the label set is `{ outcome: 'success' }` or `{ outcome: 'failure' }` only.
+
+### PromQL examples
+
+**p99 JWT verify latency**
+
+```promql
+histogram_quantile(
+  0.99,
+  rate(fluxora_auth_jwt_verify_duration_seconds_bucket[5m])
+)
+```
+
+**p99 API-key lookup latency**
+
+```promql
+histogram_quantile(
+  0.99,
+  rate(fluxora_auth_apikey_lookup_duration_seconds_bucket[5m])
+)
+```
+
+**Auth failure rate (any path) per second**
+
+```promql
+sum(rate(
+  fluxora_auth_jwt_verify_duration_seconds_count{outcome="failure"}[5m]
+))
++
+sum(rate(
+  fluxora_auth_apikey_lookup_duration_seconds_count{outcome="failure"}[5m]
+))
+```
+
+**Alert: JWT verify p99 > 250 ms for 5 minutes**
+
+```promql
+histogram_quantile(
+  0.99,
+  rate(fluxora_auth_jwt_verify_duration_seconds_bucket[5m])
+) > 0.25
+```
+
+### Thresholding strategy
+
+- **Latency p99 > 250 ms (JWT)**: indicates the revocation-store lookup is slow or the cryptographic step is being starved; pair with `redis_pending_commands` and CPU pressure signals.
+- **Latency p99 > 20 ms (API key, in-memory)**: useful as a canary when a DB-backed store is introduced, since lookups should remain single-digit milliseconds.
+- **Failure rate sustained > 5%**: indicates a misconfiguration in token issuance, key rotation, or upstream auth provider outage.
+
+### Affected source files
+
+- `src/metrics/businessMetrics.ts` — histogram definitions
+- `src/middleware/auth.ts` — JWT verify timer
+- `src/lib/apiKey.ts` — `isValidApiKey` timer
+- `src/middleware/adminAuth.ts` — admin env-var key check timer

--- a/src/lib/apiKey.ts
+++ b/src/lib/apiKey.ts
@@ -1,6 +1,7 @@
 import { createId } from '@paralleldrive/cuid2';
 import { createHash, timingSafeEqual } from 'crypto';
 import type { ApiKeyRecord, ApiKeyCreated } from '../db/types.js';
+import { authApiKeyLookupDurationSeconds } from '../metrics/businessMetrics.js';
 
 // ---------------------------------------------------------------------------
 // In-memory store (replace with DB-backed store when persistence is needed)
@@ -95,9 +96,21 @@ export function listApiKeys(): ApiKeyRecord[] {
 
 /**
  * Validates a raw API key against the stored hashes using constant-time comparison.
+ *
+ * Latency is recorded in the `fluxora_auth_apikey_lookup_duration_seconds`
+ * histogram, labelled only by `outcome` (`success` | `failure`). No key id,
+ * prefix, raw key, or hash value is ever emitted as a metric label.
+ *
+ * Every code path calls `endTimer` exactly once before returning, so the
+ * histogram never observes a partial (timer-started but never-closed) sample.
  */
 export function isValidApiKey(rawKey: string): boolean {
-  if (!rawKey) return false;
+  const endTimer = authApiKeyLookupDurationSeconds.startTimer();
+
+  if (!rawKey) {
+    endTimer({ outcome: 'failure' });
+    return false;
+  }
 
   const hash = sha256hex(rawKey);
   const hashBuf = Buffer.from(hash, 'hex');
@@ -107,6 +120,7 @@ export function isValidApiKey(rawKey: string): boolean {
     try {
       const storedBuf = Buffer.from(record.keyHash, 'hex');
       if (storedBuf.length === hashBuf.length && timingSafeEqual(storedBuf, hashBuf)) {
+        endTimer({ outcome: 'success' });
         return true;
       }
     } catch {
@@ -114,6 +128,7 @@ export function isValidApiKey(rawKey: string): boolean {
     }
   }
 
+  endTimer({ outcome: 'failure' });
   return false;
 }
 

--- a/src/metrics/businessMetrics.ts
+++ b/src/metrics/businessMetrics.ts
@@ -1,6 +1,58 @@
 import { Counter, Histogram, Gauge } from 'prom-client';
 import { registry } from '../metrics.js';
 
+/**
+ * Histogram tracking JWT verification latency in seconds.
+ *
+ * Auth runs on every protected request path. When the JWT verifier or the
+ * revocation-store lookup becomes a bottleneck, this histogram exposes the
+ * p50/p95/p99 distribution. Buckets are tuned for an in-process cryptographic
+ * verify plus an optional Redis revocation check — sub-millisecond through
+ * 1s — so the typical tail is visible without overcounting microseconds.
+ *
+ * @security
+ * - Label set is intentionally limited to `outcome` (`success` | `failure`)
+ *   to avoid emitting high-cardinality or credential-bearing labels
+ *   (no `jti`, `address`, `subject`, `kid`, etc.).
+ */
+export const authJwtVerifyDurationSeconds =
+  (registry.getSingleMetric('fluxora_auth_jwt_verify_duration_seconds') as Histogram<
+    'outcome'
+  >) ||
+  new Histogram({
+    name: 'fluxora_auth_jwt_verify_duration_seconds',
+    help: 'Duration of JWT signature verification in seconds, labeled by outcome',
+    labelNames: ['outcome'] as const,
+    buckets: [0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1],
+    registers: [registry],
+  });
+
+/**
+ * Histogram tracking API-key lookup latency in seconds.
+ *
+ * Records every API-key auth attempt that resolves a raw key against the
+ * key store (per-service keys via {@link isValidApiKey}) or against the
+ * admin env-var key ({@link requireAdminAuth}). The store is currently
+ * in-memory, so buckets are skewed to sub-millisecond values to expose
+ * regressions if a future DB-backed store is introduced.
+ *
+ * @security
+ * - Label set is intentionally limited to `outcome` (`success` | `failure`)
+ *   to avoid emitting high-cardinality or credential-bearing labels
+ *   (no key id, key prefix, hash, or raw key material).
+ */
+export const authApiKeyLookupDurationSeconds =
+  (registry.getSingleMetric('fluxora_auth_apikey_lookup_duration_seconds') as Histogram<
+    'outcome'
+  >) ||
+  new Histogram({
+    name: 'fluxora_auth_apikey_lookup_duration_seconds',
+    help: 'Duration of API key lookup in seconds, labeled by outcome',
+    labelNames: ['outcome'] as const,
+    buckets: [0.0001, 0.0005, 0.001, 0.0025, 0.005, 0.01, 0.025, 0.05],
+    registers: [registry],
+  });
+
 export const streamsCreatedTotal =
   (registry.getSingleMetric('fluxora_streams_created_total') as Counter<'status'>) ||
   new Counter({
@@ -63,6 +115,8 @@ export const indexerLagSeconds =
 
 /** Clean helper to de-register metrics between test runs. */
 export function deRegisterBusinessMetrics(): void {
+  registry.removeSingleMetric('fluxora_auth_jwt_verify_duration_seconds');
+  registry.removeSingleMetric('fluxora_auth_apikey_lookup_duration_seconds');
   registry.removeSingleMetric('fluxora_streams_created_total');
   registry.removeSingleMetric('fluxora_sse_active_connections');
   registry.removeSingleMetric('fluxora_sse_connections_rejected_total');

--- a/src/middleware/adminAuth.ts
+++ b/src/middleware/adminAuth.ts
@@ -1,4 +1,5 @@
 import type { Request, Response, NextFunction } from 'express';
+import { authApiKeyLookupDurationSeconds } from '../metrics/businessMetrics.js';
 
 /**
  * Middleware that gates admin routes behind a Bearer token.
@@ -6,11 +7,23 @@ import type { Request, Response, NextFunction } from 'express';
  * The token is compared against the `ADMIN_API_KEY` environment variable.
  * When the variable is unset the service refuses all admin requests —
  * fail-closed rather than fail-open.
+ *
+ * The check is recorded in `fluxora_auth_apikey_lookup_duration_seconds`
+ * with an `outcome` label only — no token material is ever included.
+ * "Unconfigured" outcomes are recorded as `failure` so a missing env-var
+ * is visible in the same panel as a credential mismatch.
  */
 export function requireAdminAuth(req: Request, res: Response, next: NextFunction): void {
+  const endTimer = authApiKeyLookupDurationSeconds.startTimer();
+
+  const recordOutcome = (outcome: 'success' | 'failure') => {
+    endTimer({ outcome });
+  };
+
   const adminKey = process.env.ADMIN_API_KEY;
 
   if (!adminKey) {
+    recordOutcome('failure');
     res.status(503).json({
       error: 'Admin API is not configured. Set ADMIN_API_KEY to enable admin access.',
     });
@@ -19,28 +32,33 @@ export function requireAdminAuth(req: Request, res: Response, next: NextFunction
 
   const header = req.headers.authorization;
   if (!header) {
+    recordOutcome('failure');
     res.status(401).json({ error: 'Missing Authorization header.' });
     return;
   }
 
   const parts = header.split(' ');
   if (parts.length !== 2 || parts[0] !== 'Bearer') {
+    recordOutcome('failure');
     res.status(401).json({ error: 'Authorization header must use Bearer scheme.' });
     return;
   }
 
   const token = parts[1];
   if (!token) {
+    recordOutcome('failure');
     res.status(401).json({ error: 'Bearer token is missing.' });
     return;
   }
 
   // Constant-time-ish comparison to reduce timing side-channels.
   if (token.length !== adminKey.length || !timingSafeEqual(token, adminKey)) {
+    recordOutcome('failure');
     res.status(403).json({ error: 'Invalid admin credentials.' });
     return;
   }
 
+  recordOutcome('success');
   next();
 }
 

--- a/src/middleware/auth.ts
+++ b/src/middleware/auth.ts
@@ -4,6 +4,7 @@ import { ApiErrorCode } from './errorHandler.js';
 import { warn, info, debug } from '../utils/logger.js';
 import { z } from 'zod';
 import { isRevoked } from '../redis/jwtRevocationStore.js';
+import { authJwtVerifyDurationSeconds } from '../metrics/businessMetrics.js';
 
 export enum Permission {
   STREAMS_READ = 'streams:read',
@@ -70,8 +71,21 @@ export async function authenticate(req: Request, res: Response, next: NextFuncti
   }
 
   try {
-    // 1. Verify signature and expiry (cryptographic check)
-    const payload = verifyToken(token) as unknown;
+    // 1. Verify signature and expiry (cryptographic check).
+    // Record latency around the verify call so p50/p95/p99 latency and the
+    // outcome split are observable from Prometheus. The outcome label is the
+    // ONLY label emitted; no token, jti, address, or subject is recorded.
+    const endJwtVerifyTimer = authJwtVerifyDurationSeconds.startTimer();
+    let jwtVerifyOutcome: 'success' | 'failure' = 'success';
+    let payload: unknown;
+    try {
+      payload = verifyToken(token) as unknown;
+    } catch (verifyErr) {
+      jwtVerifyOutcome = 'failure';
+      throw verifyErr;
+    } finally {
+      endJwtVerifyTimer({ outcome: jwtVerifyOutcome });
+    }
 
     // 2. Check revocation list (immediate invalidation check)
     const jti = (payload as any)?.jti;

--- a/tests/lib/auth.test.ts
+++ b/tests/lib/auth.test.ts
@@ -53,8 +53,16 @@ describe('Auth Module', () => {
 // ─── API Key Management ───────────────────────────────────────────────────────
 
 describe('API Key Management', () => {
-  beforeEach(() => {
+  beforeEach(async () => {
     _resetApiKeyStoreForTest();
+    // Reset the API key lookup histogram so existing tests don't leak
+    // observations into history-aware assertions in the histogram suite.
+    const mod = await import('../../src/metrics/businessMetrics.js');
+    try {
+      mod.authApiKeyLookupDurationSeconds.reset();
+    } catch {
+      // Metric may not be registered yet on first test run; safe to ignore.
+    }
   });
 
   describe('createApiKey', () => {
@@ -99,6 +107,67 @@ describe('API Key Management', () => {
 
     it('rejects empty string', () => {
       expect(isValidApiKey('')).toBe(false);
+    });
+  });
+
+  // ── API key lookup histogram (issue #361) ──
+  describe('fluxora_auth_apikey_lookup_duration_seconds histogram', () => {
+    let histogram: typeof import('../../src/metrics/businessMetrics.js').authApiKeyLookupDurationSeconds;
+
+    beforeEach(async () => {
+      const mod = await import('../../src/metrics/businessMetrics.js');
+      histogram = mod.authApiKeyLookupDurationSeconds;
+      histogram.reset();
+    });
+
+    /**
+     * Helper: prom-client Histogram `get()` exposes bucket observations
+     * (which include `le`) alongside `_count` / `_sum` series (which carry
+     * only the metric's declared labels). We assert on the count series to
+     * confirm the label set is bounded to `outcome`.
+     */
+    function findCountSeries(values: any[], outcome: string) {
+      return values.find(
+        (v) =>
+          v.metricName === 'fluxora_auth_apikey_lookup_duration_seconds_count' &&
+          (v.labels as Record<string, string>).outcome === outcome,
+      );
+    }
+
+    it('records outcome=success for a valid key (count series labels limited to outcome)', async () => {
+      const { key } = createApiKey('svc');
+      expect(isValidApiKey(key)).toBe(true);
+
+      const val = await histogram.get();
+      const success = findCountSeries(val.values, 'success');
+      expect(success).toBeDefined();
+      expect(success?.value).toBeGreaterThanOrEqual(1);
+      expect(Object.keys(success!.labels)).toEqual(['outcome']);
+    });
+
+    it('records outcome=failure for an unknown key (no credential leak via labels)', async () => {
+      createApiKey('svc');
+      expect(isValidApiKey('flx_unknown')).toBe(false);
+
+      const val = await histogram.get();
+      const failure = findCountSeries(val.values, 'failure');
+      expect(failure).toBeDefined();
+      expect(failure?.value).toBeGreaterThanOrEqual(1);
+      // No credential material ever appears in any labels (bucket or otherwise)
+      for (const v of val.values) {
+        for (const forbidden of ['keyId', 'prefix', 'keyHash', 'rawKey', 'address']) {
+          expect((v.labels as Record<string, unknown>)[forbidden]).toBeUndefined();
+        }
+      }
+    });
+
+    it('records outcome=failure for an empty string input (early-return path still observed)', async () => {
+      expect(isValidApiKey('')).toBe(false);
+
+      const val = await histogram.get();
+      const failure = findCountSeries(val.values, 'failure');
+      expect(failure).toBeDefined();
+      expect(failure?.value).toBeGreaterThanOrEqual(1);
     });
   });
 

--- a/tests/metrics/businessMetrics.test.ts
+++ b/tests/metrics/businessMetrics.test.ts
@@ -8,6 +8,8 @@ import {
   webhookDeliveryDurationSeconds,
   indexerEventsIngestedTotal,
   indexerLagSeconds,
+  authJwtVerifyDurationSeconds,
+  authApiKeyLookupDurationSeconds,
   deRegisterBusinessMetrics,
 } from '../../src/metrics/businessMetrics.js';
 import { WebhookService } from '../../src/webhooks/service.js';
@@ -23,6 +25,8 @@ beforeEach(() => {
     webhookDeliveryDurationSeconds.reset();
     indexerEventsIngestedTotal.reset();
     indexerLagSeconds.reset();
+    authJwtVerifyDurationSeconds.reset();
+    authApiKeyLookupDurationSeconds.reset();
   } catch {
     // no-op if already de-registered
   }
@@ -195,5 +199,112 @@ describe('Business Metrics Integration', () => {
     // Verify calling deRegister removes them
     deRegisterBusinessMetrics();
     expect(registry.getSingleMetric('fluxora_streams_created_total')).toBeUndefined();
+  });
+});
+
+// ───────────────────────────────────────────────────────────────────────────────
+// Issue #361 — auth-latency histograms
+// ───────────────────────────────────────────────────────────────────────────────
+describe('Auth Latency Histograms (issue #361)', () => {
+  describe('fluxora_auth_jwt_verify_duration_seconds', () => {
+    it('registers the histogram on the Prometheus registry', () => {
+      expect(
+        registry.getSingleMetric('fluxora_auth_jwt_verify_duration_seconds'),
+      ).toBe(authJwtVerifyDurationSeconds);
+    });
+
+    it('declares outcome as the only label (no high-cardinality labels)', () => {
+      const metric = registry.getSingleMetric('fluxora_auth_jwt_verify_duration_seconds');
+      // prom-client exposes labelNames as a readonly string[]
+      expect(metric?.labelNames).toEqual(['outcome']);
+    });
+
+    it('uses bounded bucket boundaries for auth latency', () => {
+      // Every bucket must be > 0 and strictly increasing
+      const upperBounds = (authJwtVerifyDurationSeconds as any).upperBounds as number[];
+      for (let i = 0; i < upperBounds.length; i++) {
+        expect(upperBounds[i]).toBeGreaterThan(0);
+        if (i > 0) {
+          expect(upperBounds[i]).toBeGreaterThan(upperBounds[i - 1]);
+        }
+      }
+      // Cover sub-millisecond through roughly 1 second for JWT verify
+      expect(upperBounds[0]).toBeLessThanOrEqual(0.001);
+      expect(upperBounds[upperBounds.length - 1]).toBeGreaterThanOrEqual(1);
+    });
+
+    it('records an outcome=success observation and only emits the outcome label', () => {
+      authJwtVerifyDurationSeconds.reset();
+      authJwtVerifyDurationSeconds.observe({ outcome: 'success' }, 0.012);
+
+      // Verify via /metrics endpoint
+      return request(app)
+        .get('/metrics')
+        .expect(200)
+        .then((res) => {
+          expect(res.text).toContain('fluxora_auth_jwt_verify_duration_seconds');
+          expect(res.text).toContain('outcome="success"');
+        });
+    });
+  });
+
+  describe('fluxora_auth_apikey_lookup_duration_seconds', () => {
+    it('registers the histogram on the Prometheus registry', () => {
+      expect(
+        registry.getSingleMetric('fluxora_auth_apikey_lookup_duration_seconds'),
+      ).toBe(authApiKeyLookupDurationSeconds);
+    });
+
+    it('declares outcome as the only label (no high-cardinality labels)', () => {
+      const metric = registry.getSingleMetric('fluxora_auth_apikey_lookup_duration_seconds');
+      expect(metric?.labelNames).toEqual(['outcome']);
+    });
+
+    it('uses bounded bucket boundaries for in-memory hash-compare latency', () => {
+      const upperBounds = (authApiKeyLookupDurationSeconds as any).upperBounds as number[];
+      for (let i = 0; i < upperBounds.length; i++) {
+        expect(upperBounds[i]).toBeGreaterThan(0);
+        if (i > 0) {
+          expect(upperBounds[i]).toBeGreaterThan(upperBounds[i - 1]);
+        }
+      }
+      // Bucket range is skewed sub-millisecond through 50 ms for hash compare
+      expect(upperBounds[0]).toBeLessThanOrEqual(0.0001);
+      expect(upperBounds[upperBounds.length - 1]).toBeGreaterThanOrEqual(0.05);
+    });
+
+    it('records an outcome=failure observation and only emits the outcome label', async () => {
+      authApiKeyLookupDurationSeconds.reset();
+      authApiKeyLookupDurationSeconds.observe({ outcome: 'failure' }, 0.0005);
+
+      const val = await authApiKeyLookupDurationSeconds.get();
+      // Only one labelled series, and the labels are exactly { outcome }
+      expect(val.values.some((v) => v.labels.outcome === 'failure' && v.value === 1)).toBe(true);
+      for (const v of val.values) {
+        expect(Object.keys(v.labels)).toEqual(['outcome']);
+      }
+    });
+
+    it('emits no credential material as labels (security guarantee)', async () => {
+      authApiKeyLookupDurationSeconds.reset();
+      // Observe with the only permitted label set
+      authApiKeyLookupDurationSeconds.observe({ outcome: 'success' }, 0.001);
+
+      const val = await authApiKeyLookupDurationSeconds.get();
+      const forbidden = ['keyId', 'key_id', 'prefix', 'principal', 'jti', 'address', 'subject'];
+      for (const v of val.values) {
+        for (const f of forbidden) {
+          expect((v.labels as Record<string, unknown>)[f]).toBeUndefined();
+        }
+      }
+    });
+  });
+
+  describe('de-registration', () => {
+    it('removes both auth histograms from the registry', () => {
+      deRegisterBusinessMetrics();
+      expect(registry.getSingleMetric('fluxora_auth_jwt_verify_duration_seconds')).toBeUndefined();
+      expect(registry.getSingleMetric('fluxora_auth_apikey_lookup_duration_seconds')).toBeUndefined();
+    });
   });
 });

--- a/tests/middleware/adminAuth.test.ts
+++ b/tests/middleware/adminAuth.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import request from 'supertest';
 import express from 'express';
 import { requireAdminAuth } from '../../src/middleware/adminAuth.js';
+import { authApiKeyLookupDurationSeconds } from '../../src/metrics/businessMetrics.js';
 
 function buildApp() {
   const app = express();
@@ -86,5 +87,71 @@ describe('requireAdminAuth middleware', () => {
       .set('Authorization', `Bearer ${ADMIN_KEY}`);
     expect(res.status).toBe(200);
     expect(res.body).toEqual({ ok: true });
+  });
+
+  // ── API key lookup histogram (issue #361) ──
+  describe('fluxora_auth_apikey_lookup_duration_seconds histogram', () => {
+    beforeEach(() => {
+      authApiKeyLookupDurationSeconds.reset();
+    });
+
+    /**
+     * prom-client Histogram `get()` emits bucket observations (which include
+     * `le`) alongside `_count` / `_sum` series (which carry only the metric's
+     * declared labels). We assert on the count series to confirm the label
+     * set is bounded to `outcome`.
+     */
+    function findApiKeyCountSeries(values: any[], outcome: string) {
+      return values.find(
+        (v) =>
+          v.metricName === 'fluxora_auth_apikey_lookup_duration_seconds_count' &&
+          (v.labels as Record<string, string>).outcome === outcome,
+      );
+    }
+
+    it('records outcome=success for a correct admin token (count series labels limited to outcome)', async () => {
+      process.env.ADMIN_API_KEY = ADMIN_KEY;
+      await request(buildApp())
+        .get('/protected')
+        .set('Authorization', `Bearer ${ADMIN_KEY}`)
+        .expect(200);
+
+      const val = await authApiKeyLookupDurationSeconds.get();
+      const success = findApiKeyCountSeries(val.values, 'success');
+      expect(success).toBeDefined();
+      expect(success?.value).toBeGreaterThanOrEqual(1);
+      expect(Object.keys(success!.labels)).toEqual(['outcome']);
+    });
+
+    it('records outcome=failure for an incorrect admin token', async () => {
+      process.env.ADMIN_API_KEY = ADMIN_KEY;
+      await request(buildApp())
+        .get('/protected')
+        .set('Authorization', 'Bearer wrong-key')
+        .expect(403);
+
+      const val = await authApiKeyLookupDurationSeconds.get();
+      const failure = findApiKeyCountSeries(val.values, 'failure');
+      expect(failure).toBeDefined();
+      expect(failure?.value).toBeGreaterThanOrEqual(1);
+    });
+
+    it('records outcome=failure when ADMIN_API_KEY is not configured (still observable, no credential leak)', async () => {
+      delete process.env.ADMIN_API_KEY;
+      await request(buildApp())
+        .get('/protected')
+        .set('Authorization', `Bearer ${ADMIN_KEY}`)
+        .expect(503);
+
+      const val = await authApiKeyLookupDurationSeconds.get();
+      const failure = findApiKeyCountSeries(val.values, 'failure');
+      expect(failure).toBeDefined();
+      expect(failure?.value).toBeGreaterThanOrEqual(1);
+      for (const v of val.values) {
+        for (const forbidden of ['keyId', 'prefix', 'token']) {
+          expect((v.labels as Record<string, unknown>)[forbidden]).toBeUndefined();
+        }
+      }
+    });
   });
 });

--- a/tests/unit/middleware/auth.test.ts
+++ b/tests/unit/middleware/auth.test.ts
@@ -213,6 +213,79 @@ describe('authenticate', () => {
 
     expect(res.statusCode).toBe(401);
   });
+
+  // ── JWT verify histogram (issue #361) ──
+  /**
+   * prom-client Histogram `get()` emits bucket observations (which include
+   * `le`) alongside `_count` / `_sum` series (which carry only the metric's
+   * declared labels). We assert on the count series to confirm the label
+   * set is bounded to `outcome`.
+   */
+  function findJwtCountSeries(values: any[], outcome: string) {
+    return values.find(
+      (v) =>
+        v.metricName === 'fluxora_auth_jwt_verify_duration_seconds_count' &&
+        (v.labels as Record<string, string>).outcome === outcome,
+    );
+  }
+
+  it('records fluxora_auth_jwt_verify_duration_seconds with outcome=success on a valid verify', async () => {
+    const { authJwtVerifyDurationSeconds } = await import(
+      '../../../src/metrics/businessMetrics.js'
+    );
+    authJwtVerifyDurationSeconds.reset();
+
+    const payload = {
+      address: 'GABC...',
+      role: 'operator',
+      permissions: [Permission.STREAMS_READ],
+      jti: 'jti-hist-success',
+    };
+    (verifyToken as any).mockReturnValue(payload);
+    (isRevoked as any).mockResolvedValue(false);
+
+    const req = mockReq({ authHeader: 'Bearer valid-histogram-token' }) as Request;
+    const res = mockRes() as Response;
+    const next = mockNext();
+
+    await authenticate(req, res, next);
+
+    const val = await authJwtVerifyDurationSeconds.get();
+    const success = findJwtCountSeries(val.values, 'success');
+    expect(success).toBeDefined();
+    expect(success?.value).toBeGreaterThanOrEqual(1);
+    // count series carries only { outcome }
+    expect(Object.keys(success!.labels)).toEqual(['outcome']);
+  });
+
+  it('records fluxora_auth_jwt_verify_duration_seconds with outcome=failure on verify throw', async () => {
+    const { authJwtVerifyDurationSeconds } = await import(
+      '../../../src/metrics/businessMetrics.js'
+    );
+    authJwtVerifyDurationSeconds.reset();
+
+    (verifyToken as any).mockImplementation(() => {
+      throw new Error('jwt malformed');
+    });
+
+    const req = mockReq({ authHeader: 'Bearer throw-token' }) as Request;
+    const res = mockRes() as Response;
+    const next = mockNext();
+
+    await authenticate(req, res, next);
+
+    const val = await authJwtVerifyDurationSeconds.get();
+    const failure = findJwtCountSeries(val.values, 'failure');
+    expect(failure).toBeDefined();
+    expect(failure?.value).toBeGreaterThanOrEqual(1);
+    expect(Object.keys(failure!.labels)).toEqual(['outcome']);
+    // No token material leaked into any label across bucket/count/sum series
+    for (const v of val.values) {
+      for (const forbidden of ['jti', 'address', 'subject', 'kid']) {
+        expect((v.labels as Record<string, unknown>)[forbidden]).toBeUndefined();
+      }
+    }
+  });
 });
 
 describe('requireAuth', () => {


### PR DESCRIPTION
## Summary

Resolves **#361**.

Adds two Prometheus histograms to `src/metrics/businessMetrics.ts` and records them around every auth lookup in the request path:

| Metric | Type | Labels | Recorded at |
|--------|------|--------|-------------|
| `fluxora_auth_jwt_verify_duration_seconds` | Histogram | `outcome` | `verifyToken()` in `src/middleware/auth.ts::authenticate` |
| `fluxora_auth_apikey_lookup_duration_seconds` | Histogram | `outcome` | `isValidApiKey()` in `src/lib/apiKey.ts`; `requireAdminAuth()` in `src/middleware/adminAuth.ts` |

### Bucket layout

- **JWT verify**: `[0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1]` seconds — covers in-process crypto verify tail.
- **API key lookup**: `[0.0001, 0.0005, 0.001, 0.0025, 0.005, 0.01, 0.025, 0.05]` seconds — skewed to sub-ms because the in-memory store does SHA-256 + `timingSafeEqual`; would shift to the millisecond range when a future DB-backed store is introduced.

### Security guarantees (and how they are enforced)

The label set is intentionally restricted to the single `outcome` label (`success` | `failure`). No credential material is ever emitted:

- No `jti`, `kid`, `sub`, `subject`, `address`
- No `keyId`, `prefix`, `keyHash`, or raw-key substrings

Two test layers enforce this:

1. `tests/metrics/businessMetrics.test.ts` asserts `labelNames === [outcome]` and that forbidden labels never appear on any observed value.
2. Each call-site test asserts the prom-client `_count` series (which carries only the declared labels) has exactly `{ outcome }`, and iterates all bucket/count/sum values to verify no forbidden label is present.

### Files changed

- `src/metrics/businessMetrics.ts` — adds both histograms with security TSDoc; updates `deRegisterBusinessMetrics`.
- `src/middleware/auth.ts` — wraps `verifyToken()` with the JWT-verify histogram (success on resolved payload, failure on throw).
- `src/lib/apiKey.ts` — wraps `isValidApiKey()`; every return path calls `endTimer(...)` exactly once early-return paths included.
- `src/middleware/adminAuth.ts` — wraps `requireAdminAuth()`; every branch calls `recordOutcome` before returning.
- `tests/metrics/businessMetrics.test.ts` — registration, label-set, bucket-bound, security, scrape-integration assertions.
- `tests/unit/middleware/auth.test.ts` — JWT verify outcomes (success path, throw path) + security assertion.
- `tests/lib/auth.test.ts` — API key lookup outcomes (valid, unknown, empty-string) + security.
- `tests/middleware/adminAuth.test.ts` — admin auth outcomes (success, wrong token, missing env) + security.
- `docs/observability.md` — new **Authentication Latency Histograms** section with metric catalog, bucket rationale, label-cardinality guarantees, and PromQL examples.

### Test results

- `tests/unit/middleware/auth.test.ts` — 11/11 pass
- `tests/middleware/adminAuth.test.ts` — 10/10 pass
- `tests/lib/auth.test.ts` — 17/17 pass (including the new histogram suite)

> **Note on pre-existing build noise**: `tsc --noEmit` on the project surfaces unrelated syntax errors in `src/openapi/spec.ts` (mid-template-string corruption around line 294) and vitest transform rejects the unrelated duplicate exports in `src/webhooks/retry.ts` (`calculateNextRetryTime`, `generateRetrySchedule`, `scheduleWebhookOutboxRetry` are each declared twice). These are present on `main` and **do not** come from this PR. They prevent the `businessMetrics.test.ts` suite from running end-to-end in the current tree; the metrics themselves are exercised through the three suites listed above which all pass cleanly. Both pre-existing issues should be tracked separately.

### PromQL examples

```promql
# p99 JWT verify latency
histogram_quantile(0.99, rate(fluxora_auth_jwt_verify_duration_seconds_bucket[5m]))

# p99 API-key lookup latency
histogram_quantile(0.99, rate(fluxora_auth_apikey_lookup_duration_seconds_bucket[5m]))

# Auth failure rate (any path) per second
sum(rate(fluxora_auth_jwt_verify_duration_seconds_count{outcome="failure"}[5m]))
+ sum(rate(fluxora_auth_apikey_lookup_duration_seconds_count{outcome="failure"}[5m]))
```

### Acceptance criteria checklist

- [x] JWT verify and API-key lookup histograms are exported
- [x] Auth middleware records both
- [x] Labels limited to `outcome`; no high-cardinality labels
- [x] Buckets are bounded and documented
- [x] Tests assert observations are recorded (count-series assertions; security label-leak guards)

Closes #361