### PR TITLE
Add request body size metric counter for oversized payloads rejected by requestProtection middleware

### DIFF
--- a/src/metrics/requestProtectionMetrics.ts
+++ b/src/metrics/requestProtectionMetrics.ts
@@ -1,0 +1,51 @@
+/**
+ * Metrics for the requestProtection middleware.
+ *
+ * Exports a prom-client Counter that is incremented whenever the
+ * `bodySizeLimitMiddleware` rejects a request with HTTP 413 (Payload Too Large).
+ *
+ * Label:
+ *   `path` — normalized route template (e.g. `/api/streams`), derived from
+ *             `req.route?.path ?? req.path`. Raw `req.originalUrl` is intentionally
+ *             avoided to prevent high-cardinality / user-data leakage in the label set.
+ *
+ * @module metrics/requestProtectionMetrics
+ *
+ * @security
+ * - The `path` label uses the route template, not the raw URL, to prevent
+ *   path parameters (e.g. stream IDs, Stellar addresses) or query strings from
+ *   appearing in metric label values (cardinality explosion / data leakage).
+ *
+ * Usage — alert example (PromQL):
+ *   increase(fluxora_request_body_too_large_total[5m]) > 50
+ */
+
+import { Counter } from 'prom-client';
+import { registry } from '../metrics.js';
+
+/**
+ * Counter incremented once for every HTTP 413 rejection produced by
+ * `bodySizeLimitMiddleware`. Labelled by `path` (route template).
+ *
+ * @example
+ * // Alert on DoS probes — fire when more than 50 oversized payloads
+ * // arrive within a 5-minute window on any single route.
+ * increase(fluxora_request_body_too_large_total[5m]) > 50
+ */
+export const requestBodyTooLargeTotal =
+  (registry.getSingleMetric('fluxora_request_body_too_large_total') as Counter<'path'>) ||
+  new Counter({
+    name: 'fluxora_request_body_too_large_total',
+    help: 'Total number of requests rejected with HTTP 413 due to body size exceeding the configured limit, labeled by normalized route path',
+    labelNames: ['path'] as const,
+    registers: [registry],
+  });
+
+/**
+ * De-register the counter. Intended only for test teardown — do not call in
+ * production code as it cannot be safely re-registered without restarting the
+ * process.
+ */
+export function deRegisterRequestProtectionMetrics(): void {
+  registry.removeSingleMetric('fluxora_request_body_too_large_total');
+}

--- a/src/middleware/requestProtection.ts
+++ b/src/middleware/requestProtection.ts
@@ -24,6 +24,24 @@
 
 import type { Request, Response, NextFunction } from 'express';
 import { payloadTooLarge, requestTimeout, validationError } from './errorHandler.js';
+import { requestBodyTooLargeTotal } from '../metrics/requestProtectionMetrics.js';
+
+/**
+ * Derive a normalized route path label for metrics.
+ *
+ * Uses `req.route.path` when Express has matched a route (most accurate), falling
+ * back to `req.path` when the middleware fires before routing (e.g. the fast-path
+ * Content-Length check). Raw `req.originalUrl` is never used — it would expose
+ * path parameters and query strings in the Prometheus label, causing cardinality
+ * explosion and potential data leakage.
+ *
+ * @internal
+ */
+function normalizedPath(req: Request): string {
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+  const routePath = (req as unknown as { route?: { path?: string } }).route?.path;
+  return typeof routePath === 'string' ? routePath : req.path;
+}
 
 // ── Idempotency-Key constants ─────────────────────────────────────────────────
 
@@ -54,6 +72,12 @@ export function bodySizeLimitMiddleware(
   if (clHeader !== undefined) {
     const cl = parseInt(clHeader, 10);
     if (!Number.isNaN(cl) && cl > BODY_LIMIT_BYTES) {
+      /**
+       * Increment the oversized-body counter so SREs can alert on sudden spikes
+       * in 413 responses (potential DoS probe or misconfigured client).
+       * @see src/metrics/requestProtectionMetrics.ts
+       */
+      requestBodyTooLargeTotal.inc({ path: normalizedPath(req) });
       next(payloadTooLarge(`Request body exceeds the ${BODY_LIMIT_BYTES}-byte limit`));
       return;
     }
@@ -68,6 +92,11 @@ export function bodySizeLimitMiddleware(
     received += chunk.length;
     if (received > BODY_LIMIT_BYTES) {
       rejected = true;
+      /**
+       * Increment the oversized-body counter for the stream-based slow path.
+       * @see src/metrics/requestProtectionMetrics.ts
+       */
+      requestBodyTooLargeTotal.inc({ path: normalizedPath(req) });
       next(payloadTooLarge(`Request body exceeds the ${BODY_LIMIT_BYTES}-byte limit`));
       req.socket.destroy();
     }

--- a/tests/middleware/requestProtection.metric.test.ts
+++ b/tests/middleware/requestProtection.metric.test.ts
@@ -1,0 +1,165 @@
+/**
+ * Tests for the fluxora_request_body_too_large_total metric counter.
+ *
+ * Verifies that:
+ *  - The counter increments exactly once per 413 rejection (Content-Length fast path)
+ *  - The counter is NOT incremented for accepted requests
+ *  - The path label uses a normalized route, not the raw URL
+ *  - Multiple rejections on different paths produce independent label combinations
+ */
+
+import express from 'express';
+import request from 'supertest';
+import {
+  bodySizeLimitMiddleware,
+  BODY_LIMIT_BYTES,
+} from '../../src/middleware/requestProtection.js';
+import { errorHandler } from '../../src/middleware/errorHandler.js';
+import {
+  requestBodyTooLargeTotal,
+  deRegisterRequestProtectionMetrics,
+} from '../../src/metrics/requestProtectionMetrics.js';
+
+// Re-create the counter for each test suite run to avoid state leaking across
+// files when vitest runs tests in the same process.
+beforeEach(() => {
+  deRegisterRequestProtectionMetrics();
+});
+
+afterEach(() => {
+  deRegisterRequestProtectionMetrics();
+});
+
+async function getCounterValue(path: string): Promise<number> {
+  const values = await requestBodyTooLargeTotal.get();
+  const entry = values.values.find((v) => v.labels['path'] === path);
+  return entry?.value ?? 0;
+}
+
+describe('fluxora_request_body_too_large_total counter', () => {
+  let app: express.Application;
+
+  beforeEach(() => {
+    app = express();
+    app.use(bodySizeLimitMiddleware);
+    app.use(express.json());
+    app.post('/api/streams', (_req, res) => res.status(201).json({ ok: true }));
+    app.post('/api/webhooks', (_req, res) => res.status(200).json({ ok: true }));
+    app.use(errorHandler);
+  });
+
+  describe('counter increments on rejection', () => {
+    it('increments once when Content-Length exceeds the limit', async () => {
+      const oversizedBody = 'x'.repeat(BODY_LIMIT_BYTES + 1);
+
+      await request(app)
+        .post('/api/streams')
+        .set('Content-Type', 'application/json')
+        .set('Content-Length', String(oversizedBody.length))
+        .send(oversizedBody)
+        .expect(413);
+
+      const count = await getCounterValue('/api/streams');
+      expect(count).toBe(1);
+    });
+
+    it('increments only once even for repeated rejections on the same path', async () => {
+      const oversizedBody = 'y'.repeat(BODY_LIMIT_BYTES + 100);
+
+      await request(app)
+        .post('/api/streams')
+        .set('Content-Type', 'application/json')
+        .set('Content-Length', String(oversizedBody.length))
+        .send(oversizedBody)
+        .expect(413);
+
+      await request(app)
+        .post('/api/streams')
+        .set('Content-Type', 'application/json')
+        .set('Content-Length', String(oversizedBody.length))
+        .send(oversizedBody)
+        .expect(413);
+
+      const count = await getCounterValue('/api/streams');
+      expect(count).toBe(2);
+    });
+
+    it('tracks different paths independently', async () => {
+      const oversizedBody = 'z'.repeat(BODY_LIMIT_BYTES + 1);
+
+      await request(app)
+        .post('/api/streams')
+        .set('Content-Type', 'application/json')
+        .set('Content-Length', String(oversizedBody.length))
+        .send(oversizedBody)
+        .expect(413);
+
+      await request(app)
+        .post('/api/webhooks')
+        .set('Content-Type', 'application/json')
+        .set('Content-Length', String(oversizedBody.length))
+        .send(oversizedBody)
+        .expect(413);
+
+      const streamsCount = await getCounterValue('/api/streams');
+      const webhooksCount = await getCounterValue('/api/webhooks');
+
+      expect(streamsCount).toBe(1);
+      expect(webhooksCount).toBe(1);
+    });
+  });
+
+  describe('counter does NOT increment for accepted requests', () => {
+    it('does not increment when body is within the size limit', async () => {
+      const smallBody = JSON.stringify({ data: 'small payload' });
+
+      const res = await request(app)
+        .post('/api/streams')
+        .set('Content-Type', 'application/json')
+        .send(smallBody);
+
+      // 201 from the route handler means the request was accepted
+      expect(res.status).toBe(201);
+
+      const count = await getCounterValue('/api/streams');
+      expect(count).toBe(0);
+    });
+
+    it('does not increment when Content-Length exactly equals the limit', async () => {
+      // Content-Length == BODY_LIMIT_BYTES should pass (limit is strict >)
+      const exactBody = Buffer.alloc(BODY_LIMIT_BYTES).fill(32).toString();
+
+      await request(app)
+        .post('/api/streams')
+        .set('Content-Type', 'application/json')
+        .set('Content-Length', String(BODY_LIMIT_BYTES))
+        .send(exactBody);
+
+      // We don't assert status here because express.json may reject invalid JSON;
+      // what matters is the counter stays at zero.
+      const count = await getCounterValue('/api/streams');
+      expect(count).toBe(0);
+    });
+  });
+
+  describe('path label normalization', () => {
+    it('uses req.path as the label (not raw originalUrl with query string)', async () => {
+      const oversizedBody = 'q'.repeat(BODY_LIMIT_BYTES + 1);
+
+      await request(app)
+        .post('/api/streams')
+        .query({ foo: 'bar' })
+        .set('Content-Type', 'application/json')
+        .set('Content-Length', String(oversizedBody.length))
+        .send(oversizedBody)
+        .expect(413);
+
+      // Counter should be keyed on '/api/streams', NOT '/api/streams?foo=bar'
+      const countNormalized = await getCounterValue('/api/streams');
+      const countWithQuery = await getCounterValue('/api/streams?foo=bar');
+
+      expect(countNormalized).toBe(1);
+      expect(countWithQuery).toBe(0);
+    });
+  });
+});


### PR DESCRIPTION
Fixes #585

## Summary
- Add `fluxora_request_body_too_large_total` prom-client Counter in `src/metrics/requestProtectionMetrics.ts`, labeled by normalized route path (`path`)
- Increment counter in `bodySizeLimitMiddleware` for both the Content-Length fast path and the stream byte-counting slow path
- Use `req.route?.path ?? req.path` for the label — never `req.originalUrl` — to avoid high-cardinality or user-data leakage in metric labels
- Add `tests/middleware/requestProtection.metric.test.ts` covering: counter increments on rejection, counter NOT incremented for accepted requests, and path label normalization (query strings excluded)

## Changes
- `src/metrics/requestProtectionMetrics.ts` (new): exports `requestBodyTooLargeTotal` Counter and `deRegisterRequestProtectionMetrics` for test teardown
- `src/middleware/requestProtection.ts`: imports counter, adds `normalizedPath()` helper, increments counter on every 413 rejection
- `tests/middleware/requestProtection.metric.test.ts` (new): full test suite for metric behavior