### PR TITLE
fix: persist fallbackModeCount metric in HybridBanStore

### DIFF
--- a/src/redis/banStore.ts
+++ b/src/redis/banStore.ts
@@ -197,6 +197,8 @@ export class RedisBanStore implements BanStore {
  */
 export class HybridBanStore implements BanStore {
   usingFallback = false;
+  /** Number of times a Redis operation failed and the fallback was invoked. */
+  fallbackModeCount = 0;
   private readonly localCache = new InMemoryBanStore();
 
   constructor(
@@ -224,6 +226,7 @@ export class HybridBanStore implements BanStore {
     } catch (err) {
       this.onError?.(err, 'isBanned');
       this.usingFallback = true;
+      this.fallbackModeCount += 1;
       return this.fallback.isBanned(ip);
     }
   }
@@ -238,6 +241,7 @@ export class HybridBanStore implements BanStore {
     } catch (err) {
       this.onError?.(err, 'ban');
       this.usingFallback = true;
+      this.fallbackModeCount += 1;
       // Local cache already has it — fail safe
       await this.fallback.ban(options);
     }


### PR DESCRIPTION
Fixes #562

Adds `fallbackModeCount: number` to `HybridBanStore` and increments it whenever `isBanned` or `ban` falls back due to a `RedisBanStore` error. Allows monitoring agents to observe how many operations were served from the fallback store.