### PR TITLE
fix(ssrf): normalize hostnames to punycode before validation

### DIFF
--- a/src/webhooks/dispatcher.ts
+++ b/src/webhooks/dispatcher.ts
@@ -70,6 +70,7 @@ export class WebhookDispatcher {
     const enhancedPolicy = this.policy as EnhancedRetryPolicy;
 
     // Validate webhook target for SSRF protection before any network call
+    let validatedUrl = url;
     try {
       let allowlist: string[] | undefined;
       try {
@@ -78,7 +79,7 @@ export class WebhookDispatcher {
       } catch {
         // Config not initialized, proceed without allowlist
       }
-      await validateWebhookTarget(url, {
+      validatedUrl = await validateWebhookTarget(url, {
         allowlist,
       });
     } catch (error) {
@@ -97,7 +98,7 @@ export class WebhookDispatcher {
       throw error;
     }
 
-    const gate = await circuitBreakerStore.checkAndClaimAttempt(url, enhancedPolicy);
+    const gate = await circuitBreakerStore.checkAndClaimAttempt(validatedUrl, enhancedPolicy);
     if (!gate.allowed) {
       const nextRetryAt = resolveCircuitBreakerDeferral(gate, enhancedPolicy).getTime();
       logger.warn('Webhook delivery deferred by circuit breaker', undefined, {
@@ -123,7 +124,7 @@ export class WebhookDispatcher {
     const signature = computeWebhookSignature(secret, timestamp, payload);
 
     try {
-      const response = await this.sendRequest(url, payload, deliveryId, eventType, timestamp, signature, effectiveCorrelationId);
+      const response = await this.sendRequest(validatedUrl, payload, deliveryId, eventType, timestamp, signature, effectiveCorrelationId);
       
       const attempt: WebhookDeliveryAttempt = {
         attemptNumber,
@@ -132,7 +133,7 @@ export class WebhookDispatcher {
       };
 
       if (response.ok) {
-        await circuitBreakerStore.recordSuccess(url, enhancedPolicy as CircuitBreakerPolicy);
+        await circuitBreakerStore.recordSuccess(validatedUrl, enhancedPolicy as CircuitBreakerPolicy);
         logger.info('Webhook delivered successfully', undefined, {
           deliveryId,
           eventType,
@@ -152,8 +153,8 @@ export class WebhookDispatcher {
       attempt.error = errorMessage;
 
       const consecutiveFailures = countsTowardCircuitBreaker(attempt, this.policy)
-        ? (await circuitBreakerStore.recordFailure(url, enhancedPolicy as CircuitBreakerPolicy)).consecutiveFailures
-        : (await circuitBreakerStore.getState(url))?.consecutiveFailures ?? 0;
+        ? (await circuitBreakerStore.recordFailure(validatedUrl, enhancedPolicy as CircuitBreakerPolicy)).consecutiveFailures
+        : (await circuitBreakerStore.getState(validatedUrl))?.consecutiveFailures ?? 0;
       const retryable = shouldRetry(attempt, attemptNumber, this.policy, consecutiveFailures);
       
       if (retryable) {
@@ -197,8 +198,8 @@ export class WebhookDispatcher {
       };
 
       const consecutiveFailures = countsTowardCircuitBreaker(attempt, this.policy)
-        ? (await circuitBreakerStore.recordFailure(url, enhancedPolicy as CircuitBreakerPolicy)).consecutiveFailures
-        : (await circuitBreakerStore.getState(url))?.consecutiveFailures ?? 0;
+        ? (await circuitBreakerStore.recordFailure(validatedUrl, enhancedPolicy as CircuitBreakerPolicy)).consecutiveFailures
+        : (await circuitBreakerStore.getState(validatedUrl))?.consecutiveFailures ?? 0;
       const retryable = shouldRetry(attempt, attemptNumber, this.policy, consecutiveFailures);
       
       if (retryable) {
@@ -330,6 +331,7 @@ export interface SimpleWebhookDispatch {
 
 export async function dispatchWebhook(opts: SimpleWebhookDispatch): Promise<void> {
   // Validate webhook target for SSRF protection before any network call
+  let validatedUrl = opts.url;
   try {
     let allowlist: string[] | undefined;
     try {
@@ -338,7 +340,7 @@ export async function dispatchWebhook(opts: SimpleWebhookDispatch): Promise<void
     } catch {
       // Config not initialized, proceed without allowlist
     }
-    await validateWebhookTarget(opts.url, {
+    validatedUrl = await validateWebhookTarget(opts.url, {
       allowlist,
     });
   } catch (error) {
@@ -376,7 +378,7 @@ export async function dispatchWebhook(opts: SimpleWebhookDispatch): Promise<void
   const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
 
   try {
-    await fetch(opts.url, {
+    await fetch(validatedUrl, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',

--- a/src/webhooks/ssrfGuard.ts
+++ b/src/webhooks/ssrfGuard.ts
@@ -20,6 +20,7 @@
 
 import { logger } from '../lib/logger.js';
 import { getConfig } from '../config/env.js';
+import { domainToASCII } from 'node:url';
 
 /**
  * Error thrown when a webhook target URL fails SSRF validation.
@@ -381,7 +382,7 @@ export async function validateWebhookTarget(
     allowlist?: string[];
     dnsTimeoutMs?: number;
   }
-): Promise<void> {
+): Promise<string> {
   const requireHttps = options?.requireHttps ?? true;
   const allowlist = options?.allowlist;
 
@@ -403,6 +404,20 @@ export async function validateWebhookTarget(
       throw new WebhookTargetValidationError(
         `Invalid webhook URL format: ${url}`,
         'INVALID_URL'
+      );
+    }
+
+    // Normalize hostname to ASCII (IDNA/punycode)
+    try {
+      const asciiHostname = domainToASCII(parsedUrl.hostname);
+      if (asciiHostname === '') {
+        throw new Error('Failed to normalize hostname');
+      }
+      parsedUrl.hostname = asciiHostname;
+    } catch (error) {
+      throw new WebhookTargetValidationError(
+        `Invalid hostname (IDNA normalization failed): ${parsedUrl.hostname}`,
+        'INVALID_HOSTNAME'
       );
     }
 
@@ -431,6 +446,7 @@ export async function validateWebhookTarget(
     }
 
     // All checks passed
+    return parsedUrl.toString();
   } catch (error) {
     if (error instanceof WebhookTargetValidationError) {
       // Log the validation failure (without the full URL for security)

--- a/tests/webhooks/ssrfGuard.test.ts
+++ b/tests/webhooks/ssrfGuard.test.ts
@@ -24,7 +24,7 @@ describe('SSRF Guard DNS Timeout and Resolution', () => {
 
     await expect(
       validateWebhookTarget('https://safe-domain.com/webhook', { dnsTimeoutMs: 500 })
-    ).resolves.not.toThrow();
+    ).resolves.toBe('https://safe-domain.com/webhook');
   });
 
   it('should reject private IP resolved from hostname', async () => {
@@ -103,5 +103,35 @@ describe('SSRF Guard DNS Timeout and Resolution', () => {
     await expect(promise).rejects.toThrow(WebhookTargetValidationError);
     expect(capturedSignal).toBeDefined();
     expect(capturedSignal?.aborted).toBe(true);
+  });
+});
+
+describe('SSRF Guard IDNA and Homograph Normalization', () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should normalize valid Unicode hostnames to punycode', async () => {
+    vi.mocked(dns.promises.lookup).mockResolvedValue({ address: '8.8.8.8', family: 4 } as any);
+
+    const result = await validateWebhookTarget('https://faß.de/webhook', { dnsTimeoutMs: 500 });
+    expect(result).toBe('https://xn--fa-hia.de/webhook');
+    
+    expect(dns.promises.lookup).toHaveBeenCalledWith('xn--fa-hia.de', expect.any(Object));
+  });
+
+  it('should normalize homograph hostnames to punycode', async () => {
+    vi.mocked(dns.promises.lookup).mockResolvedValue({ address: '8.8.8.8', family: 4 } as any);
+
+    // Some environments normalize this to example.com, ensuring it doesn't bypass checks as raw unicode
+    const result = await validateWebhookTarget('https://ⓔⓍⓐⓂⓅⓁⓔ.com/webhook', { dnsTimeoutMs: 500 });
+    expect(result).toBe('https://example.com/webhook');
+  });
+
+  it('should reject hostnames that fail IDNA normalization or URL parsing', async () => {
+    // Unpaired surrogates often fail URL parsing or IDNA normalization
+    const promise = validateWebhookTarget('https://a\uD800b.com/webhook', { dnsTimeoutMs: 500 });
+    
+    await expect(promise).rejects.toThrow(WebhookTargetValidationError);
   });
 });


### PR DESCRIPTION
Fixes SSRF hostname validation by normalizing internationalized domain names (IDNs) to punycode before validation.

Changes
Added hostname normalization prior to SSRF validation
Updated webhook dispatcher handling
Added and updated test coverage for IDN hostname scenarios
Improved validation consistency for internationalized domains
Files Updated
src/webhooks/ssrfGuard.ts
src/webhooks/dispatcher.ts
tests/webhooks/ssrfGuard.test.ts
closes #513 