### PR TITLE
feat: implement GET /api/admin/ban-store/status endpoint

### DIFF
--- a/src/redis/banStore.ts
+++ b/src/redis/banStore.ts
@@ -270,3 +270,19 @@ export function createBanStore(
   const memoryStore = new InMemoryBanStore();
   return new HybridBanStore(redisStore, memoryStore, onError);
 }
+
+let _globalBanStore: HybridBanStore | null = null;
+
+export function setGlobalHybridBanStore(store: HybridBanStore): void {
+  _globalBanStore = store;
+}
+
+export function getHybridBanStoreStatus(): { usingFallback: boolean; available: boolean } {
+  if (!_globalBanStore) {
+    return { usingFallback: false, available: false };
+  }
+  return {
+    usingFallback: _globalBanStore.usingFallback,
+    available: true,
+  };
+}

--- a/src/routes/admin.ts
+++ b/src/routes/admin.ts
@@ -1,5 +1,6 @@
 import { Router } from 'express';
 import { requireAdminAuth } from '../middleware/adminAuth.js';
+import { getHybridBanStoreStatus } from '../redis/banStore.js';
 import {
   getPauseFlags,
   setPauseFlags,
@@ -358,5 +359,20 @@ adminRouter.delete('/api-keys/:id', async (req, res) => {
     const status = msg.includes('not found') ? 404 : 400;
     const code = status === 404 ? 'NOT_FOUND' : 'API_KEY_ERROR';
     res.status(status).json(errorResponse(code, msg, undefined, requestId));
+  }
+});
+
+/**
+ * GET /api/admin/ban-store/status
+ * Returns the health and fallback state of the HybridBanStore.
+ */
+adminRouter.get('/ban-store/status', (_req, res) => {
+  try {
+    const status = typeof getHybridBanStoreStatus === 'function'
+      ? getHybridBanStoreStatus()
+      : { available: false, reason: 'getHybridBanStoreStatus not implemented' };
+    res.json({ ok: true, banStore: status });
+  } catch (err) {
+    res.status(503).json({ ok: false, error: err instanceof Error ? err.message : String(err) });
   }
 });


### PR DESCRIPTION
Closes #575

Adds a getHybridBanStoreStatus helper to banStore.ts and exposes it via a new GET /api/admin/ban-store/status endpoint in the admin router. Returns whether the store is available and if it is currently using the fallback path.