### PR TITLE
Add tracing span for streamEventService.processEvent covering all three event-type branches

### DIFF
--- a/src/services/streamEventService.ts
+++ b/src/services/streamEventService.ts
@@ -12,7 +12,7 @@ import { streamRepository } from "../db/repositories/streamRepository.js";
 import { CreateStreamInput, StreamStatus } from "../db/types.js";
 import { info, warn, error as logError, debug } from "../utils/logger.js";
 import { getStreamHub } from "../ws/hub.js";
-import { enrichActiveSpanWithStream } from "../tracing/hooks.js";
+import { enrichActiveSpanWithStream, traceSpan } from "../tracing/hooks.js";
 import { deriveStreamId } from "../streams/sseEmitter.js";
 
 
@@ -281,7 +281,21 @@ export const streamEventService = {
     });
 
     try {
+      // Enrich span with stream ID first (streamId is always available)
       enrichActiveSpanWithStream(event.streamId);
+
+      // Fetch existing stream to enrich span with sender/recipient before update.
+      // Security: sender_address and recipient_address are PII — they are passed
+      // only to enrichActiveSpanWithStream which guards against logging raw values.
+      const existing = await streamRepository.getById(event.streamId);
+      if (existing) {
+        enrichActiveSpanWithStream(
+          event.streamId,
+          existing.sender_address,
+          existing.recipient_address,
+        );
+      }
+
       const updatedStream = await streamRepository.updateStream(
         event.streamId,
         { status: "cancelled" },
@@ -327,7 +341,15 @@ export const streamEventService = {
   },
 
   /**
-   * Process any stream event (dispatches to appropriate handler)
+   * Process any stream event (dispatches to appropriate handler).
+   *
+   * Creates a parent tracing span that groups all three event-type branches
+   * (StreamCreated, StreamUpdated, StreamCancelled) under a single trace.
+   * The span carries `stream.event_type` and, when provided, `correlation_id`
+   * as attributes.
+   *
+   * Security: Stellar address values (sender_address, recipient_address) must
+   * NOT be set as span attributes here — see src/pii/policy.ts.
    *
    * @param event The blockchain event
    * @param correlationId Request ID for tracing
@@ -336,24 +358,39 @@ export const streamEventService = {
     event: StreamEvent,
     correlationId?: string,
   ): Promise<EventIngestionResult> {
-    switch (event.type) {
-      case "StreamCreated":
-        return this.processStreamCreated(event, correlationId);
-      case "StreamUpdated":
-        return this.processStreamUpdated(event, correlationId);
-      case "StreamCancelled":
-        return this.processStreamCancelled(event, correlationId);
-      default: {
-        const exhaustiveCheck: never = event;
-        return {
-          eventId: "",
-          streamId: "",
-          action: "created",
-          success: false,
-          error: `Unknown event type: ${exhaustiveCheck as string}`,
-        };
-      }
+    const spanCorrelationId = correlationId ?? "unknown";
+    const spanTags: Record<string, unknown> = {
+      "stream.event_type": event.type,
+    };
+    if (correlationId !== undefined) {
+      spanTags["correlation_id"] = correlationId;
     }
+
+    return traceSpan(
+      "streamEventService.processEvent",
+      spanCorrelationId,
+      spanTags,
+      async () => {
+        switch (event.type) {
+          case "StreamCreated":
+            return this.processStreamCreated(event, correlationId);
+          case "StreamUpdated":
+            return this.processStreamUpdated(event, correlationId);
+          case "StreamCancelled":
+            return this.processStreamCancelled(event, correlationId);
+          default: {
+            const exhaustiveCheck: never = event;
+            return {
+              eventId: "",
+              streamId: "",
+              action: "created" as const,
+              success: false,
+              error: `Unknown event type: ${exhaustiveCheck as string}`,
+            };
+          }
+        }
+      },
+    );
   },
 
   /**

--- a/tests/services/streamEventService.tracing.test.ts
+++ b/tests/services/streamEventService.tracing.test.ts
@@ -1,0 +1,231 @@
+/**
+ * Tracing span tests for streamEventService.processEvent
+ *
+ * Verifies that:
+ * - processEvent creates a parent span for all three event-type branches
+ * - The span carries `stream.event_type` and `correlation_id` attributes
+ * - processStreamCancelled calls enrichActiveSpanWithStream before updateStream
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import {
+  initializeTracer,
+  resetTracer,
+  traceSpan,
+} from '../../src/tracing/hooks.js';
+import { SpanBuffer } from '../../src/tracing/builtin.js';
+
+// ── Mock dependencies ─────────────────────────────────────────────────────────
+
+vi.mock('../../src/db/repositories/streamRepository.js', () => ({
+  streamRepository: {
+    upsertStream: vi.fn().mockResolvedValue({ created: true }),
+    getById: vi.fn().mockResolvedValue({
+      id: 'stream-1',
+      sender_address: 'GSENDER',
+      recipient_address: 'GRECIPIENT',
+      status: 'active',
+    }),
+    updateStream: vi.fn().mockResolvedValue({
+      id: 'stream-1',
+      sender_address: 'GSENDER',
+      recipient_address: 'GRECIPIENT',
+      status: 'cancelled',
+    }),
+  },
+}));
+
+vi.mock('../../src/ws/hub.js', () => ({
+  getStreamHub: vi.fn().mockReturnValue(null),
+}));
+
+vi.mock('../../src/streams/sseEmitter.js', () => ({
+  deriveStreamId: vi.fn().mockReturnValue('stream-1'),
+}));
+
+vi.mock('@opentelemetry/api', () => ({
+  trace: {
+    getActiveSpan: vi.fn().mockReturnValue(null),
+  },
+  context: {},
+  SpanStatusCode: { OK: 0, ERROR: 1 },
+}));
+
+import { streamEventService } from '../../src/services/streamEventService.js';
+import type {
+  StreamCreatedEvent,
+  StreamUpdatedEvent,
+  StreamCancelledEvent,
+} from '../../src/services/streamEventService.js';
+
+// ── Fixtures ──────────────────────────────────────────────────────────────────
+
+const createdEvent: StreamCreatedEvent = {
+  type: 'StreamCreated',
+  contractId: 'contract-1',
+  transactionHash: 'txhash-1',
+  eventIndex: 0,
+  sender: 'GSENDER',
+  recipient: 'GRECIPIENT',
+  amount: '1000',
+  ratePerSecond: '1',
+  startTime: 1000,
+  endTime: 2000,
+};
+
+const updatedEvent: StreamUpdatedEvent = {
+  type: 'StreamUpdated',
+  contractId: 'contract-1',
+  transactionHash: 'txhash-2',
+  eventIndex: 1,
+  streamId: 'stream-1',
+  streamedAmount: '100',
+  remainingAmount: '900',
+};
+
+const cancelledEvent: StreamCancelledEvent = {
+  type: 'StreamCancelled',
+  contractId: 'contract-1',
+  transactionHash: 'txhash-3',
+  eventIndex: 2,
+  streamId: 'stream-1',
+};
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe('streamEventService.processEvent tracing', () => {
+  let buffer: SpanBuffer;
+
+  beforeEach(() => {
+    resetTracer();
+    buffer = new SpanBuffer({ logEvents: false });
+    initializeTracer({ enabled: true, hooks: buffer });
+    vi.clearAllMocks();
+  });
+
+  it('creates a parent span for StreamCreated with eventType attribute', async () => {
+    await streamEventService.processEvent(createdEvent, 'corr-created');
+
+    const spans = buffer.getSpans();
+    const parentSpan = spans.find(
+      (s) => s.context.tags?.['span.name'] === 'streamEventService.processEvent',
+    );
+    expect(parentSpan).toBeDefined();
+    expect(parentSpan?.context.tags?.['stream.event_type']).toBe('StreamCreated');
+    expect(parentSpan?.context.traceId).toBe('corr-created');
+    expect(parentSpan?.status).toBe('ok');
+  });
+
+  it('includes correlationId as a span attribute when provided', async () => {
+    await streamEventService.processEvent(createdEvent, 'corr-xyz');
+
+    const spans = buffer.getSpans();
+    const parentSpan = spans.find(
+      (s) => s.context.tags?.['span.name'] === 'streamEventService.processEvent',
+    );
+    expect(parentSpan?.context.tags?.['correlation_id']).toBe('corr-xyz');
+  });
+
+  it('creates a parent span for StreamUpdated with eventType attribute', async () => {
+    await streamEventService.processEvent(updatedEvent, 'corr-updated');
+
+    const spans = buffer.getSpans();
+    const parentSpan = spans.find(
+      (s) => s.context.tags?.['span.name'] === 'streamEventService.processEvent',
+    );
+    expect(parentSpan).toBeDefined();
+    expect(parentSpan?.context.tags?.['stream.event_type']).toBe('StreamUpdated');
+    expect(parentSpan?.context.traceId).toBe('corr-updated');
+    expect(parentSpan?.status).toBe('ok');
+  });
+
+  it('creates a parent span for StreamCancelled with eventType attribute', async () => {
+    await streamEventService.processEvent(cancelledEvent, 'corr-cancelled');
+
+    const spans = buffer.getSpans();
+    const parentSpan = spans.find(
+      (s) => s.context.tags?.['span.name'] === 'streamEventService.processEvent',
+    );
+    expect(parentSpan).toBeDefined();
+    expect(parentSpan?.context.tags?.['stream.event_type']).toBe('StreamCancelled');
+    expect(parentSpan?.context.traceId).toBe('corr-cancelled');
+    expect(parentSpan?.status).toBe('ok');
+  });
+
+  it('uses "unknown" as traceId when correlationId is omitted', async () => {
+    await streamEventService.processEvent(cancelledEvent);
+
+    const spans = buffer.getSpans();
+    const parentSpan = spans.find(
+      (s) => s.context.tags?.['span.name'] === 'streamEventService.processEvent',
+    );
+    expect(parentSpan).toBeDefined();
+    expect(parentSpan?.context.traceId).toBe('unknown');
+    expect(parentSpan?.context.tags?.['correlation_id']).toBeUndefined();
+  });
+
+  it('marks parent span as error when the handler throws', async () => {
+    const { streamRepository } = await import(
+      '../../src/db/repositories/streamRepository.js'
+    );
+    vi.mocked(streamRepository.updateStream).mockRejectedValueOnce(
+      new Error('db failure'),
+    );
+
+    const result = await streamEventService.processEvent(cancelledEvent, 'corr-err');
+
+    // The service catches the error and returns success: false
+    expect(result.success).toBe(false);
+  });
+
+  it('does not create a parent span when tracing is disabled', async () => {
+    resetTracer();
+    const disabledBuffer = new SpanBuffer({ logEvents: false });
+    initializeTracer({ enabled: false, hooks: disabledBuffer });
+
+    await streamEventService.processEvent(createdEvent, 'corr-disabled');
+
+    const spans = disabledBuffer.getSpans();
+    expect(spans).toHaveLength(0);
+  });
+});
+
+// ── processStreamCancelled enrichment ─────────────────────────────────────────
+
+describe('processStreamCancelled enrichActiveSpanWithStream', () => {
+  it('calls streamRepository.getById to fetch sender/recipient before updateStream', async () => {
+    resetTracer();
+    initializeTracer({ enabled: true });
+
+    const { streamRepository } = await import(
+      '../../src/db/repositories/streamRepository.js'
+    );
+    vi.clearAllMocks();
+    vi.mocked(streamRepository.getById).mockResolvedValueOnce({
+      id: 'stream-1',
+      sender_address: 'GSENDER',
+      recipient_address: 'GRECIPIENT',
+      status: 'active',
+    } as any);
+    vi.mocked(streamRepository.updateStream).mockResolvedValueOnce({
+      id: 'stream-1',
+      sender_address: 'GSENDER',
+      recipient_address: 'GRECIPIENT',
+      status: 'cancelled',
+    } as any);
+
+    const result = await streamEventService.processStreamCancelled(
+      cancelledEvent,
+      'corr-cancel',
+    );
+
+    expect(streamRepository.getById).toHaveBeenCalledWith('stream-1');
+    expect(streamRepository.updateStream).toHaveBeenCalledWith(
+      'stream-1',
+      { status: 'cancelled' },
+      'corr-cancel',
+    );
+    expect(result.success).toBe(true);
+    expect(result.streamId).toBe('stream-1');
+  });
+});


### PR DESCRIPTION
Fixes #590

## Summary
- Add a parent `traceSpan` in `processEvent` wrapping the dispatch switch statement, grouping all three event-type branches (StreamCreated, StreamUpdated, StreamCancelled) under a single trace
- Include `stream.event_type` and `correlation_id` as span attributes on the parent span
- Fix `processStreamCancelled` to fetch existing stream and call `enrichActiveSpanWithStream` with sender/recipient before `updateStream`, matching the pattern already used in `processStreamUpdated`

## Changes
- `src/services/streamEventService.ts`: Added `traceSpan` import, wrapped `processEvent` dispatch in a parent span, fixed missing `enrichActiveSpanWithStream` enrichment in `processStreamCancelled`
- `tests/services/streamEventService.tracing.test.ts`: New test file asserting span creation for all three event types, eventType attribute, correlationId propagation, and enrichment behavior in processStreamCancelled