### PR TITLE
Fix webhook response size and Content-Type validation to prevent DoS

### DIFF
--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -252,6 +252,10 @@ export const EnvSchema = z.object({
   WEBHOOK_CIRCUIT_BREAKER_THRESHOLD: integerEnv('WEBHOOK_CIRCUIT_BREAKER_THRESHOLD', 0, 1000).default(0),
   WEBHOOK_CIRCUIT_BREAKER_RESET_MS: integerEnv('WEBHOOK_CIRCUIT_BREAKER_RESET_MS', 1).default(300_000),
   WEBHOOK_ALLOWED_HOSTS: optionalString('WEBHOOK_ALLOWED_HOSTS'),
+  WEBHOOK_MAX_RESPONSE_BYTES: z.preprocess(
+    byteSizeToNumber,
+    z.number().int('WEBHOOK_MAX_RESPONSE_BYTES must resolve to whole bytes').positive('WEBHOOK_MAX_RESPONSE_BYTES must be positive'),
+  ).default(64 * 1024),
 
   ENABLE_STREAM_VALIDATION: booleanEnv().default(true),
   ENABLE_RATE_LIMIT: booleanEnv().optional(),
@@ -377,7 +381,8 @@ export interface Config {
   webhookPollIntervalMs: number;
   webhookBatchSize: number;
   webhookRetryRps: number;
-  webhookAllowedHosts?: string[] | undefined;
+  webhookAllowedHosts: string[] | undefined;
+  webhookMaxResponseBytes: number;
 
   enableStreamValidation: boolean;
   enableRateLimit: boolean;
@@ -532,6 +537,7 @@ function toConfig(env: ParsedEnv): Config {
     webhookAllowedHosts: env.WEBHOOK_ALLOWED_HOSTS
       ? env.WEBHOOK_ALLOWED_HOSTS.split(',').map(h => h.trim()).filter(h => h.length > 0)
       : undefined,
+    webhookMaxResponseBytes: env.WEBHOOK_MAX_RESPONSE_BYTES,
 
     enableStreamValidation: env.ENABLE_STREAM_VALIDATION,
     enableRateLimit: env.ENABLE_RATE_LIMIT ?? !isProduction,

--- a/src/webhooks/service.ts
+++ b/src/webhooks/service.ts
@@ -591,6 +591,28 @@ export class WebhookService {
         signal: controller.signal,
       });
 
+      // Validate Content-Type header (must be present and not empty)
+      const contentType = response.headers.get('content-type');
+      if (!contentType) {
+        throw new Error('Missing Content-Type header in webhook response');
+      }
+
+      // Enforce maximum response body size
+      const maxBytes = Number(process.env.WEBHOOK_MAX_RESPONSE_BYTES) || 64 * 1024;
+      if (response.body) {
+        const reader = response.body.getReader();
+        let bytesRead = 0;
+        while (true) {
+          const { done, value } = await reader.read();
+          if (done) break;
+          bytesRead += value.length;
+          if (bytesRead > maxBytes) {
+            controller.abort();
+            throw new Error('Webhook response exceeds maximum allowed size');
+          }
+        }
+      }
+
       return response;
     } finally {
       clearTimeout(timeoutId);


### PR DESCRIPTION
this pr closes #488 Fix webhook response size and Content-Type validation to prevent DoS
This update safeguards outbound webhook deliveries by verifying the response’s Content-Type header and ensuring the body does not exceed the configured byte limit, mitigating memory-exhaustion attacks.