### PR TITLE
feat: add OpenAPI schema improvements for POST /internal/webhooks/receive

### DIFF
--- a/src/openapi/spec.ts
+++ b/src/openapi/spec.ts
@@ -1730,17 +1730,32 @@ registry.registerPath({
         'application/json': {
           schema: z.object({
             ok: z.literal(true),
-            deliveryId: z.string(),
-            eventType: z.string().nullable(),
-            event: z.unknown(),
+            deliveryId: z.string().openapi({ example: 'del_01HXYZ', description: 'Echoed delivery ID' }),
+            eventType: z.string().nullable().openapi({ example: 'stream.created' }),
+            event: z.record(z.string(), z.unknown()).nullable().openapi({ description: 'Parsed event payload' }),
           }),
         },
       },
     },
     '400': errorResponses['400'],
-    '401': errorResponses['401'],
+    '401': {
+      description: 'Invalid signature or missing required headers',
+      content: { 'application/json': { schema: ErrorEnvelope } },
+    },
+    '409': {
+      description: 'Duplicate delivery — already processed this delivery ID',
+      content: {
+        'application/json': {
+          schema: z.object({
+            error: z.literal('duplicate_delivery'),
+            message: z.string(),
+            deliveryId: z.string(),
+          }),
+        },
+      },
+    },
     '413': {
-      description: 'Payload too large',
+      description: 'Payload too large (> 1 MB)',
       content: { 'application/json': { schema: ErrorEnvelope } },
     },
   },


### PR DESCRIPTION
Closes #572

Improves the existing OpenAPI spec for POST /internal/webhooks/receive: adds openapi() metadata to response fields, adds 409 duplicate_delivery response, and clarifies the 401 response description.