### PR TITLE
feat: structured audit-log entry when deprecated route is past sunset date

### DIFF
--- a/src/middleware/deprecation.ts
+++ b/src/middleware/deprecation.ts
@@ -101,11 +101,15 @@ function applyDeprecationHeaders(req: Request, res: Response, entries: Normalize
 
     if (entry.sunset.getTime() <= Date.now()) {
       logger.warn('deprecated route is past its sunset date', {
+        event: 'route.sunset.past',
         method: req.method,
         path: req.path,
         route: entry.route,
         sunsetDate: entry.sunsetDate,
+        sunsetTimestamp: entry.sunset.toISOString(),
+        overdueMs: Date.now() - entry.sunset.getTime(),
         correlationId: req.correlationId,
+        userAgent: req.headers['user-agent'] ?? 'unknown',
       });
     }
   }


### PR DESCRIPTION
Fixes #564

Extends the `applyDeprecationHeaders` warn log with structured audit fields:
- `event: 'route.sunset.past'` for log-query filtering
- `sunsetTimestamp` (ISO 8601) for exact sunset time
- `overdueMs` — how far past the deadline the route is being called
- `userAgent` — helps identify outdated clients still calling sunset routes