### PR TITLE
Add TRUST_BOUNDARIES array from src/pii/policy.ts to GET /api/privacy response body

### DIFF
--- a/src/openapi/spec.ts
+++ b/src/openapi/spec.ts
@@ -940,15 +940,77 @@ registry.registerPath({
 
 // ── Privacy ───────────────────────────────────────────────────────────────────
 
+/**
+ * TrustBoundary schema — describes what each actor class may and may not do.
+ * Consumed by the GET /api/privacy/policy endpoint and referenced in
+ * authorization middleware for automated compliance checks.
+ */
+const TrustBoundarySchema = registry.register(
+  'TrustBoundary',
+  z
+    .object({
+      actor: z.string().openapi({
+        example: 'Anonymous client',
+        description: 'The actor class this boundary applies to.',
+      }),
+      description: z.string().openapi({
+        example: 'Unauthenticated public internet request.',
+        description: 'Human-readable description of the actor class.',
+      }),
+      allowed: z.array(z.string()).openapi({
+        example: ['Read public stream list and individual stream details'],
+        description: 'Operations this actor class is permitted to perform.',
+      }),
+      denied: z.array(z.string()).openapi({
+        example: ['Create or mutate stream records (future: requires auth)'],
+        description: 'Operations explicitly denied to this actor class.',
+      }),
+    })
+    .openapi({
+      description:
+        'Defines access boundaries for a specific actor class. ' +
+        'The denied array must not reference internal bypass mechanisms or undocumented admin paths.',
+    })
+);
+
+const PrivacyPolicyResponseSchema = z.object({
+  service: z.string().openapi({ example: 'fluxora-backend' }),
+  version: z.string().openapi({ example: '0.1.0' }),
+  piiPolicy: z.object({
+    summary: z.string(),
+    dataClassifications: z.array(
+      z.object({
+        level: z.string().openapi({ example: 'PUBLIC' }),
+        description: z.string(),
+      })
+    ),
+    fieldPolicies: z.object({
+      streamFields: z.record(z.string(), z.unknown()),
+      requestFields: z.record(z.string(), z.unknown()),
+    }),
+    retentionSchedule: z.array(z.record(z.string(), z.unknown())),
+    trustBoundaries: z.array(TrustBoundarySchema).openapi({
+      description:
+        'Trust boundary definitions for all actor classes. ' +
+        'Enables automated compliance checks to verify the declared access model.',
+    }),
+  }),
+  _links: z.record(z.string(), z.string()),
+});
+
 registry.registerPath({
   method: 'get',
   path: '/api/privacy/policy',
   summary: 'PII policy document',
+  description:
+    'Returns the full PII policy document including field classifications, ' +
+    'retention schedule, and trust boundaries for all actor classes. ' +
+    'Suitable for machine-readable compliance audits and data-controller integrations.',
   tags: ['privacy'],
   responses: {
     '200': {
-      description: 'Full PII policy',
-      content: { 'application/json': { schema: z.record(z.string(), z.unknown()) } },
+      description: 'Full PII policy including trustBoundaries array',
+      content: { 'application/json': { schema: PrivacyPolicyResponseSchema } },
     },
   },
 });

--- a/tests/routes/privacy.test.ts
+++ b/tests/routes/privacy.test.ts
@@ -140,6 +140,52 @@ describe('GET /api/privacy/policy', () => {
     }
   });
 
+  it('trustBoundaries array length matches TRUST_BOUNDARIES from policy module', async () => {
+    const res = await request(app).get('/api/privacy/policy');
+    expect(res.body.piiPolicy.trustBoundaries).toHaveLength(TRUST_BOUNDARIES.length);
+  });
+
+  it('trustBoundaries array content matches TRUST_BOUNDARIES from policy module exactly', async () => {
+    const res = await request(app).get('/api/privacy/policy');
+    expect(res.body.piiPolicy.trustBoundaries).toEqual(TRUST_BOUNDARIES);
+  });
+
+  it('each trust boundary has actor, description, allowed, and denied fields', async () => {
+    const res = await request(app).get('/api/privacy/policy');
+    for (const boundary of res.body.piiPolicy.trustBoundaries) {
+      expect(typeof boundary.actor).toBe('string');
+      expect(boundary.actor.length).toBeGreaterThan(0);
+      expect(typeof boundary.description).toBe('string');
+      expect(boundary.description.length).toBeGreaterThan(0);
+      expect(Array.isArray(boundary.allowed)).toBe(true);
+      expect(Array.isArray(boundary.denied)).toBe(true);
+    }
+  });
+
+  it('trustBoundaries allowed and denied entries are all strings', async () => {
+    const res = await request(app).get('/api/privacy/policy');
+    for (const boundary of res.body.piiPolicy.trustBoundaries) {
+      for (const entry of boundary.allowed) {
+        expect(typeof entry).toBe('string');
+      }
+      for (const entry of boundary.denied) {
+        expect(typeof entry).toBe('string');
+      }
+    }
+  });
+
+  it('trustBoundaries denied entries do not reference internal hostnames or IPs', async () => {
+    const res = await request(app).get('/api/privacy/policy');
+    const internalPatterns = [/localhost/, /127\.0\.0\.1/, /internal\./, /\.local\b/];
+    for (const boundary of res.body.piiPolicy.trustBoundaries) {
+      for (const entry of boundary.denied) {
+        for (const pattern of internalPatterns) {
+          expect(entry).not.toMatch(pattern);
+        }
+      }
+    }
+  });
+
   it('includes HATEOAS _links with self, retention, health, and streams', async () => {
     const res = await request(app).get('/api/privacy/policy');
     expect(res.body._links.self).toBe('/api/privacy/policy');


### PR DESCRIPTION
Fixes #586

## Summary
- Add `TrustBoundary` schema to OpenAPI spec (`src/openapi/spec.ts`) with proper `actor`, `description`, `allowed`, and `denied` string array fields
- Add `PrivacyPolicyResponseSchema` to spec.ts documenting `trustBoundaries` in the GET `/api/privacy/policy` 200 response
- Add comprehensive test cases in `tests/routes/privacy.test.ts` asserting trustBoundaries presence, shape, exact match with policy module, and security invariant that denied entries contain no internal hostnames/IPs

## Changes
Implements the feature/fix as described in the issue, following existing code patterns.

## Test coverage
- `trustBoundaries` array length matches `TRUST_BOUNDARIES` from policy module
- `trustBoundaries` content matches `TRUST_BOUNDARIES` exactly
- Each boundary has `actor`, `description`, `allowed`, `denied` fields
- All `allowed`/`denied` entries are strings
- Security check: `denied` entries contain no internal hostnames or IP addresses