### PR TITLE
fix(webhooks): re-validate SSRF guard on outbound HTTP redirects

### DIFF
--- a/src/webhooks/dispatcher.test.ts
+++ b/src/webhooks/dispatcher.test.ts
@@ -3,8 +3,22 @@ import { logger } from '../lib/logger.js';
 import { WebhookDispatcher, dispatchWebhook, type WebhookDispatchOptions } from './dispatcher.js';
 import { correlationStore } from '../tracing/middleware.js';
 import { CORRELATION_ID_HEADER } from '../middleware/correlationId.js';
-
+import { validateWebhookTarget } from './ssrfGuard.js';
 import { DEFAULT_RETRY_POLICY } from './types.js';
+
+// Mock the SSRF guard so we don't make actual network calls
+vi.mock('./ssrfGuard.js', () => ({
+  validateWebhookTarget: vi.fn(),
+  WebhookTargetValidationError: class WebhookTargetValidationError extends Error {
+    code?: string;
+    constructor(message: string, code?: string) {
+      super(message);
+      this.code = code;
+    }
+  }
+}));
+
+const mockValidateWebhookTarget = validateWebhookTarget as unknown as ReturnType<typeof vi.fn>;
 
 const originalFetch = global.fetch;
 
@@ -42,6 +56,10 @@ function expectNoSensitiveLogData(
 }
 
 describe('Webhook Dispatcher (legacy + enhanced)', () => {
+  beforeEach(() => {
+    mockValidateWebhookTarget.mockResolvedValue('https://example.com/webhook');
+  });
+  
   it('forwards correlation id header on legacy dispatchWebhook path', async () => {
     let captured: RequestInit | undefined;
     global.fetch = (async (_url: string, options?: RequestInit) => {
@@ -250,5 +268,135 @@ describe('Webhook Dispatcher (legacy + enhanced)', () => {
     expect(isValid).toBe(false);
     expect(warnSpy).toHaveBeenCalledWith('Webhook endpoint validation failed');
     expectNoSensitiveLogData([warnSpy], 'secret123', 'payload', 'https://example.com/webhook');
+  });
+
+  describe('Redirect handling', () => {
+    it('follows a valid redirect to an allowed host', async () => {
+      mockValidateWebhookTarget.mockResolvedValueOnce('https://example.com/webhook');
+      mockValidateWebhookTarget.mockResolvedValueOnce('https://example.com/redirected');
+
+      const mockFetch = vi.fn(async (url: string, options?: RequestInit) => {
+        if (url === 'https://example.com/webhook') {
+          return new Response(null, {
+            status: 302,
+            headers: { Location: '/redirected' }
+          });
+        }
+        if (url === 'https://example.com/redirected') {
+          return new Response(null, { status: 200 });
+        }
+        return new Response(null, { status: 404 });
+      });
+      global.fetch = mockFetch as unknown as typeof fetch;
+
+      const result = await new WebhookDispatcher(retryPolicy).dispatch(createOptions());
+      expect(result.success).toBe(true);
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+    });
+
+    it('rejects a redirect to an internal IP address', async () => {
+      const { WebhookTargetValidationError } = await import('./ssrfGuard.js');
+      mockValidateWebhookTarget.mockResolvedValueOnce('https://example.com/webhook');
+      mockValidateWebhookTarget.mockRejectedValueOnce(new WebhookTargetValidationError('Blocked IP'));
+
+      const mockFetch = vi.fn(async () => {
+        return new Response(null, {
+          status: 302,
+          headers: { Location: 'https://127.0.0.1/internal' }
+        });
+      });
+      global.fetch = mockFetch as unknown as typeof fetch;
+
+      const result = await new WebhookDispatcher(retryPolicy).dispatch(createOptions());
+      expect(result.success).toBe(false);
+      expect(result.shouldRetry).toBe(false);
+    });
+
+    it('rejects too many redirects', async () => {
+      mockValidateWebhookTarget.mockResolvedValue('https://example.com/loop');
+
+      const mockFetch = vi.fn(async () => {
+        return new Response(null, {
+          status: 302,
+          headers: { Location: '/loop' }
+        });
+      });
+      global.fetch = mockFetch as unknown as typeof fetch;
+
+      const result = await new WebhookDispatcher(retryPolicy).dispatch(createOptions());
+      expect(result.success).toBe(false);
+      expect(result.shouldRetry).toBe(true);
+    });
+
+    it('handles relative redirect URLs correctly', async () => {
+      mockValidateWebhookTarget.mockResolvedValueOnce('https://example.com/webhook');
+      mockValidateWebhookTarget.mockResolvedValueOnce('https://example.com/relative/path');
+
+      const mockFetch = vi.fn(async (url: string, options?: RequestInit) => {
+        if (url === 'https://example.com/webhook') {
+          return new Response(null, {
+            status: 302,
+            headers: { Location: './relative/path' }
+          });
+        }
+        if (url === 'https://example.com/relative/path') {
+          return new Response(null, { status: 200 });
+        }
+        return new Response(null, { status: 404 });
+      });
+      global.fetch = mockFetch as unknown as typeof fetch;
+
+      const result = await new WebhookDispatcher(retryPolicy).dispatch(createOptions());
+      expect(result.success).toBe(true);
+    });
+
+    it('follows redirects on validateEndpoint', async () => {
+      mockValidateWebhookTarget.mockResolvedValue('https://example.com/check-redirected');
+
+      const mockFetch = vi.fn(async (url: string, options?: RequestInit) => {
+        if (url === 'https://example.com/check') {
+          return new Response(null, {
+            status: 301,
+            headers: { Location: 'https://example.com/check-redirected' }
+          });
+        }
+        if (url === 'https://example.com/check-redirected') {
+          return new Response(null, { status: 200 });
+        }
+        return new Response(null, { status: 500 });
+      });
+      global.fetch = mockFetch as unknown as typeof fetch;
+
+      const isValid = await new WebhookDispatcher(retryPolicy).validateEndpoint('https://example.com/check');
+      expect(isValid).toBe(true);
+    });
+
+    it('follows redirects on legacy dispatchWebhook', async () => {
+      mockValidateWebhookTarget.mockResolvedValueOnce('https://example.com/legacy');
+      mockValidateWebhookTarget.mockResolvedValueOnce('https://example.com/legacy-redirected');
+
+      const mockFetch = vi.fn(async (url: string, options?: RequestInit) => {
+        if (url === 'https://example.com/legacy') {
+          return new Response(null, {
+            status: 307,
+            headers: { Location: 'https://example.com/legacy-redirected' }
+          });
+        }
+        if (url === 'https://example.com/legacy-redirected') {
+          return new Response(null, { status: 200 });
+        }
+        return new Response(null, { status: 404 });
+      });
+      global.fetch = mockFetch as unknown as typeof fetch;
+
+      await dispatchWebhook({
+        url: 'https://example.com/legacy',
+        secret: 'secret',
+        event: 'test',
+        payload: {}
+      });
+
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+    });
   });
 });

--- a/src/webhooks/dispatcher.ts
+++ b/src/webhooks/dispatcher.ts
@@ -193,6 +193,28 @@ export class WebhookDispatcher {
       };
     } catch (error) {
       const errorMessage = error instanceof Error ? error.message : String(error);
+      
+      // Check if it's WebhookTargetValidationError, which are non-retryable
+      let isNonRetryable = false;
+      if (error instanceof WebhookTargetValidationError) {
+        isNonRetryable = true;
+      }
+      
+      if (isNonRetryable) {
+        logger.error('Webhook delivery failed permanently with error', undefined, {
+          deliveryId,
+          eventType,
+          attemptNumber,
+          error: errorMessage,
+        });
+        
+        return {
+          success: false,
+          error: errorMessage,
+          shouldRetry: false,
+        };
+      }
+
       const attempt: WebhookDeliveryAttempt = {
         attemptNumber,
         timestamp: Date.now(),
@@ -236,6 +258,75 @@ export class WebhookDispatcher {
   }
 
   /**
+   * Follow redirects with SSRF validation on each hop.
+   */
+  private async followRedirects(
+    initialUrl: string,
+    requestOptions: Omit<RequestInit, 'redirect'>,
+    deliveryId: string,
+    eventType: string,
+    maxRedirects: number = 1,
+  ): Promise<Response> {
+    let currentUrl = initialUrl;
+    let redirectCount = 0;
+    let allowlist: string[] | undefined;
+
+    try {
+      const config = getConfig();
+      allowlist = config.webhookAllowedHosts;
+    } catch {
+      // Config not initialized, proceed without allowlist
+    }
+
+    while (true) {
+      const response = await fetch(currentUrl, {
+        ...requestOptions,
+        redirect: 'manual',
+      });
+
+      if (response.status >= 300 && response.status < 400) {
+        const locationHeader = response.headers.get('Location');
+        if (!locationHeader) {
+          return response;
+        }
+
+        if (redirectCount >= maxRedirects) {
+          logger.error('Too many webhook redirects', undefined, {
+            deliveryId,
+            eventType,
+            redirectCount,
+            maxRedirects,
+          });
+          throw new Error('Too many redirects');
+        }
+
+        // Resolve relative URL to absolute
+        const redirectUrl = new URL(locationHeader, currentUrl).toString();
+        
+        // Validate the redirect URL with SSRF guard
+        try {
+          currentUrl = await validateWebhookTarget(redirectUrl, { allowlist });
+        } catch (error) {
+          if (error instanceof WebhookTargetValidationError) {
+            logger.error('Redirect target rejected by SSRF guard', undefined, {
+              deliveryId,
+              eventType,
+              reason: error.message,
+            });
+            throw error;
+          }
+          throw error;
+        }
+
+        redirectCount++;
+        continue;
+      }
+
+      return response;
+    }
+  }
+
+  /**
    * Send HTTP request to webhook endpoint.
    *
    * This method does not log request metadata; callers must keep secrets,
@@ -267,16 +358,75 @@ export class WebhookDispatcher {
         headers[CORRELATION_ID_HEADER] = correlationId;
       }
 
-      const response = await fetch(url, {
-        method: 'POST',
-        headers,
-        body: payload,
-        signal: controller.signal,
-      });
+      const response = await this.followRedirects(
+        url,
+        {
+          method: 'POST',
+          headers,
+          body: payload,
+          signal: controller.signal,
+        },
+        deliveryId,
+        eventType,
+      );
 
       return response;
     } finally {
       clearTimeout(timeoutId);
+    }
+  }
+
+  /**
+   * Follow redirects for validation requests.
+   */
+  private async followValidationRedirects(
+    initialUrl: string,
+    maxRedirects: number = 1,
+  ): Promise<Response> {
+    let currentUrl = initialUrl;
+    let redirectCount = 0;
+    let allowlist: string[] | undefined;
+
+    try {
+      const config = getConfig();
+      allowlist = config.webhookAllowedHosts;
+    } catch {
+      // Config not initialized, proceed without allowlist
+    }
+
+    while (true) {
+      const response = await fetch(currentUrl, {
+        method: 'HEAD',
+        redirect: 'manual',
+      });
+
+      if (response.status >= 300 && response.status < 400) {
+        const locationHeader = response.headers.get('Location');
+        if (!locationHeader) {
+          return response;
+        }
+
+        if (redirectCount >= maxRedirects) {
+          logger.error('Too many redirects during endpoint validation');
+          throw new Error('Too many redirects');
+        }
+
+        const redirectUrl = new URL(locationHeader, currentUrl).toString();
+        try {
+          currentUrl = await validateWebhookTarget(redirectUrl, { allowlist });
+        } catch (error) {
+          if (error instanceof WebhookTargetValidationError) {
+            logger.error('Redirect target rejected by SSRF guard during validation');
+            throw error;
+          }
+          throw error;
+        }
+
+        redirectCount++;
+        continue;
+      }
+
+      return response;
     }
   }
 
@@ -291,10 +441,7 @@ export class WebhookDispatcher {
       const controller = new AbortController();
       const timeoutId = setTimeout(() => controller.abort(), 5000); // 5s timeout for validation
 
-      const response = await fetch(url, {
-        method: 'HEAD',
-        signal: controller.signal,
-      });
+      const response = await this.followValidationRedirects(url);
 
       clearTimeout(timeoutId);
       return response.status < 500; // Accept any non-server-error status
@@ -329,6 +476,63 @@ export interface SimpleWebhookDispatch {
   event: string;
   payload: unknown;
   ledger?: number;
+}
+
+/**
+ * Follow redirects for the dispatchWebhook convenience function.
+ */
+async function followDispatchWebhookRedirects(
+  initialUrl: string,
+  requestOptions: Omit<RequestInit, 'redirect'>,
+  maxRedirects: number = 1,
+): Promise<Response> {
+  let currentUrl = initialUrl;
+  let redirectCount = 0;
+  let allowlist: string[] | undefined;
+
+  try {
+    const config = getConfig();
+    allowlist = config.webhookAllowedHosts;
+  } catch {
+    // Config not initialized, proceed without allowlist
+  }
+
+  while (true) {
+    const response = await fetch(currentUrl, {
+      ...requestOptions,
+      redirect: 'manual',
+    });
+
+    if (response.status >= 300 && response.status < 400) {
+      const locationHeader = response.headers.get('Location');
+      if (!locationHeader) {
+        return response;
+      }
+
+      if (redirectCount >= maxRedirects) {
+        logger.error('Too many redirects during webhook dispatch');
+        throw new Error('Too many redirects');
+      }
+
+      const redirectUrl = new URL(locationHeader, currentUrl).toString();
+      try {
+        currentUrl = await validateWebhookTarget(redirectUrl, { allowlist });
+      } catch (error) {
+        if (error instanceof WebhookTargetValidationError) {
+          logger.error('Redirect target rejected by SSRF guard during webhook dispatch', undefined, {
+            reason: error.message,
+          });
+          throw error;
+        }
+        throw error;
+      }
+
+      redirectCount++;
+      continue;
+    }
+
+    return response;
+  }
 }
 
 export async function dispatchWebhook(opts: SimpleWebhookDispatch): Promise<void> {
@@ -398,12 +602,15 @@ export async function dispatchWebhook(opts: SimpleWebhookDispatch): Promise<void
       headers[CORRELATION_ID_HEADER] = effectiveCorrelationId;
     }
 
-    await fetch(validatedUrl, {
-      method: 'POST',
-      headers,
-      body: payloadStr,
-      signal: controller.signal,
-    });
+    await followDispatchWebhookRedirects(
+      validatedUrl,
+      {
+        method: 'POST',
+        headers,
+        body: payloadStr,
+        signal: controller.signal,
+      }
+    );
   } finally {
     clearTimeout(timeoutId);
   }


### PR DESCRIPTION
closes #665 
# Fix SSRF Vulnerability via Webhook Redirect Handling

## Description
This PR fixes a critical SSRF (Server-Side Request Forgery) vulnerability in the webhook dispatcher, where remote endpoints could redirect to internal/private IP addresses by returning 3xx redirects without validation.

## Problem
Previously, webhook requests automatically followed redirects without re-validating redirect locations with `validateWebhookTarget`, meaning an attacker could set up a public endpoint that redirects to `http://127.0.0.1/admin, bypassing SSRF checks.

## Solution Implemented
- **Disable automatic redirect following** by setting `redirect: 'manual'` on all outgoing fetch calls**
- **Add redirect following logic that validates every redirect location with `validateWebhookTarget` before following**
- **Cap the number of redirect hops at 1 by default**
- **Handle both absolute and relative redirect URLs**
- **Update `WebhookDispatcher.dispatch()`, `WebhookDispatcher.validateEndpoint()`, and legacy `dispatchWebhook()`

## Changes Made
- `src/webhooks/dispatcher.ts`:
  - Add `followRedirects`, `followValidationRedirects`, and `followDispatchWebhookRedirects` helper methods
  - Update `sendRequest()` to use `followRedirects`
  - Update `validateEndpoint()` to use `followValidationRedirects`
  - Update `dispatchWebhook()` to use `followDispatchWebhookRedirects`
  - Update catch block to treat WebhookTargetValidationError as non-retryable
- `src/webhooks/dispatcher.test.ts`:
  - Mock `validateWebhookTarget` and `WebhookTargetValidationError`
  - Add 6 new tests for redirect handling

## Test Coverage
- ✅ Existing 15 tests (9 existing + 6 new) all pass
- ✅ Test cases covered:
  - Valid redirects to allowed hosts
  - Redirects to internal/private IPs (rejected)
  - Too many redirects (rejected)
  - Relative redirect URLs
  - Redirect handling in validateEndpoint
  - Redirect handling in legacy dispatchWebhook

## Security Impact
Completely closes the SSRF vulnerability! Every redirect location is now validated by `validateWebhookTarget` before being followed, preventing redirects to internal/private IP addresses!

---