### PR TITLE
Fix/dlq insert serialization guard

### DIFF
--- a/migrations/20260626000000_add_dlq_consumer_suspension_topic_index.ts
+++ b/migrations/20260626000000_add_dlq_consumer_suspension_topic_index.ts
@@ -1,0 +1,35 @@
+/**
+ * Migration: Add explicit index on dlq_consumer_suspension.topic
+ *
+ * Issue #499: Add an index on dlq_consumer_suspension.topic to avoid full scans
+ * in dlqRepository suspension lookups.
+ *
+ * Although `topic` is the primary key and has an implicit index, this migration
+ * adds an explicit, named index for clarity and to ensure query planners use it
+ * optimally for the getConsumerSuspension(topic) lookups that run on the
+ * webhook-delivery path.
+ *
+ * Suspension lookups occur frequently during webhook delivery processing and
+ * must perform at index speed even as the suspension table grows.
+ */
+
+import type { ColumnDefinitions, MigrationBuilder } from 'node-pg-migrate';
+
+export const shorthands: ColumnDefinitions | undefined = undefined;
+
+export async function up(pgm: MigrationBuilder): Promise<void> {
+  // Create an explicit index on topic for the suspension lookup query.
+  // The index name uses the project convention: idx_<table>_<columns>
+  pgm.createIndex(
+    'dlq_consumer_suspension',
+    'topic',
+    { ifNotExists: true, name: 'idx_dlq_consumer_suspension_topic' },
+  );
+}
+
+export async function down(pgm: MigrationBuilder): Promise<void> {
+  pgm.dropIndex('dlq_consumer_suspension', 'topic', {
+    ifExists: true,
+    name: 'idx_dlq_consumer_suspension_topic',
+  });
+}

--- a/src/db/repositories/dlqRepository.ts
+++ b/src/db/repositories/dlqRepository.ts
@@ -20,6 +20,39 @@
 import { getPool, query } from '../pool.js';
 import type { DlqEntry } from '../../routes/dlq.js';
 
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+/**
+ * Safely serialize a payload to JSON, handling non-serializable values
+ * like circular references and BigInt.
+ *
+ * If serialization fails, returns a safe fallback representation that
+ * records the error and a type hint without exposing sensitive data.
+ *
+ * @param payload — The payload object to serialize
+ * @returns A JSON string, or a safe fallback on serialization error
+ *
+ * @security
+ * Fallback representation avoids including the original payload to prevent
+ * accidentally leaking secrets in error states.
+ */
+function safeSerializePayload(payload: unknown): string {
+  try {
+    return JSON.stringify(payload);
+  } catch (error) {
+    // Serialization failed (e.g., circular reference, BigInt, or Symbol)
+    // Record a safe fallback that documents the failure without leaking data.
+    const errorMsg = error instanceof Error ? error.message : String(error);
+    const fallback = {
+      _serialization_error: true,
+      reason: errorMsg,
+      type: typeof payload,
+      timestamp: new Date().toISOString(),
+    };
+    return JSON.stringify(fallback);
+  }
+}
+
 // ── Configurable threshold ────────────────────────────────────────────────────
 
 /**
@@ -88,7 +121,7 @@ export const dlqRepository = {
       [
         entry.id,
         entry.topic,
-        JSON.stringify(entry.payload),
+        safeSerializePayload(entry.payload),
         entry.error,
         entry.attempts,
         entry.correlationId ?? null,

--- a/tests/db/dlq.suspensionIndex.test.ts
+++ b/tests/db/dlq.suspensionIndex.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { up } from '../../migrations/20260626000000_add_dlq_consumer_suspension_topic_index.js';
+
+describe('dlq consumer suspension topic index migration', () => {
+  it('creates the topic index with IF NOT EXISTS', async () => {
+    const createIndex = vi.fn();
+    const pgm = {
+      createIndex,
+    } as any;
+
+    await up(pgm);
+
+    expect(createIndex).toHaveBeenCalledWith(
+      'dlq_consumer_suspension',
+      'topic',
+      { ifNotExists: true, name: 'idx_dlq_consumer_suspension_topic' },
+    );
+  });
+});

--- a/tests/db/dlqRepository.test.ts
+++ b/tests/db/dlqRepository.test.ts
@@ -1,0 +1,167 @@
+/**
+ * Unit tests for dlqRepository.insert (PostgreSQL-backed).
+ *
+ * Covers: serialization of normal payloads, circular references, BigInt,
+ * and other non-serializable values. All pg pool interactions are mocked —
+ * no real database required.
+ *
+ * Issue #519: Verify that non-serializable payloads are caught and a safe
+ * fallback representation is recorded, not letting the insert throw.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+const mockQuery = vi.fn();
+vi.mock('../../src/db/pool.js', () => ({
+  getPool: vi.fn(() => ({})),
+  query: (...args: unknown[]) => mockQuery(...args),
+}));
+
+import { dlqRepository } from '../../src/db/repositories/dlqRepository.js';
+import type { DlqEntry } from '../../src/routes/dlq.js';
+
+function makeDlqEntry(overrides: Partial<DlqEntry> = {}): DlqEntry {
+  return {
+    id: 'dlq-001',
+    topic: 'stream.created',
+    payload: { data: 'test' },
+    error: 'Network timeout',
+    attempts: 1,
+    correlationId: 'corr-123',
+    firstFailedAt: '2026-01-01T00:00:00.000Z',
+    lastFailedAt: '2026-01-01T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+describe('dlqRepository.insert', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockQuery.mockResolvedValue({ rowCount: 1 });
+  });
+
+  it('inserts a normal payload via JSON.stringify', async () => {
+    const entry = makeDlqEntry({
+      payload: { streamId: 'abc-123', amount: '1000' },
+    });
+
+    await dlqRepository.insert(entry);
+
+    const [, , params] = mockQuery.mock.calls[0]!;
+    const serializedPayload = params[2];
+    expect(typeof serializedPayload).toBe('string');
+    expect(JSON.parse(serializedPayload as string)).toEqual({
+      streamId: 'abc-123',
+      amount: '1000',
+    });
+  });
+
+  it('handles circular reference without throwing', async () => {
+    const circular: any = { data: 'value' };
+    circular.self = circular; // Circular reference
+
+    const entry = makeDlqEntry({ payload: circular });
+
+    // Should not throw; instead records safe fallback
+    await dlqRepository.insert(entry);
+
+    const [, , params] = mockQuery.mock.calls[0]!;
+    const serializedPayload = params[2] as string;
+    const fallback = JSON.parse(serializedPayload);
+
+    expect(fallback._serialization_error).toBe(true);
+    expect(fallback.reason).toContain('circular');
+    expect(fallback.type).toBe('object');
+    expect(fallback.timestamp).toBeDefined();
+  });
+
+  it('handles BigInt without throwing', async () => {
+    const entry = makeDlqEntry({
+      payload: { amount: BigInt('9007199254740992') },
+    });
+
+    // Should not throw; instead records safe fallback
+    await dlqRepository.insert(entry);
+
+    const [, , params] = mockQuery.mock.calls[0]!;
+    const serializedPayload = params[2] as string;
+    const fallback = JSON.parse(serializedPayload);
+
+    expect(fallback._serialization_error).toBe(true);
+    expect(fallback.reason).toContain('BigInt');
+    expect(fallback.type).toBe('object');
+  });
+
+  it('handles nested non-serializable values', async () => {
+    const entry = makeDlqEntry({
+      payload: {
+        nested: {
+          value: Symbol('test-symbol'),
+        },
+      },
+    });
+
+    // Should not throw
+    await dlqRepository.insert(entry);
+
+    const [, , params] = mockQuery.mock.calls[0]!;
+    const serializedPayload = params[2] as string;
+    const fallback = JSON.parse(serializedPayload);
+
+    expect(fallback._serialization_error).toBe(true);
+    expect(fallback.type).toBe('object');
+  });
+
+  it('successfully records DLQ row even when payload serialization falls back', async () => {
+    const circular: any = { data: 'value' };
+    circular.self = circular;
+
+    const entry = makeDlqEntry({
+      id: 'dlq-circular-001',
+      topic: 'bad.stream',
+      payload: circular,
+    });
+
+    await dlqRepository.insert(entry);
+
+    // Verify INSERT was called (not thrown)
+    expect(mockQuery).toHaveBeenCalledTimes(1);
+    const [, sql] = mockQuery.mock.calls[0]!;
+    expect(sql).toContain('INSERT INTO dead_letter_queue');
+  });
+
+  it('does not include original payload in fallback representation (security)', async () => {
+    const secretData = { apiKey: 'secret-key-12345', data: 'public' };
+    // Make it circular to trigger serialization failure
+    const payload: any = secretData;
+    payload.self = payload;
+
+    const entry = makeDlqEntry({ payload });
+
+    await dlqRepository.insert(entry);
+
+    const [, , params] = mockQuery.mock.calls[0]!;
+    const serializedPayload = params[2] as string;
+
+    // Fallback should not contain the secret
+    expect(serializedPayload).not.toContain('secret-key-12345');
+    expect(serializedPayload).not.toContain('apiKey');
+  });
+
+  it('records payload type in fallback for debugging', async () => {
+    const circular: any = { data: 'test' };
+    circular.ref = circular;
+
+    const entry = makeDlqEntry({
+      payload: circular,
+    });
+
+    await dlqRepository.insert(entry);
+
+    const [, , params] = mockQuery.mock.calls[0]!;
+    const fallback = JSON.parse(params[2] as string);
+
+    expect(fallback.type).toBe('object');
+    expect(fallback.timestamp).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+  });
+});


### PR DESCRIPTION
Closes #519 
Description:

Added safe fallback serialization for [dlqRepository.insert()](vscode-file://vscode-app/c:/Users/Wittig_Lyon/AppData/Local/Programs/Microsoft%20VS%20Code/7e7950df89/resources/app/out/vs/code/electron-browser/workbench/workbench.html).
Prevents non-serializable webhook payloads (circular refs, BigInt, Symbols) from throwing and dropping DLQ inserts.
Fallback preserves an audit-safe marker, reason, payload type, and timestamp without leaking original payload content.
Added tests for normal payloads, circular payloads, BigInt, and fallback security.