### PR TITLE
feat: add per-stream SSE drain timeout for graceful shutdown

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -192,7 +192,8 @@ export function createApp(options: AppOptions = {}): Express {
   //   1. Drain SSE — close open event-stream responses with retry:0.
   //   2. Stop indexer — signal replay loop to stop at next safe batch boundary.
   //   3. Quit Redis — close all tracked Redis sockets.
-  addShutdownHook(() => drainSseEventBus());
+  const sseDrainTimeoutMs = options.config?.sse?.drainTimeoutMs ?? loadConfig().sse.drainTimeoutMs;
+  addShutdownHook(() => drainSseEventBus(sseDrainTimeoutMs));
   addShutdownHook(() => requestStopReplay());
   addShutdownHook(() => quitAllRedisClients());
 

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -272,6 +272,8 @@ export const EnvSchema = z.object({
   WORKER_ENABLED: booleanEnv().default(false),
   INDEXER_STALL_THRESHOLD_MS: integerEnv('INDEXER_STALL_THRESHOLD_MS', 1000).default(5 * 60 * 1000),
   INDEXER_LAST_SUCCESSFUL_SYNC_AT: optionalString('INDEXER_LAST_SUCCESSFUL_SYNC_AT'),
+  /** Milliseconds to wait per SSE stream before force-closing during shutdown drain. */
+  SSE_DRAIN_TIMEOUT_MS: integerEnv('SSE_DRAIN_TIMEOUT_MS', 1000).default(5000),
   DEPLOYMENT_CHECKLIST_VERSION: z.string().min(1).default('2026-03-27'),
   ADMIN_STATE_FILE: optionalString('ADMIN_STATE_FILE'),
   RPC_CB_FAILURE_THRESHOLD: integerEnv('RPC_CB_FAILURE_THRESHOLD', 1).default(5),

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -9,6 +9,9 @@ export const config = {
   indexer: {
     replayBatchSize: parseInt(process.env.REPLAY_BATCH_SIZE || '1000', 10),
   },
+  sse: {
+    drainTimeoutMs: parseInt(process.env.SSE_DRAIN_TIMEOUT_MS || '5000', 10),
+  },
   server: {
     port: parseInt(process.env.PORT || '3000', 10),
   },

--- a/src/streams/sseEmitter.ts
+++ b/src/streams/sseEmitter.ts
@@ -4,6 +4,9 @@ import {
   sseLiveSubscribersGauge,
   sseEventListenersGauge,
 } from '../metrics/businessMetrics.js';
+import type { Config } from '../config/env.js';
+import { loadConfig } from '../config/env.js';
+import { logger } from '../lib/logger.js';
 
 export const SSE_STREAM_UPDATE_EVENT = 'stream_update';
 
@@ -25,6 +28,44 @@ export interface LiveSseStreamUpdateEvent {
 export type SseStreamSubscriber = (event: LiveSseStreamUpdateEvent) => void;
 
 const liveSubscribersByStreamId = new Map<string, Set<SseStreamSubscriber>>();
+
+interface TimeoutableShutdownCallback {
+  fn: () => void;
+  timeoutMs: number;
+}
+
+/** Counts SSE connections that were force-closed during shutdown due to timeout. */
+let forceClosedSseConnections = 0;
+
+function timeoutPromise<T>(promise: Promise<T>, ms: number, errorMessage: string): Promise<T> {
+  return new Promise((resolve, reject) => {
+    const timeoutId = setTimeout(() => {
+      reject(new Error(errorMessage));
+    }, ms);
+
+    promise
+      .then((result) => {
+        clearTimeout(timeoutId);
+        resolve(result);
+      })
+      .catch((err) => {
+        clearTimeout(timeoutId);
+        reject(err);
+      });
+  });
+}
+
+export function _injectForceClosedSseConnectionsForTest(): void {
+  forceClosedSseConnections = 0;
+}
+
+export function getForceClosedSseConnections(): number {
+  return forceClosedSseConnections;
+}
+
+export function resetForceClosedSseConnectionsCount(): void {
+  forceClosedSseConnections = 0;
+}
 
 function totalLiveSubscriberCount(): number {
   let total = 0;
@@ -121,7 +162,7 @@ export function getLiveSseSubscriberCount(streamId?: string): number {
  * Callbacks registered by active SSE response handlers. Each callback
  * writes the SSE retry directive and closes the response.
  */
-const sseShutdownCallbacks = new Set<() => void>();
+const sseShutdownCallbacks = new Set<TimeoutableShutdownCallback>();
 
 /**
  * Register a shutdown callback for an active SSE response.
@@ -129,11 +170,22 @@ const sseShutdownCallbacks = new Set<() => void>();
  * normally so the Set does not grow unboundedly.
  *
  * @param fn - Callback that writes `retry: 0` and ends the response.
+ * @param timeoutMs - Per-stream timeout in milliseconds before force-closing.
  * @returns Deregister function.
  */
-export function registerSseShutdownCallback(fn: () => void): () => void {
-  sseShutdownCallbacks.add(fn);
-  return () => sseShutdownCallbacks.delete(fn);
+export function registerSseShutdownCallback(
+  fn: () => void,
+  timeoutMs = 5000,
+): () => void {
+  sseShutdownCallbacks.add({ fn, timeoutMs });
+  return () => {
+    for (const cb of sseShutdownCallbacks) {
+      if (cb.fn === fn) {
+        sseShutdownCallbacks.delete(cb);
+        break;
+      }
+    }
+  };
 }
 
 /**
@@ -143,21 +195,49 @@ export function registerSseShutdownCallback(fn: () => void): () => void {
  * immediately reconnect, then ends each response. Detaches the dispatch
  * listener and resets subscriber state.
  */
-export function drainSseEventBus(): void {
-  for (const cb of Array.from(sseShutdownCallbacks)) {
-    try {
-      cb();
-    } catch {
-      // Isolate a single failing response from the rest of the drain.
-    }
-  }
+export function drainSseEventBus(timeoutMs?: number): Promise<void> {
+  const callbacksToProcess = Array.from(sseShutdownCallbacks);
   sseShutdownCallbacks.clear();
 
-  // Tear down the shared dispatcher so no further events are fanned out.
-  liveSubscribersByStreamId.clear();
-  sseEventBus.off(SSE_STREAM_UPDATE_EVENT, dispatchLiveSseEvent);
-  sseLiveSubscribersGauge.set(0);
-  sseEventListenersGauge.set(0);
+  // Run shutdown callbacks concurrently with per-stream timeouts
+  const drainPromises = callbacksToProcess.map((cb) => {
+    const effectiveTimeout = timeoutMs ?? cb.timeoutMs;
+    
+    return new Promise<void>((resolve) => {
+      const timeoutId = setTimeout(() => {
+        logger.warn('SSE drain callback timed out', undefined, {
+          error: `Timeout exceeded after ${effectiveTimeout} ms`,
+          timeoutMs: effectiveTimeout,
+        });
+        forceClosedSseConnections++;
+        resolve();
+      }, effectiveTimeout);
+
+      try {
+        const result = cb.fn();
+        if (result && typeof result === 'object' && 'then' in result) {
+          (result as Promise<void>).then(() => clearTimeout(timeoutId), () => clearTimeout(timeoutId));
+        } else {
+          clearTimeout(timeoutId);
+          resolve();
+        }
+      } catch (err) {
+        clearTimeout(timeoutId);
+        logger.error('SSE drain callback failed', undefined, {
+          error: err instanceof Error ? err.message : String(err),
+        });
+        resolve();
+      }
+    });
+  });
+
+  return Promise.all(drainPromises).then(() => {
+    // Tear down the shared dispatcher so no further events are fanned out.
+    liveSubscribersByStreamId.clear();
+    sseEventBus.off(SSE_STREAM_UPDATE_EVENT, dispatchLiveSseEvent);
+    sseLiveSubscribersGauge.set(0);
+    sseEventListenersGauge.set(0);
+  });
 }
 
 export function _resetSseSubscriptionsForTest(): void {

--- a/tests/shutdown.test.ts
+++ b/tests/shutdown.test.ts
@@ -361,6 +361,8 @@ import {
   drainSseEventBus,
   registerSseShutdownCallback,
   _resetSseSubscriptionsForTest,
+  getForceClosedSseConnections,
+  resetForceClosedSseConnectionsCount,
 } from '../src/streams/sseEmitter.js';
 import {
   requestStopReplay,
@@ -378,52 +380,54 @@ import {
 
 describe('#336 SSE drain hook', () => {
   beforeEach(() => {
+    _resetShutdownState();
     _resetSseSubscriptionsForTest();
   });
 
   afterEach(() => {
+    _resetShutdownState();
     _resetSseSubscriptionsForTest();
   });
 
-  it('drainSseEventBus() calls all registered shutdown callbacks', () => {
+  it('drainSseEventBus() calls all registered shutdown callbacks', async () => {
     const cb1 = vi.fn();
     const cb2 = vi.fn();
     registerSseShutdownCallback(cb1);
     registerSseShutdownCallback(cb2);
 
-    drainSseEventBus();
+    await drainSseEventBus();
 
     expect(cb1).toHaveBeenCalledTimes(1);
     expect(cb2).toHaveBeenCalledTimes(1);
   });
 
-  it('drainSseEventBus() clears callbacks so a second call is a no-op', () => {
+  it('drainSseEventBus() clears callbacks so a second call is a no-op', async () => {
     const cb = vi.fn();
     registerSseShutdownCallback(cb);
 
-    drainSseEventBus();
-    drainSseEventBus();
+    await drainSseEventBus();
+    await drainSseEventBus();
 
     expect(cb).toHaveBeenCalledTimes(1);
   });
 
-  it('deregister function removes the callback before drain', () => {
+  it('deregister function removes the callback before drain', async () => {
     const cb = vi.fn();
     const deregister = registerSseShutdownCallback(cb);
     deregister();
 
-    drainSseEventBus();
+    await drainSseEventBus();
 
     expect(cb).not.toHaveBeenCalled();
   });
 
-  it('drain isolates a throwing callback and still calls remaining ones', () => {
+  it('drain isolates a throwing callback and still calls remaining ones', async () => {
     const bad = vi.fn(() => { throw new Error('boom'); });
     const good = vi.fn();
     registerSseShutdownCallback(bad);
     registerSseShutdownCallback(good);
 
-    expect(() => drainSseEventBus()).not.toThrow();
+    await expect(drainSseEventBus()).resolves.toBeUndefined();
     expect(good).toHaveBeenCalledTimes(1);
   });
 
@@ -438,6 +442,22 @@ describe('#336 SSE drain hook', () => {
     await gracefulShutdown(server, 'SIGTERM', 5_000);
 
     expect(cb).toHaveBeenCalledTimes(1);
+  });
+
+  it('drainSseEventBus() logs and counts force-closed connections', async () => {
+    const slowCallback = vi.fn(() => {
+      return new Promise<void>((resolve) => setTimeout(resolve, 1000));
+    });
+    const fastCallback = vi.fn();
+    registerSseShutdownCallback(slowCallback, 100);
+    registerSseShutdownCallback(fastCallback, 100);
+
+    resetForceClosedSseConnectionsCount();
+    await drainSseEventBus(200);
+
+    expect(slowCallback).not.toHaveBeenCalled();
+    expect(fastCallback).toHaveBeenCalledTimes(1);
+    expect(getForceClosedSseConnections()).toBe(1);
   });
 });
 


### PR DESCRIPTION
Closes #520

---

- Add SSE_DRAIN_TIMEOUT_MS config option (default: 5000ms)
- Modify registerSseShutdownCallback to accept per-stream timeout parameter
- Implement drainSseEventBus with per-connection timeouts
- Add forceClosedSseConnections counter to track timeouted connections
- Updates all shutdown tests to use async drainSseEventBus
- Verify shutdown sequence: HTTP -> SSE -> indexer -> Redis

Fixes issue where single slow SSE client could consume entire shutdown budget