### PR TITLE
Add startup validation that ADMIN_STATE_FILE path is writable before the server accepts requests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -864,6 +864,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
       "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -2393,6 +2394,7 @@
       "integrity": "sha512-PJ5vePq5/ognBbrIcoC5+SHO5dfpeLPzP9FpLkzWrguoYQEeeSjlJpVwOpo1JRSTEi7dRcwNy4h4dzV70PqHcg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.61.1",
         "@typescript-eslint/types": "8.61.1",
@@ -2784,6 +2786,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
       "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3457,6 +3460,7 @@
       "integrity": "sha512-1y+7C+vi12bUK1IpZeaV3gsH9fHLBmPvYmPx42pvT/E9yG0IC8g3PUZZgp0+JLJl7ZDK0flc2gc+Aw9dpCvIsQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "workspaces": [
         "packages/*"
       ],
@@ -4962,6 +4966,7 @@
       "resolved": "https://registry.npmjs.org/pg/-/pg-8.22.0.tgz",
       "integrity": "sha512-8wih1vVIBMxoUM2oB4soJsD9tDnDpLv4OXBJ+EJzFsvycD+lfyIreC2gGHq78f8jbLLt+bvlPTFdFZfJkOuzAA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "pg-connection-string": "^2.14.0",
         "pg-pool": "^3.14.0",
@@ -6077,6 +6082,7 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -6142,6 +6148,7 @@
       "integrity": "sha512-X8EX+XV4QR5xCsrgxaED954zTDfY8KqlDtskKEL0cHhyS/P8b4IFOvGDQpsC9Q1XnLq915wEfwwY/zzskCtmhg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "~0.28.0"
       },
@@ -6187,6 +6194,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -6244,6 +6252,7 @@
       "integrity": "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",
@@ -6844,6 +6853,7 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -6857,6 +6867,7 @@
       "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/chai": "^5.2.2",
         "@vitest/expect": "3.2.4",
@@ -7122,6 +7133,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
       "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ import { config } from './config/index.js';
 import { indexerRouter } from './routes/indexer';
 import { gracefulShutdown } from './shutdown.js';
 import { indexerService } from './indexer/service.js';
+import { checkAdminStatePersistence } from './state/adminState.js';
 
 const app = express();
 
@@ -29,6 +30,14 @@ app.use((err: any, req: express.Request, res: express.Response, next: express.Ne
 let server: any;
 
 if (process.env.NODE_ENV !== 'test') {
+  /**
+   * Startup initialization sequence:
+   * 1. Validate admin state file writability (graceful degradation on failure).
+   * 2. Start the HTTP server and begin accepting requests.
+   * 3. Resume any incomplete indexer replays from the database checkpoint.
+   */
+  void checkAdminStatePersistence();
+
   // Start server
   server = app.listen(config.server.port, () => {
     console.log(`Indexer service listening on port ${config.server.port}`);

--- a/src/state/adminState.ts
+++ b/src/state/adminState.ts
@@ -9,7 +9,7 @@
  */
 
 import * as fs from 'node:fs';
-import { dirname } from 'node:path';
+import { dirname, join } from 'node:path';
 import type { RedisClient } from '../redis/client.js';
 import { RedisDistributedLock, NoOpLock, Lock } from './adminStateLock.js';
 import { logger } from '../lib/logger.js';
@@ -289,4 +289,38 @@ export function _reloadPauseFlagsFromPersistenceForTest(): void {
     return;
   }
   state.pauseFlags = persisted;
+}
+
+/**
+ * Checks whether the configured `ADMIN_STATE_FILE` path is writable at startup.
+ *
+ * Performs a write-and-delete probe using a `.probe` sentinel file in the same
+ * directory as the admin state file. If the probe fails (e.g. read-only
+ * container filesystem), a structured warning is emitted but the server
+ * continues to start — in-memory pause flags remain fully functional without
+ * persistence.
+ *
+ * Security: the probe file path is derived solely from the server-controlled
+ * environment variable and is not logged in the warning to avoid leaking
+ * internal directory structure in security-sensitive deployments.
+ *
+ * @returns A promise that resolves to `true` if the path is writable, or
+ *   `false` if the write probe failed.
+ */
+export async function checkAdminStatePersistence(): Promise<boolean> {
+  const adminStatePath = resolveAdminStatePath();
+  const dir = dirname(adminStatePath);
+  const probePath = join(dir, '.fluxora-admin-state.probe');
+
+  try {
+    fs.mkdirSync(dir, { recursive: true, mode: 0o700 });
+    fs.writeFileSync(probePath, '', { encoding: 'utf8', mode: 0o600 });
+    fs.rmSync(probePath, { force: true });
+    return true;
+  } catch {
+    logger.warn('Admin state file path is not writable; pause flags will not persist across restarts', undefined, {
+      event: 'admin_state_file_not_writable',
+    });
+    return false;
+  }
 }

--- a/tests/state/adminState.startupCheck.test.ts
+++ b/tests/state/adminState.startupCheck.test.ts
@@ -1,0 +1,138 @@
+import * as fs from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { checkAdminStatePersistence, _resetForTest } from '../../src/state/adminState.js';
+
+vi.mock('../../src/lib/logger.js', () => ({
+  logger: {
+    warn: vi.fn(),
+    info: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
+// Mock node:fs so mkdirSync can be made to throw on demand
+vi.mock('node:fs', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:fs')>();
+  return {
+    ...actual,
+    default: { ...actual },
+  };
+});
+
+import { logger } from '../../src/lib/logger.js';
+
+describe('checkAdminStatePersistence', () => {
+  let originalAdminStateFile: string | undefined;
+  let tempDir: string;
+
+  beforeEach(() => {
+    originalAdminStateFile = process.env.ADMIN_STATE_FILE;
+    tempDir = join(
+      tmpdir(),
+      `fluxora-probe-test-${Date.now()}-${Math.random().toString(16).slice(2)}`,
+    );
+    vi.clearAllMocks();
+    _resetForTest();
+  });
+
+  afterEach(() => {
+    _resetForTest();
+    if (originalAdminStateFile !== undefined) {
+      process.env.ADMIN_STATE_FILE = originalAdminStateFile;
+    } else {
+      delete process.env.ADMIN_STATE_FILE;
+    }
+    // Cleanup temp directory if it exists
+    try {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    } catch {
+      // no-op
+    }
+  });
+
+  it('returns true and does not log a warning when the path is writable', async () => {
+    const adminStateFile = join(tempDir, 'admin-state.json');
+    process.env.ADMIN_STATE_FILE = adminStateFile;
+
+    const result = await checkAdminStatePersistence();
+
+    expect(result).toBe(true);
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
+
+  it('cleans up the probe file after a successful write check', async () => {
+    const adminStateFile = join(tempDir, 'admin-state.json');
+    process.env.ADMIN_STATE_FILE = adminStateFile;
+
+    await checkAdminStatePersistence();
+
+    const probePath = join(tempDir, '.fluxora-admin-state.probe');
+    expect(fs.existsSync(probePath)).toBe(false);
+  });
+
+  it('returns false and logs a warning with the correct event when path is not writable', async () => {
+    // Create a read-only directory to simulate a non-writable filesystem
+    const readOnlyDir = join(tempDir, 'readonly');
+    fs.mkdirSync(readOnlyDir, { recursive: true });
+    fs.chmodSync(readOnlyDir, 0o444);
+
+    const adminStateFile = join(readOnlyDir, 'subdir', 'admin-state.json');
+    process.env.ADMIN_STATE_FILE = adminStateFile;
+
+    const result = await checkAdminStatePersistence();
+
+    // Restore permissions for cleanup
+    fs.chmodSync(readOnlyDir, 0o755);
+
+    expect(result).toBe(false);
+    expect(logger.warn).toHaveBeenCalledOnce();
+    const [, , meta] = (logger.warn as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(meta).toMatchObject({ event: 'admin_state_file_not_writable' });
+  });
+
+  it('warning log does not expose the file path', async () => {
+    // Create a read-only directory
+    const readOnlyDir = join(tempDir, 'sensitive-internal-path');
+    fs.mkdirSync(readOnlyDir, { recursive: true });
+    fs.chmodSync(readOnlyDir, 0o444);
+
+    const adminStateFile = join(readOnlyDir, 'subdir', 'admin-state.json');
+    process.env.ADMIN_STATE_FILE = adminStateFile;
+
+    await checkAdminStatePersistence();
+
+    // Restore permissions for cleanup
+    fs.chmodSync(readOnlyDir, 0o755);
+
+    const calls = (logger.warn as ReturnType<typeof vi.fn>).mock.calls;
+    const allArgs = JSON.stringify(calls);
+    expect(allArgs).not.toContain('sensitive-internal-path');
+  });
+
+  it('server continues to operate (no throw) when path is not writable', async () => {
+    const readOnlyDir = join(tempDir, 'no-throw-test');
+    fs.mkdirSync(readOnlyDir, { recursive: true });
+    fs.chmodSync(readOnlyDir, 0o444);
+
+    process.env.ADMIN_STATE_FILE = join(readOnlyDir, 'subdir', 'admin-state.json');
+
+    await expect(checkAdminStatePersistence()).resolves.not.toThrow();
+
+    fs.chmodSync(readOnlyDir, 0o755);
+  });
+
+  it('respects a custom ADMIN_STATE_FILE environment variable', async () => {
+    const customDir = join(tempDir, 'custom');
+    const customFile = join(customDir, 'custom-admin-state.json');
+    process.env.ADMIN_STATE_FILE = customFile;
+
+    const result = await checkAdminStatePersistence();
+
+    expect(result).toBe(true);
+    // The custom directory should have been created
+    expect(fs.existsSync(customDir)).toBe(true);
+  });
+});


### PR DESCRIPTION
Fixes #584

## Summary
- Adds `checkAdminStatePersistence()` to `src/state/adminState.ts` that probes the configured `ADMIN_STATE_FILE` directory with a write-and-delete `.probe` sentinel file at startup
- On failure, emits `logger.warn` with `event: 'admin_state_file_not_writable'` (path is intentionally omitted from the log for security)
- Server continues to start even when persistence is unavailable — in-memory pause flags remain fully functional (graceful degradation, no throw)
- Calls `checkAdminStatePersistence()` from `src/index.ts` during startup initialization sequence
- Adds 6 comprehensive tests in `tests/state/adminState.startupCheck.test.ts` covering: writable path (no warning), non-writable path (warning + returns false), probe file cleanup, path not leaked in warning log, no-throw guarantee, and custom `ADMIN_STATE_FILE` env var

## Changes
Implements the feature as described in the issue, following existing code patterns in `src/state/adminState.ts`.

## Security Notes
- Probe file path is derived solely from the server-controlled `ADMIN_STATE_FILE` environment variable
- Warning log emits only the structured `event` field — no path is included to avoid leaking internal directory structure
- Probe file is always cleaned up after successful write check