### PR TITLE
Validate Stellar account StrKeys before RPC

### DIFF
--- a/src/validation/stellarAddressValidator.ts
+++ b/src/validation/stellarAddressValidator.ts
@@ -34,9 +34,75 @@ import { CircuitOpenError } from '../services/stellar-rpc.js';
 
 export const STELLAR_ACCOUNT_CACHE_PREFIX = 'fluxora:stellar:account:';
 
+const STELLAR_ED25519_PUBLIC_KEY_VERSION_BYTE = 6 << 3;
+const STELLAR_STRKEY_LENGTH = 56;
+const STELLAR_STRKEY_DECODED_LENGTH = 35;
+const STELLAR_STRKEY_PAYLOAD_LENGTH = 33;
+const STELLAR_STRKEY_ALPHABET = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ234567';
+const STELLAR_ACCOUNT_PUBLIC_KEY_REGEX = /^G[A-Z2-7]{55}$/;
+
+// SEP-23 StrKey validation for Stellar Ed25519 public keys.
+function decodeStellarBase32(value: string): number[] | null {
+  const bytes: number[] = [];
+  let bits = 0;
+  let current = 0;
+
+  for (const char of value) {
+    const digit = STELLAR_STRKEY_ALPHABET.indexOf(char);
+    if (digit === -1) return null;
+
+    current = (current << 5) | digit;
+    bits += 5;
+
+    if (bits >= 8) {
+      bytes.push((current >> (bits - 8)) & 0xff);
+      bits -= 8;
+    }
+  }
+
+  return bytes;
+}
+
+function crc16XModem(bytes: readonly number[]): number {
+  let crc = 0;
+
+  for (const byte of bytes) {
+    crc ^= byte << 8;
+    for (let bit = 0; bit < 8; bit += 1) {
+      crc = (crc & 0x8000) !== 0 ? (crc << 1) ^ 0x1021 : crc << 1;
+      crc &= 0xffff;
+    }
+  }
+
+  return crc;
+}
+
+function isValidStellarAccountAddress(value: string): boolean {
+  if (typeof value !== 'string') return false;
+  if (value.length !== STELLAR_STRKEY_LENGTH || !STELLAR_ACCOUNT_PUBLIC_KEY_REGEX.test(value)) {
+    return false;
+  }
+
+  const decoded = decodeStellarBase32(value);
+  if (decoded === null || decoded.length !== STELLAR_STRKEY_DECODED_LENGTH) {
+    return false;
+  }
+
+  if (decoded[0] !== STELLAR_ED25519_PUBLIC_KEY_VERSION_BYTE) {
+    return false;
+  }
+
+  const payload = decoded.slice(0, STELLAR_STRKEY_PAYLOAD_LENGTH);
+  const expectedChecksum = crc16XModem(payload);
+  const actualChecksum =
+    decoded[STELLAR_STRKEY_PAYLOAD_LENGTH]! | (decoded[STELLAR_STRKEY_PAYLOAD_LENGTH + 1]! << 8);
+
+  return expectedChecksum === actualChecksum;
+}
+
 export interface AddressValidationResult {
   valid: boolean;
-  /** Populated when valid is false and the address was reachable but absent. */
+  /** Populated when valid is false and an address is malformed or absent. */
   missingAddresses?: string[];
 }
 
@@ -44,17 +110,25 @@ export class StellarAddressValidator {
   constructor(
     private readonly rpc: StellarRpcService,
     private readonly redis: RedisClient | null,
-    private readonly cacheTtlSeconds: number,
+    private readonly cacheTtlSeconds: number
   ) {}
 
   /**
    * Validate that both addresses exist on-chain.
    *
-   * Returns { valid: false, missingAddresses } when one or both are absent.
+   * Returns { valid: false, missingAddresses } when one or both are malformed
+   * or absent.
    * Returns { valid: true } when both exist (or when the RPC is unavailable
    * and we fail-open).
    */
   async validate(sender: string, recipient: string): Promise<AddressValidationResult> {
+    const malformed = [sender, recipient].filter(
+      (address) => !isValidStellarAccountAddress(address)
+    );
+    if (malformed.length > 0) {
+      return { valid: false, missingAddresses: malformed };
+    }
+
     const [senderExists, recipientExists] = await Promise.all([
       this.checkAddress(sender),
       this.checkAddress(recipient),
@@ -89,9 +163,12 @@ export class StellarAddressValidator {
       return exists;
     } catch (err) {
       if (err instanceof CircuitOpenError) {
-        console.warn('[StellarAddressValidator] Circuit breaker OPEN — failing open for address check', {
-          addressLength: address.length,
-        });
+        console.warn(
+          '[StellarAddressValidator] Circuit breaker OPEN — failing open for address check',
+          {
+            addressLength: address.length,
+          }
+        );
         return null; // fail-open
       }
       // Network / provider error — fail-open with a warning
@@ -116,11 +193,9 @@ export class StellarAddressValidator {
   private async setCached(address: string): Promise<void> {
     if (!this.redis) return;
     try {
-      await this.redis.set(
-        `${STELLAR_ACCOUNT_CACHE_PREFIX}${address}`,
-        '1',
-        { ex: this.cacheTtlSeconds },
-      );
+      await this.redis.set(`${STELLAR_ACCOUNT_CACHE_PREFIX}${address}`, '1', {
+        ex: this.cacheTtlSeconds,
+      });
     } catch {
       // Cache write failure is non-fatal
     }

--- a/tests/stellarAddressValidator.test.ts
+++ b/tests/stellarAddressValidator.test.ts
@@ -2,8 +2,8 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { StellarAddressValidator } from '../src/validation/stellarAddressValidator.js';
 import type { StellarRpcService } from '../src/services/stellar-rpc.js';
 
-const VALID_ADDRESS_1 = 'GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN';
-const VALID_ADDRESS_2 = 'GBVVJJHAN5M34MSDMTSMLQZQOJON4CSYFWNIRLDXEAEDTIFWALKFYBVK';
+const VALID_ADDRESS_1 = 'GAAREIZUIVLGO6EJTKV3ZTO654ABCIRTIRKWM54ITGVLXTG5537RAI5F';
+const VALID_ADDRESS_2 = 'GBNWY7MOT6YMDUXD6QCRMJZYJFNGW7ENT2X4BUPC6MCBKJRXJBMWUCQH';
 const INVALID_ADDRESS = 'GBADADDR000000000000000000000000000000000000000000000000';
 
 function makeMockRpc(allowlist: Set<string>): StellarRpcService {
@@ -43,7 +43,10 @@ describe('StellarAddressValidator allowlist validation', () => {
 
   it('returns invalid with both missing addresses listed when neither exists', async () => {
     const validator = new StellarAddressValidator(rpc, mockRedis, 300);
-    const result = await validator.validate(INVALID_ADDRESS, 'GCOTHER00000000000000000000000000000000000000000000000000');
+    const result = await validator.validate(
+      INVALID_ADDRESS,
+      'GCOTHER00000000000000000000000000000000000000000000000000'
+    );
     expect(result.valid).toBe(false);
     expect(result.missingAddresses).toHaveLength(2);
   });

--- a/tests/validation/stellarAddressChainValidation.test.ts
+++ b/tests/validation/stellarAddressChainValidation.test.ts
@@ -26,8 +26,10 @@ import { FakeRedisClient } from '../../src/redis/__test__/fakeRedisClient.js';
 
 // ── Helpers ──────────────────────────────────────────────────────────────────
 
-const SENDER    = 'GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN';
-const RECIPIENT = 'GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGZCP2J7F1NRQKQOHP3OGN';
+const SENDER = 'GAAREIZUIVLGO6EJTKV3ZTO654ABCIRTIRKWM54ITGVLXTG5537RAI5F';
+const RECIPIENT = 'GBNWY7MOT6YMDUXD6QCRMJZYJFNGW7ENT2X4BUPC6MCBKJRXJBMWUCQH';
+const CONTRACT_ADDRESS = 'CASTMR2YNF5IXHFNX3H6B4ICCMSDKRSXNB4YVG5MXXHN74ABCIRTISIC';
+const WRONG_NETWORK_ACCOUNT = 'GCV3ZTO654ABCIRTIRKWM54ITGVLXTG5537RAIJSINKGK5UHTCU3V7YT';
 const TTL = 300;
 
 function makeRpc(responses: Record<string, boolean | Error>) {
@@ -39,6 +41,42 @@ function makeRpc(responses: Record<string, boolean | Error>) {
     }),
   } as unknown as import('../../src/services/stellar-rpc.js').StellarRpcService;
 }
+
+function mutateChecksum(address: string): string {
+  const last = address[address.length - 1];
+  return `${address.slice(0, -1)}${last === 'A' ? 'B' : 'A'}`;
+}
+
+const MALFORMED_ACCOUNT_CASES = [
+  {
+    name: 'too short',
+    address: SENDER.slice(0, -1),
+  },
+  {
+    name: 'too long',
+    address: `${SENDER}A`,
+  },
+  {
+    name: 'invalid checksum',
+    address: mutateChecksum(SENDER),
+  },
+  {
+    name: 'wrong prefix',
+    address: `S${SENDER.slice(1)}`,
+  },
+  {
+    name: 'contract StrKey where account is expected',
+    address: CONTRACT_ADDRESS,
+  },
+  {
+    name: 'fullwidth G homoglyph',
+    address: `Ｇ${SENDER.slice(1)}`,
+  },
+  {
+    name: 'Greek Alpha homoglyph inside payload',
+    address: `${SENDER.slice(0, 2)}Α${SENDER.slice(3)}`,
+  },
+] as const;
 
 // ── Core validation logic ─────────────────────────────────────────────────────
 
@@ -53,6 +91,49 @@ describe('StellarAddressValidator', () => {
     const rpc = makeRpc({ [SENDER]: true, [RECIPIENT]: true });
     const v = new StellarAddressValidator(rpc, redis, TTL);
     expect(await v.validate(SENDER, RECIPIENT)).toEqual({ valid: true });
+  });
+
+  it.each(MALFORMED_ACCOUNT_CASES)(
+    'rejects malformed sender address before RPC: $name',
+    async ({ address }) => {
+      const rpc = {
+        accountExists: vi.fn(async () => true),
+      } as unknown as import('../../src/services/stellar-rpc.js').StellarRpcService;
+      const v = new StellarAddressValidator(rpc, redis, TTL);
+
+      const result = await v.validate(address, RECIPIENT);
+
+      expect(result.valid).toBe(false);
+      expect(result.missingAddresses).toContain(address);
+      expect(rpc.accountExists).not.toHaveBeenCalledWith(address);
+    }
+  );
+
+  it.each(MALFORMED_ACCOUNT_CASES)(
+    'rejects malformed recipient address before RPC: $name',
+    async ({ address }) => {
+      const rpc = {
+        accountExists: vi.fn(async () => true),
+      } as unknown as import('../../src/services/stellar-rpc.js').StellarRpcService;
+      const v = new StellarAddressValidator(rpc, redis, TTL);
+
+      const result = await v.validate(SENDER, address);
+
+      expect(result.valid).toBe(false);
+      expect(result.missingAddresses).toContain(address);
+      expect(rpc.accountExists).not.toHaveBeenCalledWith(address);
+    }
+  );
+
+  it('rejects a valid account StrKey that does not exist on the configured chain', async () => {
+    const rpc = makeRpc({ [SENDER]: true, [WRONG_NETWORK_ACCOUNT]: false });
+    const v = new StellarAddressValidator(rpc, redis, TTL);
+
+    const result = await v.validate(SENDER, WRONG_NETWORK_ACCOUNT);
+
+    expect(result.valid).toBe(false);
+    expect(result.missingAddresses).toContain(WRONG_NETWORK_ACCOUNT);
+    expect(rpc.accountExists).toHaveBeenCalledWith(WRONG_NETWORK_ACCOUNT);
   });
 
   it('returns valid:false with sender in missingAddresses when sender absent', async () => {
@@ -114,11 +195,7 @@ describe('StellarAddressValidator', () => {
     const rpc = makeRpc({ [SENDER]: true, [RECIPIENT]: true });
     const v = new StellarAddressValidator(rpc, redis, 600);
     await v.validate(SENDER, RECIPIENT);
-    expect(setSpy).toHaveBeenCalledWith(
-      expect.stringContaining(SENDER),
-      '1',
-      { ex: 600 },
-    );
+    expect(setSpy).toHaveBeenCalledWith(expect.stringContaining(SENDER), '1', { ex: 600 });
   });
 
   it('falls through to RPC when Redis get throws', async () => {
@@ -154,7 +231,7 @@ describe('StellarAddressValidator', () => {
     expect(result.valid).toBe(true);
     expect(warnSpy).toHaveBeenCalledWith(
       expect.stringContaining('Circuit breaker OPEN'),
-      expect.any(Object),
+      expect.any(Object)
     );
     warnSpy.mockRestore();
   });
@@ -166,10 +243,7 @@ describe('StellarAddressValidator', () => {
     const v = new StellarAddressValidator(rpc, redis, TTL);
     const result = await v.validate(SENDER, RECIPIENT);
     expect(result.valid).toBe(true);
-    expect(warnSpy).toHaveBeenCalledWith(
-      expect.stringContaining('RPC error'),
-      expect.any(Object),
-    );
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('RPC error'), expect.any(Object));
     warnSpy.mockRestore();
   });
 


### PR DESCRIPTION
## Summary
- add SEP-23 account StrKey validation in `StellarAddressValidator` before any cache/RPC lookup
- reject malformed sender/recipient inputs locally, including wrong length, bad checksum, wrong prefix, Unicode confusables, and C-addresses where a G-address is expected
- refresh validator fixtures to use deterministic valid G-address samples and keep valid-but-absent account coverage for the configured chain case

Closes #700

## Verification
- `pnpm exec vitest run tests/validation/stellarAddressChainValidation.test.ts tests/stellarAddressValidator.test.ts tests/ws/hub.subscriptionFiltering.test.ts`
- `pnpm exec vitest run tests/validation/stellarAddressChainValidation.test.ts tests/stellarAddressValidator.test.ts --coverage --coverage.include=src/validation/stellarAddressValidator.ts` (98.02% line/statement coverage for `stellarAddressValidator.ts`)
- `pnpm exec prettier --check src/validation/stellarAddressValidator.ts tests/validation/stellarAddressChainValidation.test.ts tests/stellarAddressValidator.test.ts`
- `pnpm exec eslint src/validation/stellarAddressValidator.ts tests/validation/stellarAddressChainValidation.test.ts tests/stellarAddressValidator.test.ts --ext .ts`

Repo-wide `pnpm run lint`, `pnpm run typecheck`, `pnpm run build`, and `pnpm run test` still surface pre-existing unrelated project-wide failures; the changed files pass the focused checks above.