### PR TITLE
Add a DNS resolution timeout and AbortController to lookup() in src/webhooks/ssrfGuard.ts

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,7 @@ The test suite includes:
 | `PORT` | 3000 | HTTP server port |
 | `API_KEYS` | - | Comma-separated list of valid API keys |
 | `API_KEY_PEPPER` | - | Server-side pepper for API key hashing (**Required if API_KEYS is configured**) |
+| `WEBHOOK_DNS_TIMEOUT_MS` | 2000 | Webhook DNS lookup resolution timeout in milliseconds (fail-closed) |
 
 
 ### Batch Size Tuning

--- a/docs/webhooks.md
+++ b/docs/webhooks.md
@@ -13,6 +13,7 @@ Required configuration:
 - `WEBHOOK_RETRY_RPS`: maximum outbound retry attempts per second per consumer URL. Defaults to `10`. Set lower (e.g. `2`) for consumers known to be slow or fragile.
 - `WEBHOOK_CIRCUIT_BREAKER_THRESHOLD`: consecutive retryable failures before the circuit opens. Defaults to `0` (disabled). Set e.g. `10` to enable cross-instance protection.
 - `WEBHOOK_CIRCUIT_BREAKER_RESET_MS`: how long the circuit stays open before a single half-open probe. Defaults to `300000` (5 minutes).
+- `WEBHOOK_DNS_TIMEOUT_MS`: DNS lookup resolution timeout in milliseconds (fail-closed). Defaults to `2000` (2 seconds).
 
 The service startup path starts the dispatcher after migrations are checked. Shutdown registers the dispatcher as a drainable service, so SIGTERM/SIGINT stops future polls and waits for the in-flight batch before closing database connections.
 
@@ -149,15 +150,20 @@ Add to your environment configuration:
 ```bash
 # Optional: Restrict webhook delivery to specific hosts
 WEBHOOK_ALLOWED_HOSTS=api.example.com,*.trusted.com
+
+# Optional: Webhook DNS resolution timeout (in milliseconds)
+WEBHOOK_DNS_TIMEOUT_MS=2000
 ```
 
 ### Error handling
 
 SSRF validation failures are logged without exposing the full URL for security. The validation fails closed: any ambiguous or unresolvable target is rejected with a `WebhookTargetValidationError`.
 
+If DNS resolution times out or is aborted, it is rejected with a `WebhookTargetValidationError` containing a `DNS_TIMEOUT` code, which fails closed.
+
 ### Implementation details
 
 - Validation function: `validateWebhookTarget(url, options)` in `src/webhooks/ssrfGuard.ts`
 - Applied in: `WebhookDispatcher.dispatch()` and `dispatchWebhook()` in `src/webhooks/dispatcher.ts`
 - Timeout: Uses `DEFAULT_RETRY_POLICY.timeoutMs` (30 seconds)
-- DNS resolution: Uses Node.js `dns.promises.lookup()`
+- DNS resolution: Uses Node.js `dns.promises.lookup()` wrapped with a custom timeout helper and `AbortController` bounded by `WEBHOOK_DNS_TIMEOUT_MS` (default `2000` ms).

--- a/src/config/env.test.ts
+++ b/src/config/env.test.ts
@@ -176,6 +176,28 @@ describe('Environment Configuration', () => {
 
             expect(() => loadConfig()).toThrow(ConfigError);
         });
+
+        it('should parse WEBHOOK_DNS_TIMEOUT_MS with default value', () => {
+            process.env.NODE_ENV = 'development';
+            const config = loadConfig();
+
+            expect(config.webhookDnsTimeoutMs).toBe(2000);
+        });
+
+        it('should allow WEBHOOK_DNS_TIMEOUT_MS override', () => {
+            process.env.NODE_ENV = 'development';
+            process.env.WEBHOOK_DNS_TIMEOUT_MS = '5000';
+            const config = loadConfig();
+
+            expect(config.webhookDnsTimeoutMs).toBe(5000);
+        });
+
+        it('should reject invalid WEBHOOK_DNS_TIMEOUT_MS', () => {
+            process.env.NODE_ENV = 'development';
+            process.env.WEBHOOK_DNS_TIMEOUT_MS = '-100';
+
+            expect(() => loadConfig()).toThrow(ConfigError);
+        });
     });
 
     // -------------------------------------------------------------------------

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -256,6 +256,7 @@ export const EnvSchema = z.object({
     byteSizeToNumber,
     z.number().int('WEBHOOK_MAX_RESPONSE_BYTES must resolve to whole bytes').positive('WEBHOOK_MAX_RESPONSE_BYTES must be positive'),
   ).default(64 * 1024),
+  WEBHOOK_DNS_TIMEOUT_MS: integerEnv('WEBHOOK_DNS_TIMEOUT_MS', 1).default(2000),
 
   ENABLE_STREAM_VALIDATION: booleanEnv().default(true),
   ENABLE_RATE_LIMIT: booleanEnv().optional(),
@@ -392,6 +393,7 @@ export interface Config {
   webhookRetryRps: number;
   webhookAllowedHosts: string[] | undefined;
   webhookMaxResponseBytes: number;
+  webhookDnsTimeoutMs: number;
 
   enableStreamValidation: boolean;
   enableRateLimit: boolean;
@@ -547,6 +549,7 @@ function toConfig(env: ParsedEnv): Config {
       ? env.WEBHOOK_ALLOWED_HOSTS.split(',').map(h => h.trim()).filter(h => h.length > 0)
       : undefined,
     webhookMaxResponseBytes: env.WEBHOOK_MAX_RESPONSE_BYTES,
+    webhookDnsTimeoutMs: env.WEBHOOK_DNS_TIMEOUT_MS,
 
     enableStreamValidation: env.ENABLE_STREAM_VALIDATION,
     enableRateLimit: env.ENABLE_RATE_LIMIT ?? !isProduction,

--- a/src/webhooks/ssrfGuard.ts
+++ b/src/webhooks/ssrfGuard.ts
@@ -19,14 +19,18 @@
  */
 
 import { logger } from '../lib/logger.js';
+import { getConfig } from '../config/env.js';
 
 /**
  * Error thrown when a webhook target URL fails SSRF validation.
  */
 export class WebhookTargetValidationError extends Error {
-  constructor(message: string) {
+  readonly code?: string;
+
+  constructor(message: string, code?: string) {
     super(message);
     this.name = 'WebhookTargetValidationError';
+    this.code = code;
   }
 }
 
@@ -203,25 +207,68 @@ function isBlockedIPv6(ip: string): { blocked: boolean; reason?: string } {
 }
 
 /**
+ * Helper to perform a DNS lookup with a timeout and abort support.
+ *
+ * @param hostname - The hostname to resolve.
+ * @param timeoutMs - The timeout in milliseconds.
+ * @returns A promise that resolves with the lookup result (address).
+ * @throws {WebhookTargetValidationError} If the lookup times out or fails.
+ */
+async function lookupWithTimeout(hostname: string, timeoutMs: number): Promise<string> {
+  const dns = await import('dns');
+  const { lookup } = dns.promises;
+
+  const controller = new AbortController();
+  const signal = controller.signal;
+
+  let timeoutId: NodeJS.Timeout | undefined;
+
+  const timeoutPromise = new Promise<never>((_, reject) => {
+    timeoutId = setTimeout(() => {
+      controller.abort();
+      reject(
+        new WebhookTargetValidationError(
+          `DNS resolution timed out for hostname: ${hostname}`,
+          'DNS_TIMEOUT'
+        )
+      );
+    }, timeoutMs);
+  });
+
+  try {
+    const lookupPromise = lookup(hostname, { all: false, signal });
+    const result = await Promise.race([lookupPromise, timeoutPromise]);
+    return result.address;
+  } catch (error: any) {
+    if (error instanceof WebhookTargetValidationError) {
+      throw error;
+    }
+
+    if (error.name === 'AbortError' || error.code === 'ECANCELED') {
+      throw new WebhookTargetValidationError(
+        `DNS resolution timed out for hostname: ${hostname}`,
+        'DNS_TIMEOUT'
+      );
+    }
+
+    throw new WebhookTargetValidationError(
+      `DNS resolution failed for hostname: ${hostname}`,
+      'DNS_RESOLUTION_FAILED'
+    );
+  } finally {
+    if (timeoutId) {
+      clearTimeout(timeoutId);
+    }
+  }
+}
+
+/**
  * Resolve a hostname to its IP addresses.
  * This is used to defeat DNS rebinding attacks.
  */
-async function resolveHostname(hostname: string): Promise<string[]> {
-  try {
-    // Use Node.js DNS resolution
-    const dns = await import('dns');
-    const { lookup } = dns.promises;
-    
-    const { address, family } = await lookup(hostname, { all: false });
-    
-    // Convert to array for consistent interface
-    return [address];
-  } catch (error) {
-    // If DNS resolution fails, fail closed
-    throw new WebhookTargetValidationError(
-      `DNS resolution failed for hostname: ${hostname}`
-    );
-  }
+async function resolveHostname(hostname: string, timeoutMs: number): Promise<string[]> {
+  const address = await lookupWithTimeout(hostname, timeoutMs);
+  return [address];
 }
 
 /**
@@ -230,13 +277,15 @@ async function resolveHostname(hostname: string): Promise<string[]> {
 function validateProtocol(url: URL, requireHttps: boolean): void {
   if (requireHttps && url.protocol !== 'https:') {
     throw new WebhookTargetValidationError(
-      `Webhook URL must use HTTPS, got: ${url.protocol}`
+      `Webhook URL must use HTTPS, got: ${url.protocol}`,
+      'INVALID_PROTOCOL'
     );
   }
   
   if (url.protocol !== 'http:' && url.protocol !== 'https:') {
     throw new WebhookTargetValidationError(
-      `Webhook URL must use HTTP or HTTPS, got: ${url.protocol}`
+      `Webhook URL must use HTTP or HTTPS, got: ${url.protocol}`,
+      'INVALID_PROTOCOL'
     );
   }
 }
@@ -268,7 +317,8 @@ function validateAllowlist(hostname: string, allowlist: string[] | undefined): v
   }
   
   throw new WebhookTargetValidationError(
-    `Webhook hostname not in allowlist: ${hostname}`
+    `Webhook hostname not in allowlist: ${hostname}`,
+    'ALLOWLIST_VIOLATION'
   );
 }
 
@@ -283,14 +333,16 @@ function validateIPAddress(ip: string): void {
     const result = isBlockedIPv6(ip);
     if (result.blocked) {
       throw new WebhookTargetValidationError(
-        `Blocked IPv6 address: ${ip} (${result.reason})`
+        `Blocked IPv6 address: ${ip} (${result.reason})`,
+        'BLOCKED_ADDRESS'
       );
     }
   } else {
     const result = isBlockedIPv4(ip);
     if (result.blocked) {
       throw new WebhookTargetValidationError(
-        `Blocked IPv4 address: ${ip} (${result.reason})`
+        `Blocked IPv4 address: ${ip} (${result.reason})`,
+        'BLOCKED_ADDRESS'
       );
     }
   }
@@ -327,10 +379,20 @@ export async function validateWebhookTarget(
   options?: {
     requireHttps?: boolean;
     allowlist?: string[];
+    dnsTimeoutMs?: number;
   }
 ): Promise<void> {
   const requireHttps = options?.requireHttps ?? true;
   const allowlist = options?.allowlist;
+
+  let dnsTimeoutMs = options?.dnsTimeoutMs;
+  if (dnsTimeoutMs === undefined) {
+    try {
+      dnsTimeoutMs = getConfig().webhookDnsTimeoutMs;
+    } catch {
+      dnsTimeoutMs = 2000; // Sensible default fallback
+    }
+  }
 
   try {
     // Parse URL
@@ -339,7 +401,8 @@ export async function validateWebhookTarget(
       parsedUrl = new URL(url);
     } catch (error) {
       throw new WebhookTargetValidationError(
-        `Invalid webhook URL format: ${url}`
+        `Invalid webhook URL format: ${url}`,
+        'INVALID_URL'
       );
     }
 
@@ -360,7 +423,7 @@ export async function validateWebhookTarget(
       validateIPAddress(hostname);
     } else {
       // Hostname - resolve and validate all IPs
-      const resolvedIPs = await resolveHostname(hostname);
+      const resolvedIPs = await resolveHostname(hostname, dnsTimeoutMs);
       
       for (const ip of resolvedIPs) {
         validateIPAddress(ip);
@@ -373,6 +436,7 @@ export async function validateWebhookTarget(
       // Log the validation failure (without the full URL for security)
       logger.warn('Webhook target validation failed', undefined, {
         reason: error.message,
+        code: error.code,
       });
       throw error;
     }
@@ -382,7 +446,8 @@ export async function validateWebhookTarget(
       error: error instanceof Error ? error.message : String(error),
     });
     throw new WebhookTargetValidationError(
-      'Webhook target validation failed unexpectedly'
+      'Webhook target validation failed unexpectedly',
+      'UNKNOWN_ERROR'
     );
   }
 }

--- a/tests/webhooks/ssrfGuard.test.ts
+++ b/tests/webhooks/ssrfGuard.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { validateWebhookTarget, WebhookTargetValidationError } from '../../src/webhooks/ssrfGuard.js';
+import * as dns from 'dns';
+
+// Mock dns promises lookup
+vi.mock('dns', async (importOriginal) => {
+  const original = await importOriginal<typeof import('dns')>();
+  return {
+    ...original,
+    promises: {
+      ...original.promises,
+      lookup: vi.fn(),
+    },
+  };
+});
+
+describe('SSRF Guard DNS Timeout and Resolution', () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should allow valid public IP resolved from hostname', async () => {
+    vi.mocked(dns.promises.lookup).mockResolvedValue({ address: '8.8.8.8', family: 4 } as any);
+
+    await expect(
+      validateWebhookTarget('https://safe-domain.com/webhook', { dnsTimeoutMs: 500 })
+    ).resolves.not.toThrow();
+  });
+
+  it('should reject private IP resolved from hostname', async () => {
+    vi.mocked(dns.promises.lookup).mockResolvedValue({ address: '192.168.1.1', family: 4 } as any);
+
+    const promise = validateWebhookTarget('https://unsafe-domain.com/webhook', {
+      dnsTimeoutMs: 500,
+    });
+
+    await expect(promise).rejects.toThrow(WebhookTargetValidationError);
+    try {
+      await promise;
+    } catch (err: any) {
+      expect(err.code).toBe('BLOCKED_ADDRESS');
+      expect(err.message).toContain('Blocked IPv4 address');
+    }
+  });
+
+  it('should time out and reject the target when DNS lookup hangs', async () => {
+    // Mock a lookup that hangs forever
+    vi.mocked(dns.promises.lookup).mockImplementation(() => {
+      return new Promise(() => {
+        // Never resolve or reject
+      });
+    });
+
+    const startTime = Date.now();
+    const promise = validateWebhookTarget('https://hanging-resolver.com/webhook', {
+      dnsTimeoutMs: 100,
+    });
+
+    await expect(promise).rejects.toThrow(WebhookTargetValidationError);
+    const duration = Date.now() - startTime;
+    
+    // Ensure the timeout actually fired around 100ms
+    expect(duration).toBeGreaterThanOrEqual(90);
+    expect(duration).toBeLessThan(500);
+
+    // Verify that the error code is DNS_TIMEOUT
+    try {
+      await promise;
+    } catch (err: any) {
+      expect(err.code).toBe('DNS_TIMEOUT');
+      expect(err.message).toContain('DNS resolution timed out');
+    }
+  });
+
+  it('should fail closed when DNS lookup throws/rejects', async () => {
+    vi.mocked(dns.promises.lookup).mockRejectedValue(new Error('ENOTFOUND'));
+
+    const promise = validateWebhookTarget('https://some-failing-domain.com/webhook', {
+      dnsTimeoutMs: 100,
+    });
+
+    await expect(promise).rejects.toThrow(WebhookTargetValidationError);
+
+    try {
+      await promise;
+    } catch (err: any) {
+      expect(err.code).toBe('DNS_RESOLUTION_FAILED');
+      expect(err.message).toContain('DNS resolution failed');
+    }
+  });
+
+  it('should abort the signal passed to lookup when timing out', async () => {
+    let capturedSignal: AbortSignal | undefined;
+    vi.mocked(dns.promises.lookup).mockImplementation((_hostname, options: any) => {
+      capturedSignal = options?.signal;
+      return new Promise(() => {}); // hang
+    });
+
+    const promise = validateWebhookTarget('https://check-signal.com/webhook', {
+      dnsTimeoutMs: 50,
+    });
+
+    await expect(promise).rejects.toThrow(WebhookTargetValidationError);
+    expect(capturedSignal).toBeDefined();
+    expect(capturedSignal?.aborted).toBe(true);
+  });
+});


### PR DESCRIPTION
##closes #485 

```markdown
# fix(ssrf): add DNS lookup timeout and abort to webhook target validation

## Description
This PR resolves issue #485 by adding a configurable DNS resolution timeout to the SSRF guard `validateWebhookTarget`. 

Currently, the SSRF guard calls `dns.promises.lookup(hostname, { all: false })` without a deadline. If a target resolver is slow, unresponsive, or maliciously configured, it can hang indefinitely, stalling the webhook validation path and blocking caller delivery threads.

## Key Changes

### 1. Configuration
- Added the `WEBHOOK_DNS_TIMEOUT_MS` environment variable (default: `2000` ms) to the environment schema in `src/config/env.ts`.
- Added schema tests in `src/config/env.test.ts` to verify default behavior and ensure configuration bounds are correctly enforced.

### 2. SSRF Guard Logic & Fail-Closed Behavior
- Implemented `lookupWithTimeout` helper function in `src/webhooks/ssrfGuard.ts` which wraps `dns.promises.lookup` using a `Promise.race` timeout and an `AbortController`.
- Pass the `AbortSignal` to Node's `dns.promises.lookup`. If a timeout is hit, the controller signals an abort (cancelling the pending lookup to prevent memory/resource leaks) and rejects the target with a `'DNS_TIMEOUT'` validation error code.
- Added specific error codes (e.g. `'DNS_TIMEOUT'`, `'BLOCKED_ADDRESS'`) to `WebhookTargetValidationError` to easily distinguish DNS timeout events from private address rejections.

### 3. Unit Testing
- Added `tests/webhooks/ssrfGuard.test.ts` asserting:
  - Timeout fail-closed behavior when a DNS lookup hangs.
  - That the controller successfully aborts the signal on timeout to prevent leaking lookups.
  - Fail-closed behavior on lookup errors (e.g. `ENOTFOUND`).
  - Standard public and private IP resolution validations.

### 4. Documentation
- Documented `WEBHOOK_DNS_TIMEOUT_MS` in the configuration tables of `README.md` and `docs/webhooks.md`.
- Documented DNS resolution timeout details and error responses in `docs/webhooks.md`.

## Security Notes
- **Fail-Closed Semantics**: A DNS timeout throws a validation error and rejects the target as unsafe, ensuring we fail-closed rather than allowing delivery.
- **Resource Protection**: The lookup is aborted via Node's native cancellation support (`AbortSignal`) to ensure resources are not leaked during timeouts.
```