### PR TITLE
feat(rpc-cache): meter envelope-validation failures as corruption

### DIFF
--- a/docs/stellar-rpc.md
+++ b/docs/stellar-rpc.md
@@ -36,9 +36,10 @@ When the circuit is `OPEN`:
 
 Closed-circuit cache behavior emits:
 
-- `rpc_fallback_cache_hits_total`
-- `rpc_fallback_cache_misses_total`
-- `rpc_fallback_cache_early_refreshes_total`
+  - `rpc_fallback_cache_hits_total`
+  - `rpc_fallback_cache_misses_total`
+  - `rpc_fallback_cache_early_refreshes_total`
+  - `fluxora_rpc_cache_corrupt_total`
 
 Redis cache read/write failures are logged as warnings and treated as misses or no-op writes. The fallback cache must not become a hard dependency for normal RPC calls.
 

--- a/src/metrics/rpcMetrics.ts
+++ b/src/metrics/rpcMetrics.ts
@@ -46,10 +46,25 @@ export const rpcFallbackCacheEarlyRefreshesTotal =
     registers: [registry],
   });
 
+/**
+ * Counter for cache corruption events (e.g., SyntaxError or invalid envelope shape).
+ * Useful for alerting on cache poisoning or serialization regressions.
+ */
+export const fluxora_rpc_cache_corrupt_total =
+  (registry.getSingleMetric('fluxora_rpc_cache_corrupt_total') as Counter<'operation' | 'reason'>) ||
+  new Counter({
+    name: 'fluxora_rpc_cache_corrupt_total',
+    help: 'Total Stellar RPC calls that encountered corrupt data in the Redis fallback cache',
+    labelNames: ['operation', 'reason'] as const,
+    registers: [registry],
+  });
+
 export function deRegisterRpcMetrics(): void {
   registry.removeSingleMetric('rpc_circuit_open_fallback_hits_total');
   registry.removeSingleMetric('rpc_circuit_open_fallback_misses_total');
   registry.removeSingleMetric('rpc_fallback_cache_hits_total');
   registry.removeSingleMetric('rpc_fallback_cache_misses_total');
   registry.removeSingleMetric('rpc_fallback_cache_early_refreshes_total');
+  registry.removeSingleMetric('fluxora_rpc_cache_corrupt_total');
 }
+

--- a/src/redis/rpcFallbackCache.ts
+++ b/src/redis/rpcFallbackCache.ts
@@ -13,6 +13,7 @@
 import { createHash } from 'crypto';
 import type { RedisClient } from './client.js';
 import { logger } from '../lib/logger.js';
+import { fluxora_rpc_cache_corrupt_total } from '../metrics/rpcMetrics.js';
 
 export const RPC_FALLBACK_CACHE_PREFIX = 'rpc:cache::';
 const SAFE_OPERATION = /^[A-Za-z0-9._-]+$/;
@@ -96,13 +97,24 @@ function createCacheEnvelope<T>(
 function parseCachedValue<T>(raw: string, key: string): T | null {
   try {
     const parsed = JSON.parse(raw) as unknown;
-    return isCacheEnvelope<T>(parsed) ? parsed.value : parsed as T;
+    if (!isCacheEnvelope<T>(parsed)) {
+      fluxora_rpc_cache_corrupt_total.inc({ operation: 'unknown', reason: 'wrong_shape' });
+      logger.warn('Corrupt entry in RPC fallback cache', undefined, {
+        event: 'rpc_fallback_cache_corrupt_entry',
+        key,
+        reason: 'wrong_shape',
+      });
+      return null;
+    }
+    return parsed.value;
   } catch (err) {
     if (err instanceof SyntaxError) {
+      fluxora_rpc_cache_corrupt_total.inc({ operation: 'unknown', reason: 'syntax_error' });
       logger.warn('Corrupt entry in RPC fallback cache', undefined, {
         event: 'rpc_fallback_cache_corrupt_entry',
         key,
         error: err.message,
+        reason: 'syntax_error',
       });
       return null;
     }
@@ -110,18 +122,38 @@ function parseCachedValue<T>(raw: string, key: string): T | null {
   }
 }
 
-function parseCacheEntry<T>(raw: string): RpcFallbackCacheEntry<T> | null {
-  const parsed = JSON.parse(raw) as unknown;
-  if (!isCacheEnvelope<T>(parsed)) {
-    return null;
+function parseCacheEntry<T>(raw: string, key: string): RpcFallbackCacheEntry<T> | null {
+  try {
+    const parsed = JSON.parse(raw) as unknown;
+    if (!isCacheEnvelope<T>(parsed)) {
+      fluxora_rpc_cache_corrupt_total.inc({ operation: 'unknown', reason: 'wrong_shape' });
+      logger.warn('Corrupt entry in RPC fallback cache metadata', undefined, {
+        event: 'rpc_fallback_cache_corrupt_entry',
+        key,
+        reason: 'wrong_shape',
+      });
+      return null;
+    }
+    return {
+      value: parsed.value,
+      writtenAt: parsed.writtenAt,
+      expiresAt: parsed.expiresAt,
+      ttlSeconds: parsed.ttlSeconds,
+      refreshDurationMs: parsed.refreshDurationMs,
+    };
+  } catch (err) {
+    if (err instanceof SyntaxError) {
+      fluxora_rpc_cache_corrupt_total.inc({ operation: 'unknown', reason: 'syntax_error' });
+      logger.warn('Corrupt entry in RPC fallback cache metadata', undefined, {
+        event: 'rpc_fallback_cache_corrupt_entry',
+        key,
+        error: err.message,
+        reason: 'syntax_error',
+      });
+      return null;
+    }
+    throw err;
   }
-  return {
-    value: parsed.value,
-    writtenAt: parsed.writtenAt,
-    expiresAt: parsed.expiresAt,
-    ttlSeconds: parsed.ttlSeconds,
-    refreshDurationMs: parsed.refreshDurationMs,
-  };
 }
 
 export class RedisRpcFallbackCache implements RpcFallbackCache {
@@ -173,7 +205,17 @@ export class RedisRpcFallbackCache implements RpcFallbackCache {
     try {
       const raw = await this.client.get(key);
       if (raw === null) return null;
-      return parseCacheEntry<T>(raw);
+      const parsed = parseCacheEntry<T>(raw, key);
+      if (parsed === null) {
+        this._corruptEntriesTotal++;
+        await this.client.del(key);
+        logger.warn('Removed corrupt entry from RPC fallback cache', undefined, {
+          event: 'rpc_fallback_cache_corrupt_entry_removed',
+          key,
+        });
+        return null;
+      }
+      return parsed;
     } catch (err) {
       logger.warn('Stellar RPC fallback cache metadata read failed', undefined, {
         event: 'rpc_fallback_cache_metadata_read_failed',

--- a/tests/services/stellarRpc.fallback.test.ts
+++ b/tests/services/stellarRpc.fallback.test.ts
@@ -15,6 +15,7 @@ import {
 import type { RedisClient } from '../../src/redis/client.js';
 import {
   deRegisterRpcMetrics,
+  fluxora_rpc_cache_corrupt_total,
   rpcFallbackCacheEarlyRefreshesTotal,
   rpcFallbackCacheHitsTotal,
   rpcFallbackCacheMissesTotal,
@@ -258,6 +259,7 @@ describe('StellarRpcService fallback cache', () => {
 describe('corrupt cache entries', () => {
   afterEach(() => {
     vi.restoreAllMocks();
+    fluxora_rpc_cache_corrupt_total.reset();
   });
 
   it('returns null and deletes key and increments counter for empty string value', async () => {
@@ -278,6 +280,10 @@ describe('corrupt cache entries', () => {
     expect(result).toBeNull();
     expect(fakeRedis.del).toHaveBeenCalledWith(expect.stringContaining('testOp'));
     expect(cache.corruptEntriesTotal).toBe(1);
+    
+    const metric = await fluxora_rpc_cache_corrupt_total.get();
+    expect(metric.values[0]?.value).toBe(1);
+    expect(metric.values[0]?.labels).toEqual({ operation: 'unknown', reason: 'syntax_error' });
   });
 
   it('returns null and deletes key and increments counter for truncated JSON', async () => {
@@ -298,6 +304,34 @@ describe('corrupt cache entries', () => {
     expect(result).toBeNull();
     expect(fakeRedis.del).toHaveBeenCalledWith(expect.stringContaining('testOp'));
     expect(cache.corruptEntriesTotal).toBe(1);
+
+    const metric = await fluxora_rpc_cache_corrupt_total.get();
+    expect(metric.values[0]?.value).toBe(1);
+    expect(metric.values[0]?.labels).toEqual({ operation: 'unknown', reason: 'syntax_error' });
+  });
+
+  it('returns null and deletes key and increments counter for valid JSON with wrong shape', async () => {
+    const fakeRedis: RedisClient = {
+      get: vi.fn().mockResolvedValue('{"sequence": 123}'), // Missing envelope
+      set: vi.fn(),
+      setNx: vi.fn(),
+      del: vi.fn(),
+      exists: vi.fn(),
+      close: vi.fn(),
+      multi: vi.fn(),
+      zcount: vi.fn(),
+    };
+    const cache = new RedisRpcFallbackCache(fakeRedis);
+
+    const result = await cache.get('testOp');
+
+    expect(result).toBeNull();
+    expect(fakeRedis.del).toHaveBeenCalledWith(expect.stringContaining('testOp'));
+    expect(cache.corruptEntriesTotal).toBe(1);
+
+    const metric = await fluxora_rpc_cache_corrupt_total.get();
+    expect(metric.values[0]?.value).toBe(1);
+    expect(metric.values[0]?.labels).toEqual({ operation: 'unknown', reason: 'wrong_shape' });
   });
 
   it('does not swallow Redis transport errors', async () => {


### PR DESCRIPTION
Resolves #506
**Description:**
`parseCachedValue()` in `src/redis/rpcFallbackCache.ts` has been updated to treat both `SyntaxError` (unparseable JSON) and envelope validation failures (valid JSON but wrong shape) as cache corruption. Both cases now emit a corruption log, return `null` (causing the entry to be deleted from Redis), and increment the newly introduced Prom-client counter `fluxora_rpc_cache_corrupt_total`. 
**Acceptance criteria met:**
- [x] Wrong-shape parsed JSON returns `null` and increments corruption counter
- [x] `SyntaxError` path feeds the same signal
- [x] Raw cached value is **never** logged (only `key` and `reason` are logged)
- [x] Unit tests cover both corruption cases
- [x] Added `fluxora_rpc_cache_corrupt_total` metric to observability documentation (`docs/stellar-rpc.md`)
**Security notes:**
Cached values are treated as untrusted. No potentially poisoned payloads or raw `raw` strings are written to the logs.