### PR TITLE
test: cover streams content negotiation

### DIFF
--- a/src/middleware/contentType.ts
+++ b/src/middleware/contentType.ts
@@ -2,6 +2,7 @@ import type { Request, Response, NextFunction } from 'express';
 import { errorResponse } from '../utils/response.js';
 
 const WRITE_METHODS = new Set(['POST', 'PUT', 'PATCH']);
+const READ_METHODS = new Set(['GET', 'HEAD']);
 
 /**
  * Middleware that rejects POST/PUT/PATCH requests carrying a non-JSON
@@ -46,6 +47,42 @@ export function requireJsonContentType(
     errorResponse(
       'UNSUPPORTED_MEDIA_TYPE',
       'Content-Type must be application/json',
+      undefined,
+      requestId,
+    ),
+  );
+}
+
+/**
+ * Middleware that rejects read requests whose Accept header does not allow a
+ * JSON response.
+ *
+ * - No Accept header -> pass through
+ * - `application/json`, `application/*+json`, and wildcard media ranges -> pass through
+ * - Any unacceptable response type -> 406 with standard error envelope
+ *
+ * The response intentionally avoids reflecting the raw Accept header.
+ */
+export function requireJsonAccept(
+  req: Request,
+  res: Response,
+  next: NextFunction,
+): void {
+  if (!READ_METHODS.has(req.method)) {
+    next();
+    return;
+  }
+
+  if (req.accepts(['application/json', 'application/*+json'])) {
+    next();
+    return;
+  }
+
+  const requestId = req.id ?? (res.locals['requestId'] as string | undefined);
+  res.status(406).json(
+    errorResponse(
+      'NOT_ACCEPTABLE',
+      'Accept header must allow application/json',
       undefined,
       requestId,
     ),

--- a/src/routes/streams.ts
+++ b/src/routes/streams.ts
@@ -67,6 +67,7 @@ import {
   tooManyRequests,
 } from '../middleware/errorHandler.js';
 import { requireIdempotencyKey, parseIdempotencyKeyHeader } from '../middleware/requestProtection.js';
+import { requireJsonAccept } from '../middleware/contentType.js';
 import { SerializationLogger, info, debug, warn } from '../utils/logger.js';
 import { recordAuditEvent } from '../lib/auditLog.js';
 import { authenticate, requireAuth, authenticateApiKey, requireScope } from '../middleware/auth.js';
@@ -440,6 +441,7 @@ export function enforceStreamScope(req: Request, res: Response, next: NextFuncti
  */
 streamsRouter.get(
   '/',
+  requireJsonAccept,
   authenticateApiKey,
   requireScope('streams:read'),
   asyncHandler(async (req: Request, res: Response) => {

--- a/tests/routes/streams.contentNegotiation.test.ts
+++ b/tests/routes/streams.contentNegotiation.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import request from 'supertest';
+import express from 'express';
+import { initializeConfig } from '../../src/config/env.js';
+import { errorHandler } from '../../src/middleware/errorHandler.js';
+import { requestIdMiddleware } from '../../src/errors.js';
+
+initializeConfig();
+
+const mockFindWithCursor = vi.fn();
+
+vi.mock('../../src/middleware/auth.js', () => ({
+  authenticate: (_req: unknown, _res: unknown, next: () => void) => next(),
+  requireAuth: (_req: unknown, _res: unknown, next: () => void) => next(),
+  authenticateApiKey: (_req: unknown, _res: unknown, next: () => void) => next(),
+  requireScope: () => (_req: unknown, _res: unknown, next: () => void) => next(),
+}));
+
+vi.mock('../../src/db/repositories/streamRepository.js', () => ({
+  streamRepository: {
+    findWithCursor: (...args: unknown[]) => mockFindWithCursor(...args),
+    getById: vi.fn(),
+    upsertStream: vi.fn(),
+    updateStream: vi.fn(),
+    countByStatus: vi.fn().mockResolvedValue({}),
+  },
+}));
+
+vi.mock('../../src/db/pool.js', () => ({
+  getPool: vi.fn(() => ({})),
+  query: vi.fn(),
+  PoolExhaustedError: class PoolExhaustedError extends Error {
+    constructor() {
+      super('pool exhausted');
+      this.name = 'PoolExhaustedError';
+    }
+  },
+}));
+
+import { streamsRouter } from '../../src/routes/streams.js';
+
+function makeApp() {
+  const app = express();
+  app.use(requestIdMiddleware);
+  app.use(express.json());
+  app.use('/api/streams', streamsRouter);
+  app.use(errorHandler);
+  return app;
+}
+
+describe('GET /api/streams content negotiation', () => {
+  let app: ReturnType<typeof makeApp>;
+
+  beforeEach(() => {
+    app = makeApp();
+    vi.clearAllMocks();
+    mockFindWithCursor.mockResolvedValue({ streams: [], hasMore: false });
+  });
+
+  it('returns 406 for clients that only accept XML', async () => {
+    const res = await request(app).get('/api/streams').set('Accept', 'application/xml').expect(406);
+
+    expect(res.body.success).toBe(false);
+    expect(res.body.error.code).toBe('NOT_ACCEPTABLE');
+    expect(res.body.error.message).toBe('Accept header must allow application/json');
+    expect(JSON.stringify(res.body)).not.toContain('application/xml');
+    expect(mockFindWithCursor).not.toHaveBeenCalled();
+  });
+
+  it('allows explicit JSON clients', async () => {
+    const res = await request(app)
+      .get('/api/streams')
+      .set('Accept', 'application/json')
+      .expect(200);
+
+    expect(res.body.success).toBe(true);
+    expect(res.body.data.streams).toEqual([]);
+    expect(mockFindWithCursor).toHaveBeenCalledTimes(1);
+  });
+
+  it('allows wildcard clients', async () => {
+    await request(app).get('/api/streams').set('Accept', '*/*').expect(200);
+
+    expect(mockFindWithCursor).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns 406 when JSON is explicitly unacceptable', async () => {
+    await request(app)
+      .get('/api/streams')
+      .set('Accept', 'application/json;q=0, application/xml;q=1')
+      .expect(406);
+
+    expect(mockFindWithCursor).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

- Added a reusable JSON `Accept` negotiation middleware for read routes.
- Wired it into `GET /api/streams` before auth and repository work.
- Added focused route coverage for XML-only clients, explicit JSON clients, wildcard clients, and `application/json;q=0`.

## Validation

- `npm test -- tests/routes/streams.contentNegotiation.test.ts`
- `npx eslint src/middleware/contentType.ts tests/routes/streams.contentNegotiation.test.ts`
- `npx prettier --check tests/routes/streams.contentNegotiation.test.ts`
- `git diff --check`

Repo-level baseline checks still fail outside this patch:

- `npm run typecheck` reports existing errors such as `migrations/20260627000000_contract_events_partitioning.ts` using `renameIndex`, missing health config fields, missing AWS SDK types, and existing `src/routes/streams.ts` type errors.
- `npm run lint` reports existing errors across `src` and `tests`, including unused imports in `src/routes/streams.ts`.

## Security

- The 406 response does not reflect the raw `Accept` header value.

Closes #587
