### PR TITLE
fix(idempotency): validate stored envelope version before use (#504)

### DIFF
--- a/src/redis/idempotencyStore.ts
+++ b/src/redis/idempotencyStore.ts
@@ -33,14 +33,75 @@ import { correlationStore } from '../tracing/middleware.js';
 
 export const IDEMPOTENCY_KEY_PREFIX = 'fluxora:idempotency:';
 
-/** Shape stored in Redis for each idempotency entry. */
+/**
+ * Monotonically increasing integer that identifies the envelope schema.
+ * Bump this constant whenever the shape of {@link IdempotentEntry} changes
+ * in a backward-incompatible way.  Stored entries whose `version` field
+ * does not equal this value are treated as absent (recomputed).
+ */
+export const ENVELOPE_VERSION = 1;
+
+/**
+ * Shape stored in Redis for each idempotency entry.
+ *
+ * All stored Redis data is treated as **untrusted input**: the envelope is
+ * schema-validated before use so a corrupt, stale, or cross-service value
+ * cannot crash callers or produce incorrect idempotency decisions.
+ */
 export interface IdempotentEntry<T = unknown> {
+  /** Envelope schema version — must equal {@link ENVELOPE_VERSION}. */
+  version: number;
   /** SHA-256 hex digest of the normalised request body. */
   requestFingerprint: string;
   /** HTTP status code of the original response. */
   statusCode: number;
   /** Full response body as returned to the client. */
   body: T;
+}
+
+/**
+ * Parse raw Redis JSON and validate it against the expected envelope schema.
+ *
+ * Returns the validated entry, or `null` when:
+ * - `raw` is not valid JSON
+ * - required fields are missing or have wrong types
+ * - `version` does not match {@link ENVELOPE_VERSION}
+ *
+ * Callers receive a reason string for structured warning logs.
+ */
+function parseAndValidateEnvelope<T>(
+  raw: string,
+): { entry: IdempotentEntry<T>; invalidReason?: never } | { entry?: never; invalidReason: string } {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return { invalidReason: 'invalid JSON' };
+  }
+
+  if (typeof parsed !== 'object' || parsed === null) {
+    return { invalidReason: 'envelope is not an object' };
+  }
+
+  const obj = parsed as Record<string, unknown>;
+
+  if (typeof obj['requestFingerprint'] !== 'string') {
+    return { invalidReason: 'missing or invalid requestFingerprint' };
+  }
+  if (typeof obj['statusCode'] !== 'number') {
+    return { invalidReason: 'missing or invalid statusCode' };
+  }
+  if (!('body' in obj)) {
+    return { invalidReason: 'missing body' };
+  }
+  if (typeof obj['version'] !== 'number') {
+    return { invalidReason: 'missing version field' };
+  }
+  if (obj['version'] !== ENVELOPE_VERSION) {
+    return { invalidReason: `version mismatch: got ${obj['version']}, expected ${ENVELOPE_VERSION}` };
+  }
+
+  return { entry: obj as unknown as IdempotentEntry<T> };
 }
 
 export interface IdempotencyStore<T = unknown> {
@@ -107,7 +168,18 @@ export class RedisIdempotencyStore<T = unknown> implements IdempotencyStore<T> {
       const raw = await this.client.get(this.buildKey(key));
       this.onStateChange?.(true);
       if (raw === null) return null;
-      return JSON.parse(raw) as IdempotentEntry<T>;
+
+      const result = parseAndValidateEnvelope<T>(raw);
+      if (result.invalidReason !== undefined) {
+        this.logger.warn('Idempotency store: envelope validation failed — treating as absent', {
+          operation: 'get',
+          correlationId: correlationStore.getStore(),
+          keyLength: key.length,
+          reason: result.invalidReason,
+        });
+        return null;
+      }
+      return result.entry;
     } catch (err) {
       this.onStateChange?.(false);
       this.logger.warn('Idempotency store: Redis get failed — degrading to pass-through', {
@@ -122,7 +194,8 @@ export class RedisIdempotencyStore<T = unknown> implements IdempotencyStore<T> {
 
   async set(key: string, entry: IdempotentEntry<T>, ttlSeconds: number): Promise<void> {
     try {
-      await this.client.set(this.buildKey(key), JSON.stringify(entry), { ex: ttlSeconds });
+      const versioned: IdempotentEntry<T> = { ...entry, version: ENVELOPE_VERSION };
+      await this.client.set(this.buildKey(key), JSON.stringify(versioned), { ex: ttlSeconds });
       this.onStateChange?.(true);
     } catch (err) {
       this.onStateChange?.(false);

--- a/tests/redis/idempotencyStore.test.ts
+++ b/tests/redis/idempotencyStore.test.ts
@@ -16,12 +16,13 @@
  *  - InMemoryIdempotencyStore full semantics
  */
 
-import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import {
   RedisIdempotencyStore,
   NoOpIdempotencyStore,
   InMemoryIdempotencyStore,
   IDEMPOTENCY_KEY_PREFIX,
+  ENVELOPE_VERSION,
   type IdempotentEntry,
 } from '../../src/redis/idempotencyStore.js';
 import { logger } from '../../src/logging/logger.js';
@@ -31,6 +32,7 @@ import { FakeRedisClient } from '../../src/redis/__test__/fakeRedisClient.js';
 
 function makeEntry(overrides: Partial<IdempotentEntry> = {}): IdempotentEntry {
   return {
+    version: ENVELOPE_VERSION,
     requestFingerprint: 'fp-abc123',
     statusCode: 201,
     body: { data: { id: 'stream-1', status: 'active' }, meta: {} },
@@ -76,7 +78,9 @@ describe('RedisIdempotencyStore', () => {
     // Access the fake's internal string store via get() to confirm the prefix
     const raw = await fake.get(`${IDEMPOTENCY_KEY_PREFIX}my-key`);
     expect(raw).not.toBeNull();
-    expect(JSON.parse(raw!)).toEqual(entry);
+    const parsed = JSON.parse(raw!);
+    expect(parsed).toMatchObject(entry);
+    expect(parsed.version).toBe(ENVELOPE_VERSION);
   });
 
   it('forwards the TTL to the Redis client', async () => {
@@ -321,6 +325,129 @@ describe('RedisIdempotencyStore — structured logger', () => {
     );
   });
 
+});
+
+// ── RedisIdempotencyStore — envelope validation ───────────────────────────────
+
+describe('RedisIdempotencyStore — envelope validation', () => {
+  let fake: FakeRedisClient;
+  let store: RedisIdempotencyStore;
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    fake = new FakeRedisClient();
+    store = new RedisIdempotencyStore(fake);
+    warnSpy = vi.spyOn(logger, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    warnSpy.mockRestore();
+  });
+
+  async function seedRaw(key: string, value: unknown) {
+    await fake.set(`${IDEMPOTENCY_KEY_PREFIX}${key}`, JSON.stringify(value), { ex: 3600 });
+  }
+
+  it('returns null and warns on version mismatch (old version)', async () => {
+    await seedRaw('k', { ...makeEntry(), version: 0 });
+    expect(await store.get('k')).toBeNull();
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('envelope validation failed'),
+      expect.objectContaining({ reason: expect.stringContaining('version mismatch') }),
+    );
+  });
+
+  it('returns null and warns on future version', async () => {
+    await seedRaw('k', { ...makeEntry(), version: ENVELOPE_VERSION + 1 });
+    expect(await store.get('k')).toBeNull();
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('envelope validation failed'),
+      expect.objectContaining({ reason: expect.stringContaining('version mismatch') }),
+    );
+  });
+
+  it('returns null and warns when version field is missing', async () => {
+    const { version: _v, ...noVersion } = makeEntry();
+    await seedRaw('k', noVersion);
+    expect(await store.get('k')).toBeNull();
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('envelope validation failed'),
+      expect.objectContaining({ reason: 'missing version field' }),
+    );
+  });
+
+  it('returns null and warns when requestFingerprint is missing', async () => {
+    const { requestFingerprint: _fp, ...noFp } = makeEntry();
+    await seedRaw('k', noFp);
+    expect(await store.get('k')).toBeNull();
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('envelope validation failed'),
+      expect.objectContaining({ reason: 'missing or invalid requestFingerprint' }),
+    );
+  });
+
+  it('returns null and warns when statusCode is missing', async () => {
+    const { statusCode: _sc, ...noSc } = makeEntry();
+    await seedRaw('k', noSc);
+    expect(await store.get('k')).toBeNull();
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('envelope validation failed'),
+      expect.objectContaining({ reason: 'missing or invalid statusCode' }),
+    );
+  });
+
+  it('returns null and warns when body is missing', async () => {
+    const { body: _b, ...noBody } = makeEntry();
+    await seedRaw('k', noBody);
+    expect(await store.get('k')).toBeNull();
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('envelope validation failed'),
+      expect.objectContaining({ reason: 'missing body' }),
+    );
+  });
+
+  it('returns null and warns on malformed (non-object) JSON', async () => {
+    await fake.set(`${IDEMPOTENCY_KEY_PREFIX}k`, '"just a string"', { ex: 3600 });
+    expect(await store.get('k')).toBeNull();
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('envelope validation failed'),
+      expect.objectContaining({ reason: 'envelope is not an object' }),
+    );
+  });
+
+  it('returns null and warns on invalid JSON bytes', async () => {
+    await fake.set(`${IDEMPOTENCY_KEY_PREFIX}k`, '{bad json}', { ex: 3600 });
+    expect(await store.get('k')).toBeNull();
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('envelope validation failed'),
+      expect.objectContaining({ reason: 'invalid JSON' }),
+    );
+  });
+
+  it('stamps ENVELOPE_VERSION on every set()', async () => {
+    const entry = makeEntry();
+    await store.set('k', entry, 60);
+    const raw = await fake.get(`${IDEMPOTENCY_KEY_PREFIX}k`);
+    expect(JSON.parse(raw!).version).toBe(ENVELOPE_VERSION);
+  });
+
+  it('overwrites caller-supplied version with ENVELOPE_VERSION on set()', async () => {
+    const entry = makeEntry({ version: 99 } as Partial<IdempotentEntry>);
+    await store.set('k', entry, 60);
+    const raw = await fake.get(`${IDEMPOTENCY_KEY_PREFIX}k`);
+    expect(JSON.parse(raw!).version).toBe(ENVELOPE_VERSION);
+  });
+
+  it('returns the entry when the stored envelope is fully valid', async () => {
+    const entry = makeEntry();
+    await store.set('k', entry, 60);
+    const result = await store.get('k');
+    expect(result).not.toBeNull();
+    expect(result?.requestFingerprint).toBe(entry.requestFingerprint);
+    expect(result?.statusCode).toBe(entry.statusCode);
+    expect(result?.version).toBe(ENVELOPE_VERSION);
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
 });
 
 // ── RedisIdempotencyStore.close() ─────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Closes #504.

Treats all Redis-stored data as untrusted input. Before returning a parsed envelope, `get()` now validates the schema and version discriminator. Invalid/stale entries are treated as absent and a structured warning is logged — callers never see a mismatched or corrupt envelope.

## Changes

### `src/redis/idempotencyStore.ts`
- **`ENVELOPE_VERSION = 1`** — exported constant; bump when the schema changes incompatibly.
- **`IdempotentEntry.version`** — new required field (TSDoc-annotated).
- **`parseAndValidateEnvelope()`** — pure helper that parses raw JSON and checks: valid JSON, object shape, presence of `requestFingerprint` / `statusCode` / `body`, and `version === ENVELOPE_VERSION`. Returns a discriminated-union result (no exceptions).
- **`get()`** — calls `parseAndValidateEnvelope()`; on failure returns `null` and logs `{ keyLength, reason }` (no raw value, no key, no PII).
- **`set()`** — stamps `version: ENVELOPE_VERSION` on every write (overrides any caller-supplied value).

### `tests/redis/idempotencyStore.test.ts`
- Added `afterEach` import; `ENVELOPE_VERSION` imported.
- `makeEntry()` now includes `version: ENVELOPE_VERSION`.
- Fixed namespaced-key assertion to use `toMatchObject` (accommodates stamped version).
- **11 new envelope-validation tests** covering:
  - Version mismatch (old version, future version)
  - Missing `version` field
  - Missing `requestFingerprint`, `statusCode`, `body`
  - Malformed JSON (non-object value, invalid bytes)
  - `set()` stamps `ENVELOPE_VERSION` even when caller provides a different value
  - Happy-path round-trip with no warnings emitted

## Test output

```
✓ tests/redis/idempotencyStore.test.ts (43 tests) 37ms
Test Files  1 passed (1)
      Tests  43 passed (43)
```

## Security notes

- All stored Redis data is treated as untrusted; schema validation runs before any field access, preventing crashes from corrupt or cross-service writes.
- Warn logs include only `keyLength` and `reason` — the raw stored value and the idempotency key itself are never logged.