### PR TITLE
Add content-type negotiation test for GET /api/streams with Accept application/xml returning 406

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -35,6 +35,7 @@ import {
 } from './middleware/requestProtection.js';
 import { apiVersionMiddleware } from './middleware/apiVersion.js';
 import { requireJsonContentType } from './middleware/contentType.js';
+import { requireJsonAccept } from './middleware/acceptNegotiation.js';
 import { httpMetrics } from './middleware/httpMetrics.js';
 import { isShuttingDown, addShutdownHook } from './shutdown.js';
 import { startRuntimeMetrics, stopRuntimeMetrics } from './metrics/runtimeMetrics.js';
@@ -270,6 +271,7 @@ export function createApp(options: AppOptions = {}): Express {
   app.use(createHelmetMiddleware());
   app.use(bodySizeLimitMiddleware);
   app.use('/api', requireJsonContentType);
+  app.use('/api', requireJsonAccept);
   // Correlation ID must run before express.json() so req.correlationId is available
   // even when JSON parsing throws and the error handler fires immediately.
   app.use(correlationIdMiddleware);

--- a/src/middleware/acceptNegotiation.ts
+++ b/src/middleware/acceptNegotiation.ts
@@ -1,0 +1,104 @@
+import type { Request, Response, NextFunction } from 'express';
+import { errorResponse } from '../utils/response.js';
+
+/**
+ * Parses the Accept header and returns the highest-priority media type.
+ *
+ * Follows RFC 7231 §5.3.2: each entry may carry an optional `q` parameter
+ * (quality value, 0–1, default 1.0). Entries are sorted by descending quality;
+ * within the same quality level the order of appearance is preserved.
+ *
+ * @param acceptHeader - Raw value of the Accept request header.
+ * @returns Ordered list of media type strings (without parameters).
+ */
+function parseAcceptHeader(acceptHeader: string): string[] {
+  return acceptHeader
+    .split(',')
+    .map((entry) => {
+      const [mediaType, ...params] = entry.trim().split(';');
+      const qParam = params.find((p) => p.trim().startsWith('q='));
+      const q = qParam ? parseFloat(qParam.trim().slice(2)) : 1.0;
+      return { mediaType: (mediaType ?? '').trim().toLowerCase(), q: isNaN(q) ? 1.0 : q };
+    })
+    .filter(({ mediaType }) => mediaType.length > 0)
+    .sort((a, b) => b.q - a.q)
+    .map(({ mediaType }) => mediaType);
+}
+
+/**
+ * Returns `true` when the media type is acceptable for a JSON-only endpoint.
+ *
+ * Acceptable values:
+ * - `*\/*`               (wildcard — client accepts anything)
+ * - `application/*`     (application wildcard)
+ * - `application/json`  (exact JSON match)
+ * - `application/*+json` (vendor JSON subtypes, e.g. application/vnd.api+json)
+ */
+function isJsonAcceptable(mediaType: string): boolean {
+  return (
+    mediaType === '*/*' ||
+    mediaType === 'application/*' ||
+    mediaType === 'application/json' ||
+    (mediaType.startsWith('application/') && mediaType.endsWith('+json'))
+  );
+}
+
+/**
+ * Middleware that enforces JSON-only content negotiation on GET (and HEAD)
+ * routes.
+ *
+ * When a client sends an `Accept` header that cannot be satisfied by
+ * `application/json` — for example `Accept: application/xml` — this
+ * middleware responds with `406 Not Acceptable` and a standard error envelope.
+ *
+ * Behaviour matrix:
+ * - No Accept header              → pass through (implicit *\/*)
+ * - `Accept: *\/*`                → pass through
+ * - `Accept: application/json`   → pass through
+ * - `Accept: application/*`      → pass through
+ * - `Accept: application/xml`    → 406 Not Acceptable
+ * - `Accept: application/xml, application/json;q=0.9` → pass through (JSON
+ *   is listed but at lower quality; the server can still satisfy with JSON)
+ *
+ * Security note: the raw `Accept` header value is **not** echoed in the
+ * response body to prevent header-injection reflection.
+ */
+export function requireJsonAccept(
+  req: Request,
+  res: Response,
+  next: NextFunction,
+): void {
+  const acceptHeader = req.headers['accept'];
+
+  // No Accept header — implicit wildcard, always acceptable.
+  if (!acceptHeader) {
+    next();
+    return;
+  }
+
+  const types = parseAcceptHeader(acceptHeader);
+
+  // Empty or unparseable header — treat as wildcard.
+  if (types.length === 0) {
+    next();
+    return;
+  }
+
+  // If *any* of the listed types is JSON-acceptable the server can satisfy
+  // the request; proceed normally.
+  const canSatisfy = types.some(isJsonAcceptable);
+  if (canSatisfy) {
+    next();
+    return;
+  }
+
+  const requestId = req.id ?? (res.locals['requestId'] as string | undefined);
+  res.status(406).json(
+    errorResponse(
+      'NOT_ACCEPTABLE',
+      'This endpoint only produces application/json responses',
+      undefined,
+      requestId,
+    ),
+  );
+}

--- a/tests/streams.test.ts
+++ b/tests/streams.test.ts
@@ -54,6 +54,7 @@ import { correlationIdMiddleware } from '../src/middleware/correlationId.js';
 import { generateToken } from '../src/lib/auth.js';
 import { authenticate } from '../src/middleware/auth.js';
 import { initializeConfig } from '../src/config/env.js';
+import { requireJsonAccept } from '../src/middleware/acceptNegotiation.js';
 
 // Initialize config before any test module code runs (upstream requirement)
 initializeConfig();
@@ -90,6 +91,7 @@ function createTestApp() {
   app.use(requestIdMiddleware);
   app.use(correlationIdMiddleware);
   app.use(express.json());
+  app.use('/api', requireJsonAccept);
   app.use(authenticate);
   app.use('/api/streams', streamsRouter);
   app.use(errorHandler);
@@ -935,5 +937,139 @@ describe('Stream Status Transitions', () => {
       const res = await request(app).delete(`/api/streams/${id}`).set('Authorization', auth);
       expect(res.status).toBe(200);
     });
+  });
+});
+
+// ─── Content-Type Negotiation Tests ──────────────────────────────────────────
+
+/**
+ * Verifies that GET /api/streams enforces HTTP content negotiation (RFC 7231
+ * §5.3.2) by returning 406 Not Acceptable when the client signals it cannot
+ * accept application/json via the Accept header.
+ *
+ * Security note: the 406 response body uses the standard error envelope and
+ * does NOT reflect the raw Accept header value to prevent header-injection.
+ */
+describe('Content-Type Negotiation — GET /api/streams', () => {
+  let app: ReturnType<typeof createTestApp>;
+
+  beforeEach(() => {
+    app = createTestApp();
+    streams.length = 0;
+    setStreamListingDependencyState('healthy');
+    setIdempotencyDependencyState('healthy');
+    resetStreamIdempotencyStore();
+
+    vi.clearAllMocks();
+    mockFindWithCursor.mockResolvedValue({ streams: [], hasMore: false });
+  });
+
+  it('returns 200 with Accept: application/json', async () => {
+    const res = await request(app)
+      .get('/api/streams')
+      .set('Accept', 'application/json')
+      .expect(200);
+
+    expect(res.body.success).toBe(true);
+    expect(res.headers['content-type']).toMatch(/application\/json/);
+  });
+
+  it('returns 200 with Accept: */*', async () => {
+    const res = await request(app)
+      .get('/api/streams')
+      .set('Accept', '*/*')
+      .expect(200);
+
+    expect(res.body.success).toBe(true);
+  });
+
+  it('returns 200 with no Accept header (implicit */*)', async () => {
+    const res = await request(app)
+      .get('/api/streams')
+      .expect(200);
+
+    expect(res.body.success).toBe(true);
+  });
+
+  it('returns 406 with Accept: application/xml', async () => {
+    const res = await request(app)
+      .get('/api/streams')
+      .set('Accept', 'application/xml')
+      .expect(406);
+
+    expect(res.body.success).toBe(false);
+    expect(res.body.error.code).toBe('NOT_ACCEPTABLE');
+    expect(res.body.error.message).toBeDefined();
+    // Security: raw Accept header value must not be reflected in the response
+    expect(JSON.stringify(res.body)).not.toContain('application/xml');
+  });
+
+  it('returns 406 with Accept: text/html', async () => {
+    const res = await request(app)
+      .get('/api/streams')
+      .set('Accept', 'text/html')
+      .expect(406);
+
+    expect(res.body.success).toBe(false);
+    expect(res.body.error.code).toBe('NOT_ACCEPTABLE');
+  });
+
+  it('returns 406 with Accept: text/plain', async () => {
+    const res = await request(app)
+      .get('/api/streams')
+      .set('Accept', 'text/plain')
+      .expect(406);
+
+    expect(res.body.success).toBe(false);
+    expect(res.body.error.code).toBe('NOT_ACCEPTABLE');
+  });
+
+  it('returns 200 when Accept lists application/json alongside xml (json is acceptable)', async () => {
+    // The server CAN satisfy application/json even if XML is listed first at
+    // equal or higher quality — it should serve JSON and return 200.
+    const res = await request(app)
+      .get('/api/streams')
+      .set('Accept', 'application/xml, application/json;q=0.9')
+      .expect(200);
+
+    expect(res.body.success).toBe(true);
+  });
+
+  it('returns 406 when XML is exclusively preferred over JSON via quality values', async () => {
+    // q=1.0 for xml, q=0.0 for json means the client cannot accept JSON.
+    const res = await request(app)
+      .get('/api/streams')
+      .set('Accept', 'application/xml;q=1.0, application/json;q=0.0')
+      .expect(406);
+
+    expect(res.body.success).toBe(false);
+    expect(res.body.error.code).toBe('NOT_ACCEPTABLE');
+  });
+
+  it('returns 200 with Accept: application/* (application wildcard)', async () => {
+    const res = await request(app)
+      .get('/api/streams')
+      .set('Accept', 'application/*')
+      .expect(200);
+
+    expect(res.body.success).toBe(true);
+  });
+
+  it('406 response uses standard error envelope without exposing internals', async () => {
+    const res = await request(app)
+      .get('/api/streams')
+      .set('Accept', 'application/xml')
+      .set('X-Request-ID', 'negotiation-test-id')
+      .expect(406);
+
+    expect(res.body).toMatchObject({
+      success: false,
+      error: {
+        code: 'NOT_ACCEPTABLE',
+        message: expect.any(String),
+      },
+    });
+    // requestId propagation
+    expect(res.body.error.requestId).toBe('negotiation-test-id');
   });
 });


### PR DESCRIPTION
Fixes #587

## Summary
- Add `requireJsonAccept` middleware that returns 406 Not Acceptable when the client's `Accept` header cannot be satisfied by `application/json` (e.g. `Accept: application/xml`)
- Mount `requireJsonAccept` on `/api` routes in `app.ts` alongside the existing `requireJsonContentType` middleware
- Add content-negotiation test suite in `tests/streams.test.ts` covering all acceptance criteria from the issue

## Changes
- `src/middleware/acceptNegotiation.ts` — new middleware with RFC 7231 §5.3.2 Accept header parsing, 406 response with standard error envelope, no raw header reflection (security)
- `src/app.ts` — mount `requireJsonAccept` on `/api`
- `tests/streams.test.ts` — include middleware in test app and add 10 content-negotiation test cases: `Accept: application/xml` → 406, `Accept: application/json` → 200, `Accept: */*` → 200, quality-value edge cases, security envelope assertions