### PR TITLE
fix: add duplicate-event suppression before fan-out

### DIFF
--- a/docs/STREAMING_PAYMENT_DOMAIN.md
+++ b/docs/STREAMING_PAYMENT_DOMAIN.md
@@ -90,7 +90,10 @@ interface StreamCancelledEvent {
 
 ## Idempotency
 
-Every event is keyed by `(transaction_hash, event_index)`. The `streams` table has a `UNIQUE` constraint on this pair, so re-processing the same event is a no-op. This makes the ingestion pipeline safe to replay.
+Every event is keyed by `(transaction_hash, event_index)`. 
+
+1. **Fan-out Dedup:** A short-lived in-memory cache drops duplicate events before they trigger downstream side-effects (e.g., SSE, webhooks). This guarantees that even if the indexer pushes the same event multiple times (e.g., during rapid replay or redundant delivery), downstream consumers do not see duplicate events.
+2. **Database Dedup:** The `streams` table has a `UNIQUE` constraint on this pair `(transaction_hash, event_index)`. Upserting the same `StreamCreated` event twice is safe and acts as a no-op at the storage layer.
 
 ## Querying
 

--- a/src/services/streamEventService.ts
+++ b/src/services/streamEventService.ts
@@ -89,6 +89,38 @@ export interface EventIngestionResult {
  * - Duplicate events are safely ignored
  * - Out-of-order events are handled via upsert logic
  */
+
+const DEDUP_CACHE_SIZE = 10000;
+const processedEvents = new Set<string>();
+const processedEventsQueue: string[] = [];
+
+/**
+ * Checks if an event has been recently processed to prevent duplicate fan-out.
+ * Uses a short-lived in-memory LRU-like cache.
+ */
+function isDuplicateEvent(eventId: string): boolean {
+  if (processedEvents.has(eventId)) {
+    return true;
+  }
+  processedEvents.add(eventId);
+  processedEventsQueue.push(eventId);
+  if (processedEventsQueue.length > DEDUP_CACHE_SIZE) {
+    const oldest = processedEventsQueue.shift();
+    if (oldest) {
+      processedEvents.delete(oldest);
+    }
+  }
+  return false;
+}
+
+/**
+ * Exported for testing purposes only.
+ */
+export const _resetDedupCache = (): void => {
+  processedEvents.clear();
+  processedEventsQueue.length = 0;
+};
+
 export const streamEventService = {
   /**
    * Process a stream created event
@@ -114,6 +146,15 @@ export const streamEventService = {
         event.transactionHash,
         event.eventIndex,
       );
+
+      if (isDuplicateEvent(eventId)) {
+        debug("Event already processed (in-memory dedup)", {
+          eventId,
+          streamId,
+          correlationId,
+        });
+        return { eventId, streamId, action: "ignored", success: true };
+      }
 
       enrichActiveSpanWithStream(streamId, event.sender, event.recipient);
 
@@ -207,6 +248,15 @@ export const streamEventService = {
       streamId: event.streamId,
       correlationId,
     });
+
+    if (isDuplicateEvent(eventId)) {
+      debug("Event already processed (in-memory dedup)", {
+        eventId,
+        streamId: event.streamId,
+        correlationId,
+      });
+      return { eventId, streamId: event.streamId, action: "ignored", success: true };
+    }
 
     try {
       enrichActiveSpanWithStream(event.streamId);
@@ -323,6 +373,15 @@ export const streamEventService = {
       streamId: event.streamId,
       correlationId,
     });
+
+    if (isDuplicateEvent(eventId)) {
+      debug("Event already processed (in-memory dedup)", {
+        eventId,
+        streamId: event.streamId,
+        correlationId,
+      });
+      return { eventId, streamId: event.streamId, action: "ignored", success: true };
+    }
 
     try {
       // Enrich span with stream ID first (streamId is always available)

--- a/tests/services/streamEventService.dedup.test.ts
+++ b/tests/services/streamEventService.dedup.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { streamEventService, _resetDedupCache, StreamCreatedEvent } from "../../src/services/streamEventService.js";
+import { streamRepository } from "../../src/db/repositories/streamRepository.js";
+import * as hub from "../../src/ws/hub.js";
+import { CreateStreamInput } from "../../src/db/types.js";
+import { deriveStreamId } from "../../src/streams/sseEmitter.js";
+
+vi.mock("../../src/db/repositories/streamRepository.js", () => ({
+  streamRepository: {
+    upsertStream: vi.fn(),
+    getById: vi.fn(),
+    updateStream: vi.fn(),
+  },
+}));
+
+vi.mock("../../src/ws/hub.js", () => ({
+  getStreamHub: vi.fn(),
+}));
+
+vi.mock("../../src/tracing/hooks.js", () => ({
+  enrichActiveSpanWithStream: vi.fn(),
+  traceSpan: vi.fn((name, cid, tags, fn) => fn()),
+}));
+
+describe("streamEventService duplicate-event suppression", () => {
+  const mockHub = {
+    broadcast: vi.fn().mockResolvedValue(undefined),
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    _resetDedupCache();
+    vi.mocked(hub.getStreamHub).mockReturnValue(mockHub as any);
+  });
+
+  it("suppresses duplicate events and prevents fan-out", async () => {
+    const event: StreamCreatedEvent = {
+      type: "StreamCreated",
+      contractId: "C123",
+      transactionHash: "tx1",
+      eventIndex: 0,
+      sender: "G123",
+      recipient: "G456",
+      amount: "1000",
+      ratePerSecond: "10",
+      startTime: 1000,
+      endTime: 2000,
+    };
+
+    const streamId = deriveStreamId(event.transactionHash, event.eventIndex);
+
+    // Mock successful DB insertion for the first processing
+    vi.mocked(streamRepository.upsertStream).mockResolvedValue({
+      created: true,
+      stream: {
+        id: streamId,
+        sender_address: event.sender,
+        recipient_address: event.recipient,
+      } as any,
+    });
+
+    // Feed the event the first time
+    const result1 = await streamEventService.processEvent(event);
+
+    expect(result1.success).toBe(true);
+    expect(result1.action).toBe("created");
+    expect(streamRepository.upsertStream).toHaveBeenCalledTimes(1);
+    expect(mockHub.broadcast).toHaveBeenCalledTimes(1);
+
+    // Reset mocks to cleanly verify the second call
+    vi.mocked(streamRepository.upsertStream).mockClear();
+    mockHub.broadcast.mockClear();
+
+    // Feed the same event a second time
+    const result2 = await streamEventService.processEvent(event);
+
+    // It should be ignored and prevent DB upsert and fan-out
+    expect(result2.success).toBe(true);
+    expect(result2.action).toBe("ignored");
+    expect(streamRepository.upsertStream).not.toHaveBeenCalled();
+    expect(mockHub.broadcast).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Closes #696 

This PR introduces a short-lived deduplication cache in streamEventService.ts to ensure that identical stream events emitted by the indexer (e.g. due to rapid replay or redundant delivery) are suppressed before triggering any downstream fan-out (like webhooks, SSE, or WebSocket messages).

Changes Made:
- Event Suppression Cache: Implemented an in-memory, LRU-like deduplication cache storing eventIds (transactionHash + eventIndex) to suppress duplicate events during processStreamCreated, processStreamUpdated, and processStreamCancelled.
- Test Coverage: Added explicit tests for duplicate suppression in tests/services/streamEventService.dedup.test.ts to verify that feeding the identical event twice strictly prevents duplicate fan-out operations.
- Documentation: Updated docs/STREAMING_PAYMENT_DOMAIN.md to document the fan-out and database dedup guarantees.

Acceptance Criteria Covered:
- Duplicate events are suppressed before fan-out.
- Test explicitly covers the duplicate-delivery scenario.
- Dedup guarantee is documented.