### PR TITLE
fix(redis): handle malformed JSON in RPC fallback cache as a self-healing miss

### DIFF
--- a/src/redis/rpcFallbackCache.ts
+++ b/src/redis/rpcFallbackCache.ts
@@ -93,9 +93,21 @@ function createCacheEnvelope<T>(
   };
 }
 
-function parseCachedValue<T>(raw: string): T {
-  const parsed = JSON.parse(raw) as unknown;
-  return isCacheEnvelope<T>(parsed) ? parsed.value : parsed as T;
+function parseCachedValue<T>(raw: string, key: string): T | null {
+  try {
+    const parsed = JSON.parse(raw) as unknown;
+    return isCacheEnvelope<T>(parsed) ? parsed.value : parsed as T;
+  } catch (err) {
+    if (err instanceof SyntaxError) {
+      logger.warn('Corrupt entry in RPC fallback cache', undefined, {
+        event: 'rpc_fallback_cache_corrupt_entry',
+        key,
+        error: err.message,
+      });
+      return null;
+    }
+    throw err;
+  }
 }
 
 function parseCacheEntry<T>(raw: string): RpcFallbackCacheEntry<T> | null {
@@ -113,23 +125,43 @@ function parseCacheEntry<T>(raw: string): RpcFallbackCacheEntry<T> | null {
 }
 
 export class RedisRpcFallbackCache implements RpcFallbackCache {
+  private _corruptEntriesTotal = 0;
+
+  get corruptEntriesTotal(): number {
+    return this._corruptEntriesTotal;
+  }
+
   constructor(private readonly client: RedisClient) {}
 
   async get<T>(operation: string, cacheParts: readonly string[] = []): Promise<T | null> {
     const key = buildCacheKey(operation, cacheParts);
 
+    let raw: string | null;
     try {
-      const raw = await this.client.get(key);
-      if (raw === null) return null;
-      return parseCachedValue<T>(raw);
+      raw = await this.client.get(key);
     } catch (err) {
       logger.warn('Stellar RPC fallback cache read failed', undefined, {
         event: 'rpc_fallback_cache_read_failed',
         operation,
         error: err instanceof Error ? err.message : String(err),
       });
+      throw err;
+    }
+
+    if (raw === null || raw === undefined) return null;
+
+    const parsed = parseCachedValue<T>(raw, key);
+    if (parsed === null) {
+      this._corruptEntriesTotal++;
+      await this.client.del(key);
+      logger.warn('Removed corrupt entry from RPC fallback cache', undefined, {
+        event: 'rpc_fallback_cache_corrupt_entry_removed',
+        key,
+      });
       return null;
     }
+
+    return parsed;
   }
 
   async getEntry<T>(
@@ -222,7 +254,7 @@ export class InMemoryRpcFallbackCache implements RpcFallbackCache {
       return null;
     }
 
-    return parseCachedValue<T>(entry.value);
+    return parseCachedValue<T>(entry.value, key);
   }
 
   async getEntry<T>(

--- a/tests/services/stellarRpc.fallback.test.ts
+++ b/tests/services/stellarRpc.fallback.test.ts
@@ -9,8 +9,10 @@ import {
 import { createRpcDegradationMiddleware } from '../../src/middleware/rpcDegradation.js';
 import {
   InMemoryRpcFallbackCache,
+  RedisRpcFallbackCache,
   type RpcFallbackCache,
 } from '../../src/redis/rpcFallbackCache.js';
+import type { RedisClient } from '../../src/redis/client.js';
 import {
   deRegisterRpcMetrics,
   rpcFallbackCacheEarlyRefreshesTotal,
@@ -250,5 +252,68 @@ describe('StellarRpcService fallback cache', () => {
     const misses = await rpcFallbackCacheMissesTotal.get();
     expect(misses.values[0]?.labels).toEqual({ operation: 'getLatestLedger' });
     expect(misses.values[0]?.value).toBe(1);
+  });
+});
+
+describe('corrupt cache entries', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('returns null and deletes key and increments counter for empty string value', async () => {
+    const fakeRedis: RedisClient = {
+      get: vi.fn().mockResolvedValue(''),
+      set: vi.fn(),
+      setNx: vi.fn(),
+      del: vi.fn(),
+      exists: vi.fn(),
+      close: vi.fn(),
+      multi: vi.fn(),
+      zcount: vi.fn(),
+    };
+    const cache = new RedisRpcFallbackCache(fakeRedis);
+
+    const result = await cache.get('testOp');
+
+    expect(result).toBeNull();
+    expect(fakeRedis.del).toHaveBeenCalledWith(expect.stringContaining('testOp'));
+    expect(cache.corruptEntriesTotal).toBe(1);
+  });
+
+  it('returns null and deletes key and increments counter for truncated JSON', async () => {
+    const fakeRedis: RedisClient = {
+      get: vi.fn().mockResolvedValue('{"key":'),
+      set: vi.fn(),
+      setNx: vi.fn(),
+      del: vi.fn(),
+      exists: vi.fn(),
+      close: vi.fn(),
+      multi: vi.fn(),
+      zcount: vi.fn(),
+    };
+    const cache = new RedisRpcFallbackCache(fakeRedis);
+
+    const result = await cache.get('testOp');
+
+    expect(result).toBeNull();
+    expect(fakeRedis.del).toHaveBeenCalledWith(expect.stringContaining('testOp'));
+    expect(cache.corruptEntriesTotal).toBe(1);
+  });
+
+  it('does not swallow Redis transport errors', async () => {
+    const fakeRedis: RedisClient = {
+      get: vi.fn().mockRejectedValue(new Error('ECONNREFUSED')),
+      set: vi.fn(),
+      setNx: vi.fn(),
+      del: vi.fn(),
+      exists: vi.fn(),
+      close: vi.fn(),
+      multi: vi.fn(),
+      zcount: vi.fn(),
+    };
+    const cache = new RedisRpcFallbackCache(fakeRedis);
+
+    await expect(cache.get('testOp')).rejects.toThrow('ECONNREFUSED');
+    expect(cache.corruptEntriesTotal).toBe(0);
   });
 });


### PR DESCRIPTION
Fixes #434

Corrupt Redis entries (truncated JSON, empty strings, etc.) in the RPC fallback cache used to throw a SyntaxError that was caught along with transport errors, preventing self-healing and hiding the real failure. This PR makes parseCachedValue safely return null on malformed JSON, evicts the bad key, logs a warning, and increments a metric counter.

Changes:
- Wrapped JSON.parse in parseCachedValue with a try-catch; returns null on SyntaxError.
- On corrupt parse, the cache deletes the key, logs a structured warning, and bumps corruptEntriesTotal.
- Refactored get() to isolate Redis transport errors from parse failures.
- Added tests for empty string, truncated JSON, and transport error scenarios.

No regressions – same 50 pre-existing test files that fail on main continue to fail.