### PR TITLE
Feat/long poll fallback

### DIFF
--- a/API_BEHAVIOR.md
+++ b/API_BEHAVIOR.md
@@ -13,9 +13,17 @@ This document specifies the observable behavior of the Fluxora HTTP API under no
 ## Trust Boundaries
 
 ### Public Internet Clients
-- **Access**: Read-only (GET /health, GET /api/streams, GET /api/streams/{id}, GET /api/admin/status/read-only)
-- **Restrictions**: No authentication required; rate limiting applies
+- **Access**: Read-only (GET /health, GET /api/streams, GET /api/streams/{id}, GET /api/streams/{id}/events, GET /api/streams/{id}/poll, GET /api/admin/status/read-only)
+- **Restrictions**: No authentication required unless WS_AUTH_REQUIRED is enabled; rate limiting applies
 - **Guarantees**: Best-effort; no SLA
+
+### Long-Poll Fallback (GET /api/streams/{id}/poll)
+- **Purpose**: Fallback for clients behind corporate proxies that block WebSockets/SSE.
+- **Behavior**: Holds connection open (bounded by a timeout, default 30s) until a stream update event arrives or timeout elapses.
+- **Resumption**: Supports `?since=<eventId>` query parameter for historical replay of missed events.
+- **Concurrency & Limits**: Shares per-IP concurrent connection limits and maximum duration caps with SSE connections.
+- **Envelope**: Returns event objects using the same shape as WebSocket hub (`{ type: "stream_update", streamId, eventId, payload, correlationId }`).
+
 
 ### Authenticated Partners
 - **Access**: Create and manage streams (POST /api/streams, GET /api/streams)

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -443,6 +443,98 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
 
+  /api/streams/{streamId}/poll:
+    get:
+      summary: Long-polling fallback for real-time stream updates
+      description: >-
+        Long-polling fallback endpoint for enterprise clients behind proxies that block WebSocket upgrades.
+        Holds the HTTP connection open (bounded by a timeout) until a new event for the stream arrives or
+        the timeout elapses, returning the same event envelope shape used by the WebSocket hub.
+      operationId: pollStreamEvents
+      tags:
+        - Streams
+      security:
+        - ApiKeyAuth: []
+        - BearerAuth: []
+      parameters:
+        - name: streamId
+          in: path
+          required: true
+          description: Stream identifier
+          schema:
+            type: string
+        - name: since
+          in: query
+          required: false
+          description: Event ID cursor for historical resumption replay
+          schema:
+            type: string
+        - name: timeout
+          in: query
+          required: false
+          description: Maximum hold duration in seconds (1 to 30, default 30)
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: Stream event update or null if timeout elapsed
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    example: true
+                  data:
+                    nullable: true
+                    type: object
+                    properties:
+                      type:
+                        type: string
+                        example: stream_update
+                      streamId:
+                        type: string
+                        example: stream-123
+                      eventId:
+                        type: string
+                        example: evt-101
+                      payload:
+                        type: object
+                      correlationId:
+                        type: string
+                  meta:
+                    $ref: '#/components/schemas/ResponseMeta'
+        '400':
+          description: Invalid parameters or stale replay cursor
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          description: Missing or invalid authentication token
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '404':
+          description: Stream not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '429':
+          description: Too many concurrent long-poll connections
+          headers:
+            Retry-After:
+              description: Backoff duration in seconds
+              schema:
+                type: string
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
     delete:
       summary: Cancel a stream
       operationId: cancelStream

--- a/src/routes/streams.ts
+++ b/src/routes/streams.ts
@@ -93,6 +93,7 @@ import {
   SSE_CLOSE_REASONS,
   subscribeToSseStream,
   registerSseShutdownCallback,
+  type LiveSseStreamUpdateEvent,
 } from '../streams/sseEmitter.js';
 import {
   resolveSseConnectionLimits,
@@ -1216,6 +1217,290 @@ streamsRouter.get(
       origUnsubscribe();
       deregisterShutdown();
     };
+  }),
+);
+
+/**
+ * GET /api/streams/:id/poll?since=&timeout=
+ *
+ * Long-polling fallback endpoint for clients behind proxies that block WebSockets/SSE.
+ * Holds the HTTP connection open (bounded by a timeout) until a new event for the stream
+ * arrives or the timeout elapses. Returns the same event envelope shape used by the
+ * WebSocket hub.
+ */
+streamsRouter.get(
+  '/:id/poll',
+  authenticateApiKey,
+  requireScope('streams:read'),
+  asyncHandler(async (req: Request, res: Response) => {
+    const id = req.params['id'];
+    const requestId = req.id;
+
+    if (!id) {
+      throw notFound('Stream', '');
+    }
+
+    // 1. JWT Authentication and Authorization
+    const wsAuthRequired = process.env.WS_AUTH_REQUIRED === 'true';
+    const jwtSecret = process.env.JWT_SECRET;
+    const authResult = verifyWsToken(req, jwtSecret);
+
+    if (wsAuthRequired && !authResult.ok) {
+      res.status(401).json({
+        success: false,
+        error: {
+          code: 'UNAUTHORIZED',
+          message: `Authentication required: ${authResult.code}`,
+          requestId,
+        },
+      });
+      return;
+    } else if (!wsAuthRequired && !authResult.ok && authResult.code === 'INVALID_TOKEN') {
+      res.status(401).json({
+        success: false,
+        error: {
+          code: 'UNAUTHORIZED',
+          message: 'Invalid or expired authentication token',
+          requestId,
+        },
+      });
+      return;
+    }
+
+    // 2. Reserve connection capacity from sseConnectionLimiter
+    const clientIp = getClientIp(req);
+    const sseLimits = resolveSseConnectionLimits();
+    const connectionAttempt = tryAcquireSseConnection(clientIp, sseLimits);
+
+    if (!connectionAttempt.ok) {
+      res.setHeader('Retry-After', String(connectionAttempt.retryAfterSeconds));
+      warn('Long-poll connection rejected by limiter', {
+        id,
+        requestId,
+        ip: clientIp,
+        reason: connectionAttempt.reason,
+        activeConnections: connectionAttempt.activeConnections,
+        activeConnectionsForIp: connectionAttempt.activeConnectionsForIp,
+        maxConnectionsPerIp: sseLimits.maxConnectionsPerIp,
+        maxGlobalConnections: sseLimits.maxGlobalConnections,
+      });
+      throw tooManyRequests(connectionAttempt.message, {
+        reason: connectionAttempt.reason,
+        maxConnectionsPerIp: sseLimits.maxConnectionsPerIp,
+        maxGlobalConnections: sseLimits.maxGlobalConnections,
+        retryAfterSeconds: connectionAttempt.retryAfterSeconds,
+      });
+    }
+
+    const sseConnection = connectionAttempt.connection;
+    let cleanedUp = false;
+    let unsubscribeLiveUpdates: (() => void) | undefined;
+    let pollTimer: NodeJS.Timeout | undefined;
+
+    function detachLifecycleHandlers(): void {
+      res.off('close', onResponseClose);
+      res.off('error', onResponseError);
+      req.off('aborted', onRequestAborted);
+    }
+
+    function cleanup(reason: string): void {
+      if (cleanedUp) return;
+      cleanedUp = true;
+      detachLifecycleHandlers();
+
+      if (pollTimer !== undefined) {
+        clearTimeout(pollTimer);
+        pollTimer = undefined;
+      }
+      if (unsubscribeLiveUpdates !== undefined) {
+        unsubscribeLiveUpdates();
+        unsubscribeLiveUpdates = undefined;
+      }
+
+      sseConnection.release();
+      debug('Long-poll connection cleaned up', {
+        id,
+        requestId,
+        ip: sseConnection.ip,
+        reason,
+        durationMs: Date.now() - sseConnection.acceptedAt,
+      });
+    }
+
+    function onResponseClose(): void {
+      cleanup('client_close');
+    }
+
+    function onResponseError(err: Error): void {
+      warn('Long-poll response error', {
+        id,
+        requestId,
+        ip: sseConnection.ip,
+        error: err.message,
+      });
+      cleanup('response_error');
+    }
+
+    function onRequestAborted(): void {
+      cleanup('client_aborted');
+    }
+
+    res.once('close', onResponseClose);
+    res.once('error', onResponseError);
+    req.once('aborted', onRequestAborted);
+
+    // 3. Verify stream existence in DB
+    let record;
+    try {
+      record = await streamRepository.getById(id);
+    } catch (err) {
+      cleanup('db_error');
+      wrapDbError(err);
+    }
+
+    if (cleanedUp) return;
+
+    if (!record) {
+      cleanup('not_found');
+      throw notFound('Stream', id);
+    }
+
+    // 4. Validate query parameters
+    const rawSince = req.query['since'];
+    let sinceEventId: string | undefined;
+    if (rawSince !== undefined) {
+      try {
+        sinceEventId = parseLastEventIdHeader(rawSince);
+      } catch (err) {
+        cleanup('validation_error');
+        throw err;
+      }
+    }
+
+    const rawTimeout = req.query['timeout'];
+    let timeoutMs = 30_000; // Default 30s
+    if (rawTimeout !== undefined) {
+      if (typeof rawTimeout !== 'string' || !/^\d+$/.test(rawTimeout)) {
+        cleanup('validation_error');
+        throw validationError('timeout must be a positive integer');
+      }
+      const parsedTimeout = Number.parseInt(rawTimeout, 10);
+      if (parsedTimeout < 1) {
+        cleanup('validation_error');
+        throw validationError('timeout must be at least 1 second');
+      }
+      timeoutMs = parsedTimeout > 1000 ? parsedTimeout : parsedTimeout * 1000;
+    }
+    // Bound timeout by max hold duration & sseLimits
+    const MAX_LONG_POLL_HOLD_MS = 30_000;
+    timeoutMs = Math.min(timeoutMs, MAX_LONG_POLL_HOLD_MS, sseLimits.maxConnectionDurationMs);
+
+    // 5. Check historical replay if `since` was supplied
+    if (sinceEventId) {
+      const hub = getStreamHub();
+      const eventStore = hub?.getEventStore();
+      if (eventStore) {
+        try {
+          const result = await eventStore.getEvents({
+            afterEventId: sinceEventId,
+            limit: 100,
+          });
+
+          for (const event of result.events) {
+            if (cleanedUp) break;
+            if (eventMatchesStreamId(event, id)) {
+              const envelope = {
+                type: 'stream_update',
+                streamId: id,
+                eventId: event.eventId,
+                payload: event.payload,
+                correlationId: req.correlationId,
+              };
+              cleanup('replay_event_found');
+              res.json(successResponse(envelope, requestId));
+              return;
+            }
+          }
+        } catch (err) {
+          if (err instanceof StaleCursorError || (err as any)?.name === 'StaleCursorError') {
+            cleanup('stale_cursor');
+            throw validationError(
+              'Replay cursor no longer exists; resync from fromLedger',
+              { code: STALE_CURSOR_ERROR_CODE },
+            );
+          }
+
+          warn('Failed to replay event for long-poll', {
+            error: err instanceof Error ? err.message : String(err),
+            requestId,
+          });
+        }
+      }
+    }
+
+    if (cleanedUp) return;
+
+    // 6. Subscribe to live updates via sseEmitter event bus
+    const sendEventAndFinish = (event: LiveSseStreamUpdateEvent) => {
+      if (cleanedUp || res.destroyed || res.writableEnded) return;
+
+      const envelope = {
+        type: 'stream_update',
+        streamId: event.streamId,
+        eventId: event.eventId,
+        payload: event.payload,
+        correlationId: req.correlationId || event.correlationId,
+      };
+
+      cleanup('event_delivered');
+      res.json(successResponse(envelope, requestId));
+    };
+
+    const listener = (event: LiveSseStreamUpdateEvent) => {
+      if (event.streamId === id) {
+        sendEventAndFinish(event);
+      }
+    };
+
+    unsubscribeLiveUpdates = subscribeToSseStream(id, listener);
+
+    // Register shutdown drain callback
+    const deregisterShutdown = registerSseShutdownCallback(
+      async () => {
+        try {
+          if (!res.writableEnded && !res.destroyed) {
+            res.json(successResponse(null, requestId));
+          }
+        } catch {
+          // Best-effort
+        }
+        cleanup('shutdown_drain');
+      },
+      () => {
+        try {
+          if (!res.destroyed) {
+            res.destroy();
+          }
+        } catch {
+          // Best-effort
+        }
+      },
+    );
+
+    const origUnsubscribe = unsubscribeLiveUpdates;
+    unsubscribeLiveUpdates = () => {
+      origUnsubscribe();
+      deregisterShutdown();
+    };
+
+    // 7. Start hold timer
+    pollTimer = setTimeout(() => {
+      if (cleanedUp || res.destroyed || res.writableEnded) return;
+      cleanup('timeout_elapsed');
+      res.json(successResponse(null, requestId));
+    }, timeoutMs);
+
+    pollTimer.unref?.();
   }),
 );
 

--- a/tests/routes/streams-longpoll.test.ts
+++ b/tests/routes/streams-longpoll.test.ts
@@ -1,0 +1,411 @@
+import { initializeConfig } from '../../src/config/env.js';
+initializeConfig();
+
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
+import { createServer } from 'http';
+import http from 'http';
+import type { IncomingHttpHeaders } from 'http';
+import { createApp } from '../../src/app.js';
+import {
+  _resetSseSubscriptionsForTest,
+  getLiveSseSubscriberCount,
+  SSE_STREAM_UPDATE_EVENT,
+  sseEventBus,
+} from '../../src/streams/sseEmitter.js';
+import { getStreamHub } from '../../src/ws/hub.js';
+import { generateToken } from '../../src/lib/auth.js';
+import {
+  _resetSseConnectionLimiter,
+  getActiveSseConnectionCount,
+} from '../../src/streams/sseConnectionLimiter.js';
+import { sseActiveConnectionsGauge, sseConnectionsRejectedTotal } from '../../src/metrics/businessMetrics.js';
+import { StaleCursorError } from '../../src/indexer/store.js';
+
+// ── Mocks ────────────────────────────────────────────────────────────────────
+const mockGetById = vi.fn();
+
+vi.mock('ioredis', () => {
+  class RedisMock {
+    on = vi.fn();
+    quit = vi.fn().mockResolvedValue('OK');
+    disconnect = vi.fn();
+    connect = vi.fn().mockResolvedValue(undefined);
+  }
+  return {
+    default: RedisMock,
+    Redis: RedisMock,
+  };
+});
+
+vi.mock('../../src/db/repositories/streamRepository.js', () => ({
+  streamRepository: {
+    getById: (...a: unknown[]) => mockGetById(...a),
+  },
+}));
+
+vi.mock('../../src/db/pool.js', () => ({
+  getPool: vi.fn(() => ({})),
+  query: vi.fn(),
+  PoolExhaustedError: class PoolExhaustedError extends Error {
+    constructor() {
+      super('pool exhausted');
+      this.name = 'PoolExhaustedError';
+    }
+  },
+  DuplicateEntryError: class DuplicateEntryError extends Error {
+    constructor(d?: string) {
+      super(d ?? 'duplicate');
+      this.name = 'DuplicateEntryError';
+    }
+  },
+  QueryTimeoutError: class QueryTimeoutError extends Error {
+    constructor() {
+      super('query timeout');
+      this.name = 'QueryTimeoutError';
+    }
+  },
+}));
+
+vi.mock('../../src/config.js', () => ({
+  config: {
+    stellar: {
+      rpcUrl: 'https://soroban-testnet.stellar.org',
+      networkPassphrase: 'Test SDF Network ; September 2015',
+      timeout: 10000,
+      retry: { maxRetries: 3, initialDelayMs: 1000 },
+    },
+    database: {
+      url: process.env.DATABASE_URL || 'postgresql://localhost:5432/indexer_db',
+    },
+    indexer: {
+      replayBatchSize: 1000,
+    },
+    server: {
+      port: 3000,
+    },
+  },
+}));
+
+const mockGetEvents = vi.fn();
+const mockEventStore = {
+  getEvents: mockGetEvents,
+};
+
+vi.mock('../../src/ws/hub.js', async (importOriginal) => {
+  const original = await importOriginal<typeof import('../../src/ws/hub.js')>();
+  return {
+    ...original,
+    getStreamHub: vi.fn(),
+  };
+});
+
+vi.mock('../../src/middleware/auth.js', async (importOriginal) => {
+  const original = await importOriginal<typeof import('../../src/middleware/auth.js')>();
+  return {
+    ...original,
+    authenticateApiKey: (_req: any, _res: any, next: any) => next(),
+    requireScope: () => (_req: any, _res: any, next: any) => next(),
+  };
+});
+
+const VALID_SENDER = 'GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN7';
+const TEST_TOKEN = generateToken({ address: VALID_SENDER, role: 'operator' });
+
+const app = createApp();
+
+function makeDbRecord(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'stream-abc123-0',
+    sender_address: VALID_SENDER,
+    recipient_address: 'GBDEVU63Y6NTHJQQZIKVTC23NWLQVP3WJ2RI2OTSJTNYOIGICST6DUXR',
+    amount: '1000',
+    streamed_amount: '0',
+    remaining_amount: '1000',
+    rate_per_second: '10',
+    start_time: 1700000000,
+    end_time: 0,
+    status: 'active',
+    contract_id: 'api-created',
+    transaction_hash: 'a'.repeat(64),
+    event_index: 0,
+    created_at: '2024-01-01T00:00:00.000Z',
+    updated_at: '2024-01-01T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+describe('GET /api/streams/:id/poll (Long-Polling Fallback Endpoint)', () => {
+  let server: ReturnType<typeof createServer>;
+  let port: number;
+
+  function requestPoll(
+    path = '/api/streams/stream-123/poll',
+    extraHeaders: Record<string, string> = {},
+  ): Promise<{
+    status: number;
+    headers: IncomingHttpHeaders;
+    body: any;
+  }> {
+    return new Promise((resolve, reject) => {
+      const req = http.get(
+        {
+          hostname: '127.0.0.1',
+          port,
+          path,
+          agent: false,
+          headers: { ...extraHeaders },
+        },
+        (res) => {
+          let body = '';
+          res.on('data', (chunk) => (body += chunk.toString()));
+          res.on('end', () => {
+            try {
+              resolve({ status: res.statusCode ?? 0, headers: res.headers, body: JSON.parse(body) });
+            } catch (err) {
+              reject(err);
+            }
+          });
+        },
+      );
+      req.on('error', reject);
+    });
+  }
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    process.env.WS_AUTH_REQUIRED = 'false';
+    process.env.SSE_MAX_CONNECTIONS_PER_IP = '10';
+    process.env.SSE_MAX_GLOBAL_CONNECTIONS = '1000';
+    process.env.SSE_MAX_CONNECTION_DURATION_MS = String(30 * 60 * 1000);
+    process.env.SSE_RETRY_AFTER_SECONDS = '15';
+    _resetSseConnectionLimiter();
+    mockGetById.mockResolvedValue(undefined);
+    mockGetEvents.mockResolvedValue({ events: [], total: 0 });
+
+    const mockHub = {
+      getEventStore: vi.fn(() => mockEventStore),
+    };
+    vi.mocked(getStreamHub).mockReturnValue(mockHub as any);
+
+    server = createServer(app);
+    await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+    port = (server.address() as any).port;
+  });
+
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    _resetSseConnectionLimiter();
+    _resetSseSubscriptionsForTest();
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+    sseEventBus.removeAllListeners(SSE_STREAM_UPDATE_EVENT);
+  });
+
+  it('returns 404 if stream does not exist', async () => {
+    mockGetById.mockResolvedValue(undefined);
+
+    const res = await requestPoll('/api/streams/stream-nonexistent/poll');
+
+    expect(res.status).toBe(404);
+    expect(res.body.success).toBe(false);
+    expect(res.body.error.code).toBe('NOT_FOUND');
+    expect(getActiveSseConnectionCount()).toBe(0);
+  });
+
+  it('holds connection open and times out with null data when no event arrives', async () => {
+    mockGetById.mockResolvedValue(makeDbRecord({ id: 'stream-123' }));
+
+    const start = Date.now();
+    const res = await requestPoll('/api/streams/stream-123/poll?timeout=1');
+    const elapsed = Date.now() - start;
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(res.body.data).toBeNull();
+    expect(res.body.meta).toHaveProperty('timestamp');
+    expect(elapsed).toBeGreaterThanOrEqual(950);
+    expect(getActiveSseConnectionCount()).toBe(0);
+  });
+
+  it('delivers live event immediately when emitted via sseEventBus', async () => {
+    mockGetById.mockResolvedValue(makeDbRecord({ id: 'stream-123' }));
+
+    const pollPromise = requestPoll('/api/streams/stream-123/poll?timeout=5');
+
+    // Wait for listener to attach
+    await new Promise((r) => setTimeout(r, 100));
+
+    expect(getLiveSseSubscriberCount('stream-123')).toBe(1);
+    expect(getActiveSseConnectionCount()).toBe(1);
+
+    sseEventBus.emit(SSE_STREAM_UPDATE_EVENT, {
+      streamId: 'stream-123',
+      eventId: 'evt-live-101',
+      payload: { amount: '100', status: 'active' },
+    });
+
+    const res = await pollPromise;
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(res.body.data).toEqual({
+      type: 'stream_update',
+      streamId: 'stream-123',
+      eventId: 'evt-live-101',
+      payload: { amount: '100', status: 'active' },
+      correlationId: expect.any(String),
+    });
+    expect(getActiveSseConnectionCount()).toBe(0);
+    expect(getLiveSseSubscriberCount('stream-123')).toBe(0);
+  });
+
+  it('replays historical event immediately if found after since', async () => {
+    mockGetById.mockResolvedValue(makeDbRecord({ id: 'stream-123' }));
+
+    const historicalEvent = {
+      eventId: 'evt-100',
+      txHash: 'a'.repeat(64),
+      eventIndex: 0,
+      payload: { id: 'stream-123', depositAmount: '500' },
+    };
+
+    mockGetEvents.mockResolvedValue({
+      events: [historicalEvent],
+      total: 1,
+    });
+
+    const res = await requestPoll('/api/streams/stream-123/poll?since=evt-99');
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(res.body.data).toEqual({
+      type: 'stream_update',
+      streamId: 'stream-123',
+      eventId: 'evt-100',
+      payload: { id: 'stream-123', depositAmount: '500' },
+      correlationId: expect.any(String),
+    });
+    expect(mockGetEvents).toHaveBeenCalledWith({
+      afterEventId: 'evt-99',
+      limit: 100,
+    });
+    expect(getActiveSseConnectionCount()).toBe(0);
+  });
+
+  it('rejects invalid since parameter with 400 VALIDATION_ERROR', async () => {
+    mockGetById.mockResolvedValue(makeDbRecord({ id: 'stream-123' }));
+
+    const res = await requestPoll('/api/streams/stream-123/poll?since=bad%0Aheader');
+
+    expect(res.status).toBe(400);
+    expect(res.body.success).toBe(false);
+    expect(res.body.error.code).toBe('VALIDATION_ERROR');
+    expect(getActiveSseConnectionCount()).toBe(0);
+  });
+
+  it('rejects invalid timeout parameter with 400 VALIDATION_ERROR', async () => {
+    mockGetById.mockResolvedValue(makeDbRecord({ id: 'stream-123' }));
+
+    const res = await requestPoll('/api/streams/stream-123/poll?timeout=abc');
+
+    expect(res.status).toBe(400);
+    expect(res.body.success).toBe(false);
+    expect(res.body.error.code).toBe('VALIDATION_ERROR');
+    expect(getActiveSseConnectionCount()).toBe(0);
+  });
+
+  it('handles StaleCursorError when replaying events', async () => {
+    mockGetById.mockResolvedValue(makeDbRecord({ id: 'stream-123' }));
+    mockGetEvents.mockRejectedValue(new StaleCursorError('evt-evicted'));
+
+    const res = await requestPoll('/api/streams/stream-123/poll?since=evt-evicted');
+
+    expect(res.status).toBe(400);
+    expect(res.body.success).toBe(false);
+    expect(res.body.error.code).toBe('VALIDATION_ERROR');
+    expect(getActiveSseConnectionCount()).toBe(0);
+  });
+
+  it('rejects long-poll requests exceeding per-IP capacity with 429 and Retry-After', async () => {
+    process.env.SSE_MAX_CONNECTIONS_PER_IP = '1';
+    process.env.SSE_RETRY_AFTER_SECONDS = '10';
+    mockGetById.mockResolvedValue(makeDbRecord({ id: 'stream-123' }));
+
+    const firstPollPromise = requestPoll('/api/streams/stream-123/poll?timeout=5');
+
+    await new Promise((r) => setTimeout(r, 100));
+
+    expect(getActiveSseConnectionCount()).toBe(1);
+
+    const rejected = await requestPoll('/api/streams/stream-123/poll?timeout=5');
+
+    expect(rejected.status).toBe(429);
+    expect(rejected.headers['retry-after']).toBe('10');
+    expect(rejected.body.success).toBe(false);
+    expect(rejected.body.error.code).toBe('TOO_MANY_REQUESTS');
+
+    sseEventBus.emit(SSE_STREAM_UPDATE_EVENT, {
+      streamId: 'stream-123',
+      eventId: 'evt-first',
+      payload: {},
+    });
+
+    await firstPollPromise;
+    expect(getActiveSseConnectionCount()).toBe(0);
+  });
+
+  it('rejects unauthenticated request when WS_AUTH_REQUIRED is true', async () => {
+    process.env.WS_AUTH_REQUIRED = 'true';
+    mockGetById.mockResolvedValue(makeDbRecord({ id: 'stream-123' }));
+
+    const res = await requestPoll('/api/streams/stream-123/poll?timeout=1');
+
+    expect(res.status).toBe(401);
+    expect(res.body.success).toBe(false);
+    expect(res.body.error.code).toBe('UNAUTHORIZED');
+    expect(getActiveSseConnectionCount()).toBe(0);
+  });
+
+  it('accepts valid JWT token in Authorization header when WS_AUTH_REQUIRED is true', async () => {
+    process.env.WS_AUTH_REQUIRED = 'true';
+    mockGetById.mockResolvedValue(makeDbRecord({ id: 'stream-123' }));
+
+    const res = await requestPoll('/api/streams/stream-123/poll?timeout=1', {
+      Authorization: `Bearer ${TEST_TOKEN}`,
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(getActiveSseConnectionCount()).toBe(0);
+  });
+
+  it('cleans up connection slot and unsubscribes if client aborts request', async () => {
+    mockGetById.mockResolvedValue(makeDbRecord({ id: 'stream-123' }));
+
+    const initialListeners = sseEventBus.listenerCount(SSE_STREAM_UPDATE_EVENT);
+
+    const req = http.get(
+      {
+        hostname: '127.0.0.1',
+        port,
+        path: '/api/streams/stream-123/poll?timeout=5',
+        agent: false,
+      },
+      (res) => {},
+    );
+    req.on('error', () => {
+      // Swallowed expected abort error
+    });
+
+    await new Promise((r) => setTimeout(r, 100));
+
+    expect(getActiveSseConnectionCount()).toBe(1);
+    expect(sseEventBus.listenerCount(SSE_STREAM_UPDATE_EVENT)).toBe(initialListeners + 1);
+
+    req.destroy();
+
+    await new Promise((r) => setTimeout(r, 100));
+
+    expect(getActiveSseConnectionCount()).toBe(0);
+    expect(sseEventBus.listenerCount(SSE_STREAM_UPDATE_EVENT)).toBe(initialListeners);
+  });
+});


### PR DESCRIPTION
 ### Summary of Work Completed

  1. Created Feature Branch:
      • Created and checked out new branch Fluxora-Backend.
  2. Implemented Long-Polling Fallback Endpoint:
      • Added GET /api/streams/:id/poll?since=&timeout= to streams.ts.
      • Event Bus Integration: Reused sseEmitter.ts's single-source event bus
      (subscribeToSseStream) for live update fan-out.
      • Concurrency & Duration Limiting: Applied sseConnectionLimiter.ts
      (tryAcquireSseConnection) to enforce per-IP concurrent caps (returning
      HTTP 429 + Retry-After) and max hold duration bounds.
      • Envelope Consistency: Formatted events matching the exact WebSocket
      hub envelope shape ({ type: 'stream_update', streamId, eventId, payload,
      correlationId }).
      • Resumption Replay: Supported ?since=<eventId> historical event replay
      via the event store before falling back to live event listening.
      • Resource Safety: Enforced idempotent cleanup and socket slot release
      on timeout, event delivery, client abort, error, or server shutdown.
  3. Created Automated Test Suite:
      • Created streams-longpoll.test.ts covering:
	  • 404 response on missing streams.
	  • Hold duration timeout returning data: null.
	  • Real-time live event delivery.
	  • Historical event replay with ?since=.
	  • Parameter validation & StaleCursorError handling.
	  • 429 Too Many Requests per-IP capacity limits & Retry-After header.
	  • Authentication enforcement (WS_AUTH_REQUIRED).
	  • Client disconnect / abort capacity cleanup.

  4. Updated Documentation:
      • Documented the endpoint in API_BEHAVIOR.md.
      • Added full OpenAPI schema in openapi.yaml.
  5. Modular Git Commits:
      • feat(streams): add long-poll fallback GET /api/streams/:id/poll
      endpoint
      • test(streams): add test suite for long-polling fallback endpoint
      • docs(streams): document GET /api/streams/:id/poll endpoint in
      API_BEHAVIOR and OpenAPI spec


closes #725 