### PR TITLE
feat: Prometheus histogram for adminState.triggerReindex job duration

### DIFF
--- a/src/metrics/businessMetrics.ts
+++ b/src/metrics/businessMetrics.ts
@@ -227,6 +227,16 @@ export const wsAuthFailureTotal =
     registers: [registry],
   });
 
+export const adminReindexJobDurationSeconds =
+  (registry.getSingleMetric('fluxora_admin_reindex_job_duration_seconds') as Histogram<'outcome'>) ||
+  new Histogram({
+    name: 'fluxora_admin_reindex_job_duration_seconds',
+    help: 'Duration of adminState.triggerReindex job in seconds, labeled by outcome',
+    labelNames: ['outcome'] as const,
+    buckets: [0.01, 0.05, 0.1, 0.5, 1, 5, 10, 30, 60],
+    registers: [registry],
+  });
+
 /** Clean helper to de-register metrics between test runs. */
 export function deRegisterBusinessMetrics(): void {
   registry.removeSingleMetric('fluxora_auth_jwt_verify_duration_seconds');
@@ -244,4 +254,5 @@ export function deRegisterBusinessMetrics(): void {
   registry.removeSingleMetric('fluxora_sse_live_subscribers');
   registry.removeSingleMetric('fluxora_sse_event_listeners');
   registry.removeSingleMetric('fluxora_ws_auth_failure_total');
+  registry.removeSingleMetric('fluxora_admin_reindex_job_duration_seconds');
 }

--- a/src/state/adminState.ts
+++ b/src/state/adminState.ts
@@ -13,6 +13,7 @@ import { dirname } from 'node:path';
 import type { RedisClient } from '../redis/client.js';
 import { RedisDistributedLock, NoOpLock, Lock } from './adminStateLock.js';
 import { logger } from '../lib/logger.js';
+import { adminReindexJobDurationSeconds } from '../metrics/businessMetrics.js';
 
 export interface PauseFlags {
   /** Block new stream creation via the public API. */
@@ -238,6 +239,7 @@ export async function triggerReindex(): Promise<ReindexState> {
 }
 
 async function runReindexJob(): Promise<void> {
+  const endTimer = adminReindexJobDurationSeconds.startTimer();
   try {
     // Simulate incremental reindex work (placeholder for Horizon replay).
     const steps = 5;
@@ -247,10 +249,12 @@ async function runReindexJob(): Promise<void> {
     }
     state.reindex.status = 'completed';
     state.reindex.completedAt = new Date().toISOString();
+    endTimer({ outcome: 'success' });
   } catch (err) {
     state.reindex.status = 'failed';
     state.reindex.completedAt = new Date().toISOString();
     state.reindex.error = err instanceof Error ? err.message : String(err);
+    endTimer({ outcome: 'failure' });
   }
 }
 


### PR DESCRIPTION
Fixes #569

- Adds `adminReindexJobDurationSeconds` histogram (`fluxora_admin_reindex_job_duration_seconds`) to `src/metrics/businessMetrics.ts` with `outcome` label (success/failure)
- Instruments `runReindexJob()` in `src/state/adminState.ts` using `startTimer()` / `endTimer()` around the full job body
- Registers the metric in `deRegisterBusinessMetrics()` for clean test teardown