### PR TITLE
feat: add subscription cardinality gauge for WebSocket fan-out hotspots

### DIFF
--- a/docs/observability.md
+++ b/docs/observability.md
@@ -206,6 +206,67 @@ fluxora_ws_slow_clients > 5
 
 ---
 
+## WebSocket Subscription Cardinality Gauge
+
+A single stream with an unusually large subscriber count can drive disproportionate broadcast fan-out, consuming CPU and network bandwidth while increasing backpressure risk for every other stream. The subscription cardinality gauge reports the subscriber count for the top-N most-subscribed streams so operators can identify hot streams before they cause incidents.
+
+### Metric
+
+| Metric Name | Type | Labels | Description |
+|-------------|------|--------|-------------|
+| `fluxora_ws_stream_subscriber_count` | Gauge | `stream_id` (application-assigned stream identifier) | Subscriber count for the top-N WebSocket streams by fan-out size. Only the N most-subscribed streams are reported (default N = 20). |
+
+### Label cardinality and security
+
+The `stream_id` label is the opaque stream identifier assigned by the application. It does not contain PII, client IPs, JWT subjects, or any user-controlled data.
+
+Cardinality is bounded by `DEFAULT_WS_STREAM_CARDINALITY_TOP_N` (20) — at most 20 time-series are emitted at any point. The collector sorts streams by subscriber count descending, keeps the top N, and explicitly removes stale series for streams that drop below the N-th rank between collection cycles. This prevents:
+
+- **Unbounded label growth** when many low-subscriber streams exist — only the top 20 are exposed.
+- **Stale series** lingering after a stream's subscribers leave — stale labels are cleaned up on the next collection cycle.
+
+An attacker cannot inflate Prometheus memory by creating many streams with a handful of subscribers each, because only the top-N are ever exposed regardless of how many total streams exist.
+
+### Configuration
+
+| Constant | Default | Description |
+|----------|---------|-------------|
+| `DEFAULT_WS_STREAM_CARDINALITY_TOP_N` | `20` | Maximum number of streams reported by the gauge. Exported from `src/metrics/wsBackpressure.ts`. |
+
+### PromQL examples
+
+Top-5 streams by subscriber count:
+
+```promql
+topk(5, fluxora_ws_stream_subscriber_count)
+```
+
+Alert: any single stream with more than 500 subscribers (potential hot-stream):
+
+```promql
+fluxora_ws_stream_subscriber_count > 500
+```
+
+Total subscribers across all top-N streams (approximation of broadcast fan-out):
+
+```promql
+sum(fluxora_ws_stream_subscriber_count)
+```
+
+### Thresholding strategy
+
+- **`max(fluxora_ws_stream_subscriber_count) > 500` for > 5 min**: investigate the identified hot stream. High fan-out magnifies the cost of every broadcast event — one slow client can trigger backpressure for all other subscribers on that stream.
+- **`topk(1, fluxora_ws_stream_subscriber_count)` divergence from `sum(fluxora_ws_stream_subscriber_count)`**: one stream dominates the total subscriber count, indicating fan-out concentration risk.
+- **Correlation with `fluxora_ws_slow_clients` rising**: a hot stream with slow clients compounds backpressure; identify the stream from the cardinality gauge and the slow clients from the per-client backpressure gauge.
+
+### Affected source files
+
+- `src/metrics/wsBackpressure.ts` — `wsStreamSubscriberCount` gauge definition + `collectStreamSubscriberCardinality` helper
+- `src/ws/hub.ts` — `_getStreamSubscriptions()` accessor exposing the internal `streamSubscriptions` map
+- `tests/ws/hub.subscriptionCardinality.test.ts` — top-N cap, stale-series removal, empty-hub, and reset assertions
+
+---
+
 ## Authentication Latency Histograms
 
 Auth runs on every protected request path. When the JWT verifier, revocation-store lookup, or API-key store becomes a bottleneck, these histograms give a distribution view (p50/p95/p99) and a split by success/failure — without leaking credential material.

--- a/src/metrics/wsBackpressure.ts
+++ b/src/metrics/wsBackpressure.ts
@@ -1,9 +1,10 @@
 /**
  * src/metrics/wsBackpressure.ts
  *
- * Per-client WebSocket backpressure gauges exposed to Prometheus.
+ * Per-client WebSocket backpressure gauges and subscription cardinality
+ * metrics exposed to Prometheus.
  *
- * Three metrics are emitted for every live WebSocket subscriber on the
+ * Four metrics are emitted for live WebSocket subscribers on the
  * `/ws/streams` endpoint:
  *
  *   - `fluxora_ws_backpressure_buffered_bytes{connection_id="…"}` — current
@@ -14,6 +15,11 @@
  *     live clients (low cardinality, suitable for dashboards/alerts).
  *   - `fluxora_ws_slow_clients`           — count of clients whose buffered
  *     bytes exceed the configurable warning threshold (default 1 MiB).
+ *   - `fluxora_ws_stream_subscriber_count{stream_id="…"}` — subscriber
+ *     count for the top-N streams by fan-out size (default N=20). Reports
+ *     only the most-subscribed streams so operators can spot a single hot
+ *     stream driving disproportionate broadcast fan-out before it causes
+ *     backpressure incidents.
  *
  * The per-client gauge is updated by a poll loop so the value reflects the
  * actual kernel/OS send-buffer state, not just the snapshot taken during a
@@ -42,6 +48,15 @@ export const DEFAULT_WS_SLOW_CLIENT_BYTES = 1 * 1024 * 1024;
  * 5s-poll values are always at most one poll-stale in the worst case.
  */
 export const DEFAULT_WS_BACKPRESSURE_INTERVAL_MS = 5_000;
+
+/**
+ * Maximum number of streams reported by the subscription cardinality gauge.
+ * Capping this prevents unbounded Prometheus label cardinality when many
+ * streams each have a handful of subscribers — only the top-N most-subscribed
+ * streams are exposed. Streams that drop out of the top-N between collection
+ * cycles have their gauge series removed so stale labels don't persist.
+ */
+export const DEFAULT_WS_STREAM_CARDINALITY_TOP_N = 20;
 
 /**
  * Per-client backpressure gauge. Labels are intentionally limited to
@@ -93,10 +108,44 @@ export const wsSlowClients =
   });
 
 /**
- * Poll the hub for current `ws.bufferedAmount` values and update all three
- * gauges. Safe to call concurrently — prom-client labels writes are atomic
- * within a single call, and we only read `ws.bufferedAmount` which is itself
- * node:net state.
+ * Subscriber count for the top-N streams by fan-out size. Labelled by
+ * `stream_id` so operators can identify which stream is driving the most
+ * broadcast work.
+ *
+ * Cardinality guarantee: at most `DEFAULT_WS_STREAM_CARDINALITY_TOP_N`
+ * (20) time-series at any point. The collector sorts streams by subscriber
+ * count descending, keeps the top N, and explicitly removes stale series
+ * for streams that drop below the N-th rank between collection cycles.
+ *
+ * `@security` The `stream_id` label is the opaque stream identifier
+ * assigned by the application. It does not contain PII, client IPs, JWT
+ * subjects, or any user-controlled data that could be used for
+ * fingerprinting. The bounded cardinality prevents an attacker from
+ * inflating Prometheus memory by creating many low-subscriber streams —
+ * only the top 20 are ever exposed.
+ */
+export const wsStreamSubscriberCount =
+  (registry.getSingleMetric('fluxora_ws_stream_subscriber_count') as Gauge<'stream_id'>) ||
+  new Gauge<'stream_id'>({
+    name: 'fluxora_ws_stream_subscriber_count',
+    help: 'Subscriber count for the top-N WebSocket streams by fan-out size. Capped to prevent unbounded cardinality.',
+    labelNames: ['stream_id'] as const,
+    registers: [registry],
+  });
+
+/**
+ * Tracks which stream_id labels are currently emitted so we can remove
+ * stale series when a stream drops out of the top-N between collection
+ * cycles. Module-scoped; reset by `resetWsBackpressureMetrics`.
+ */
+let previousTopStreamIds = new Set<string>();
+
+/**
+ * Poll the hub for current `ws.bufferedAmount` values and update all four
+ * gauges (per-client buffered, max buffered, slow clients, and top-N stream
+ * subscriber counts). Safe to call concurrently — prom-client label writes
+ * are atomic within a single call, and we only read `ws.bufferedAmount` which
+ * is itself node:net state.
  *
  * The function is exported separately from `startWsBackpressureCollector` so
  * tests can drive it deterministically without dealing with `setInterval`
@@ -105,6 +154,7 @@ export const wsSlowClients =
 export function collectWsBackpressureMetrics(
   hub: StreamHub,
   slowThresholdBytes: number = DEFAULT_WS_SLOW_CLIENT_BYTES,
+  topN: number = DEFAULT_WS_STREAM_CARDINALITY_TOP_N,
 ): void {
   let maxBuffered = 0;
   let slowCount = 0;
@@ -123,6 +173,57 @@ export function collectWsBackpressureMetrics(
   // assignment is enough to keep dashboards honest when clients churn.
   wsMaxBufferedBytes.set(maxBuffered);
   wsSlowClients.set(slowCount);
+
+  // ── Top-N stream subscriber cardinality ───────────────────────────────────
+  collectStreamSubscriberCardinality(hub, topN);
+}
+
+/**
+ * Compute the top-N streams by subscriber count and update the
+ * `fluxora_ws_stream_subscriber_count` gauge. Stale series for streams that
+ * dropped below the N-th rank are explicitly removed to keep label
+ * cardinality bounded.
+ *
+ * Complexity: O(S log S) where S = number of active streams. With the default
+ * cap of 20, at most 20 label writes + at most 20 label removals per cycle.
+ */
+function collectStreamSubscriberCardinality(
+  hub: StreamHub,
+  topN: number,
+): void {
+  if (typeof (hub as { _getStreamSubscriptions?: unknown })._getStreamSubscriptions !== 'function') {
+    return;
+  }
+  const streamSubs = hub._getStreamSubscriptions();
+
+  // Build [streamId, subscriberCount] pairs and sort descending.
+  const entries: Array<[string, number]> = [];
+  for (const [streamId, subscribers] of streamSubs) {
+    entries.push([streamId, subscribers.size]);
+  }
+  entries.sort((a, b) => b[1] - a[1]);
+
+  const currentTop = entries.slice(0, topN);
+
+  // Remove stale series for streams that were in the previous top-N but are
+  // no longer in the current top-N.
+  const currentIds = new Set<string>();
+  for (const [streamId] of currentTop) {
+    currentIds.add(streamId);
+  }
+
+  for (const prevId of previousTopStreamIds) {
+    if (!currentIds.has(prevId)) {
+      wsStreamSubscriberCount.remove({ stream_id: prevId });
+    }
+  }
+
+  // Set values for the current top-N.
+  for (const [streamId, count] of currentTop) {
+    wsStreamSubscriberCount.set({ stream_id: streamId }, count);
+  }
+
+  previousTopStreamIds = currentIds;
 }
 
 /**
@@ -142,12 +243,15 @@ export function removeWsClientBackpressureGauge(connectionId: string): void {
 }
 
 /**
- * Reset all WS backpressure gauges to 0/empty. Useful between test runs.
+ * Reset all WS backpressure gauges to 0/empty and clear the subscription
+ * cardinality tracking state. Useful between test runs.
  */
 export function resetWsBackpressureMetrics(): void {
   wsClientBufferedBytes.reset();
   wsMaxBufferedBytes.set(0);
   wsSlowClients.set(0);
+  wsStreamSubscriberCount.reset();
+  previousTopStreamIds = new Set();
 }
 
 /**

--- a/src/ws/hub.ts
+++ b/src/ws/hub.ts
@@ -885,6 +885,18 @@ export class StreamHub extends EventEmitter {
     return this.clients.entries();
   }
 
+  /**
+   * Internal entry-point used by the subscription cardinality collector to
+   * enumerate stream subscription counts. Underscore-prefixed because it
+   * exposes internal map references — callers MUST treat them as read-only.
+   *
+   * @security Exposes only streamId keys and subscriber Set sizes; no
+   *           WebSocket references or client state is leaked.
+   */
+  _getStreamSubscriptions(): ReadonlyMap<string, Set<WebSocket>> {
+    return this.streamSubscriptions;
+  }
+
   getMetrics(): Readonly<BackpressureMetrics> {
     return { ...this.metrics };
   }

--- a/tests/ws/hub.subscriptionCardinality.test.ts
+++ b/tests/ws/hub.subscriptionCardinality.test.ts
@@ -1,0 +1,274 @@
+/**
+ * tests/ws/hub.subscriptionCardinality.test.ts
+ *
+ * Stub-based unit tests for the subscription cardinality gauge
+ * (`fluxora_ws_stream_subscriber_count`). Exercises the top-N cap,
+ * stale-series removal, empty-hub edge case, custom top-N, and the
+ * reset invariant.
+ *
+ * Follows the same stub pattern as hub.backpressureGauge.unit.test.ts
+ * to avoid the `createSlowClient` fixture and keep tests deterministic.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import type { WebSocket } from 'ws';
+import {
+  collectWsBackpressureMetrics,
+  resetWsBackpressureMetrics,
+  wsStreamSubscriberCount,
+} from '../../src/metrics/wsBackpressure.js';
+import { DEFAULT_WS_STREAM_CARDINALITY_TOP_N } from '../../src/metrics/wsBackpressure.js';
+
+// ── Stubs ──────────────────────────────────────────────────────────────────
+
+interface StubSocket {
+  OPEN: 1;
+  CLOSING: 2;
+  CLOSED: 3;
+  readyState: number;
+  bufferedAmount: number;
+}
+
+const stubSocket = (buffered = 0): StubSocket => ({
+  OPEN: 1,
+  CLOSING: 2,
+  CLOSED: 3,
+  readyState: 1,
+  bufferedAmount: buffered,
+});
+
+interface FakeClientState {
+  id: string;
+}
+
+/**
+ * Builds a hub stand-in with `_getClients()` and `_getStreamSubscriptions()`.
+ */
+function makeFakeHub(opts: {
+  clients?: Array<[StubSocket, FakeClientState]>;
+  streamSubscriptions?: Map<string, Set<StubSocket>>;
+}) {
+  const clients = opts.clients ?? [];
+  const streamSubscriptions = opts.streamSubscriptions ?? new Map();
+
+  return {
+    _getClients: function* () {
+      for (const entry of clients) yield entry;
+    },
+    _getStreamSubscriptions(): ReadonlyMap<string, Set<StubSocket>> {
+      return streamSubscriptions;
+    },
+  };
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type AnyHub = any;
+
+// ── Helpers ─────────────────────────────────────────────────────────────────
+
+async function readStreamLabel(
+  streamId: string,
+): Promise<number | null> {
+  const result = (await wsStreamSubscriberCount.get()) as {
+    values: Array<{ labels: Record<string, string>; value: number }>;
+  };
+  const match = result.values.find((v) => v.labels?.stream_id === streamId);
+  return match ? match.value : null;
+}
+
+async function readAllStreamLabels(): Promise<Map<string, number>> {
+  const result = (await wsStreamSubscriberCount.get()) as {
+    values: Array<{ labels: Record<string, string>; value: number }>;
+  };
+  const map = new Map<string, number>();
+  for (const v of result.values) {
+    map.set(v.labels.stream_id, v.value);
+  }
+  return map;
+}
+
+// ── Tests ───────────────────────────────────────────────────────────────────
+
+describe('Subscription cardinality gauge (stub-based unit tests)', () => {
+  beforeEach(() => {
+    resetWsBackpressureMetrics();
+  });
+
+  afterEach(() => {
+    resetWsBackpressureMetrics();
+  });
+
+  it('reports subscriber counts for streams when hub has subscriptions', async () => {
+    const streamSubs = new Map<string, Set<StubSocket>>();
+    streamSubs.set('stream-A', new Set([stubSocket(), stubSocket(), stubSocket()]));
+    streamSubs.set('stream-B', new Set([stubSocket(), stubSocket()]));
+
+    const hub = makeFakeHub({ streamSubscriptions: streamSubs });
+
+    collectWsBackpressureMetrics(hub as AnyHub);
+
+    expect(await readStreamLabel('stream-A')).toBe(3);
+    expect(await readStreamLabel('stream-B')).toBe(2);
+  });
+
+  it('caps label cardinality to top-N (default 20)', async () => {
+    const streamSubs = new Map<string, Set<StubSocket>>();
+
+    // Create 25 streams with 1-25 subscribers respectively.
+    for (let i = 1; i <= 25; i++) {
+      const subs = new Set<StubSocket>();
+      for (let j = 0; j < i; j++) subs.add(stubSocket());
+      streamSubs.set(`stream-${String(i).padStart(2, '0')}`, subs);
+    }
+
+    const hub = makeFakeHub({ streamSubscriptions: streamSubs });
+    collectWsBackpressureMetrics(hub as AnyHub);
+
+    const all = await readAllStreamLabels();
+
+    // Should have exactly 20 streams reported (top 20 by subscriber count).
+    expect(all.size).toBe(DEFAULT_WS_STREAM_CARDINALITY_TOP_N);
+
+    // stream-01 (1 subscriber) should NOT be in the top 20.
+    expect(all.has('stream-01')).toBe(false);
+
+    // stream-06 (6 subscribers) should be the smallest in the top 20.
+    expect(all.has('stream-06')).toBe(true);
+
+    // stream-25 (25 subscribers) should be the largest.
+    expect(all.get('stream-25')).toBe(25);
+  });
+
+  it('removes stale series when a stream drops out of top-N', async () => {
+    // First cycle: streams A(10), B(5), C(3), D(1) — all in top-4.
+    const subs1 = new Map<string, Set<StubSocket>>();
+    subs1.set('A', new Set(Array(10).fill(null).map(() => stubSocket())));
+    subs1.set('B', new Set(Array(5).fill(null).map(() => stubSocket())));
+    subs1.set('C', new Set(Array(3).fill(null).map(() => stubSocket())));
+    subs1.set('D', new Set([stubSocket()]));
+
+    const hub1 = makeFakeHub({ streamSubscriptions: subs1 });
+    collectWsBackpressureMetrics(hub1 as AnyHub, 1_048_576, 4);
+
+    let all = await readAllStreamLabels();
+    expect(all.size).toBe(4);
+    expect(all.has('D')).toBe(true);
+
+    // Second cycle: E(20) enters, D(1) drops out of top-4.
+    const subs2 = new Map<string, Set<StubSocket>>();
+    subs2.set('A', new Set(Array(10).fill(null).map(() => stubSocket())));
+    subs2.set('B', new Set(Array(5).fill(null).map(() => stubSocket())));
+    subs2.set('C', new Set(Array(3).fill(null).map(() => stubSocket())));
+    subs2.set('E', new Set(Array(20).fill(null).map(() => stubSocket())));
+
+    const hub2 = makeFakeHub({ streamSubscriptions: subs2 });
+    collectWsBackpressureMetrics(hub2 as AnyHub, 1_048_576, 4);
+
+    all = await readAllStreamLabels();
+    expect(all.size).toBe(4);
+    expect(all.has('D')).toBe(false);
+    expect(all.has('E')).toBe(true);
+    expect(all.get('E')).toBe(20);
+  });
+
+  it('reports no series when hub has zero streams', async () => {
+    const hub = makeFakeHub({ streamSubscriptions: new Map() });
+    collectWsBackpressureMetrics(hub as AnyHub);
+
+    const all = await readAllStreamLabels();
+    expect(all.size).toBe(0);
+  });
+
+  it('clears all series when streams go from many to zero', async () => {
+    const subs = new Map<string, Set<StubSocket>>();
+    subs.set('X', new Set(Array(5).fill(null).map(() => stubSocket())));
+    subs.set('Y', new Set(Array(3).fill(null).map(() => stubSocket())));
+
+    const hub1 = makeFakeHub({ streamSubscriptions: subs });
+    collectWsBackpressureMetrics(hub1 as AnyHub, 1_048_576, 10);
+    expect((await readAllStreamLabels()).size).toBe(2);
+
+    // All streams removed.
+    const hub2 = makeFakeHub({ streamSubscriptions: new Map() });
+    collectWsBackpressureMetrics(hub2 as AnyHub, 1_048_576, 10);
+    expect((await readAllStreamLabels()).size).toBe(0);
+  });
+
+  it('supports a custom top-N value', async () => {
+    const subs = new Map<string, Set<StubSocket>>();
+    subs.set('a', new Set(Array(10).fill(null).map(() => stubSocket())));
+    subs.set('b', new Set(Array(5).fill(null).map(() => stubSocket())));
+    subs.set('c', new Set(Array(1).fill(null).map(() => stubSocket())));
+
+    const hub = makeFakeHub({ streamSubscriptions: subs });
+    collectWsBackpressureMetrics(hub as AnyHub, 1_048_576, 2);
+
+    const all = await readAllStreamLabels();
+    expect(all.size).toBe(2);
+    expect(all.has('c')).toBe(false);
+    expect(all.get('a')).toBe(10);
+    expect(all.get('b')).toBe(5);
+  });
+
+  it('ranks streams with equal subscriber counts arbitrarily but consistently', async () => {
+    const subs = new Map<string, Set<StubSocket>>();
+    subs.set('equal-1', new Set(Array(5).fill(null).map(() => stubSocket())));
+    subs.set('equal-2', new Set(Array(5).fill(null).map(() => stubSocket())));
+    subs.set('equal-3', new Set(Array(5).fill(null).map(() => stubSocket())));
+
+    const hub = makeFakeHub({ streamSubscriptions: subs });
+    collectWsBackpressureMetrics(hub as AnyHub, 1_048_576, 2);
+
+    const all = await readAllStreamLabels();
+    expect(all.size).toBe(2);
+
+    // All equal streams have 5 subscribers.
+    for (const val of all.values()) {
+      expect(val).toBe(5);
+    }
+  });
+
+  it('resets the cardinality gauge state via resetWsBackpressureMetrics', async () => {
+    const subs = new Map<string, Set<StubSocket>>();
+    subs.set('reset-me', new Set(Array(3).fill(null).map(() => stubSocket())));
+
+    const hub = makeFakeHub({ streamSubscriptions: subs });
+    collectWsBackpressureMetrics(hub as AnyHub, 1_048_576, 10);
+    expect(await readStreamLabel('reset-me')).toBe(3);
+
+    resetWsBackpressureMetrics();
+
+    const all = await readAllStreamLabels();
+    expect(all.size).toBe(0);
+  });
+
+  it('handles streams with zero subscribers (empty Set)', async () => {
+    const subs = new Map<string, Set<StubSocket>>();
+    subs.set('empty-stream', new Set());
+    subs.set('populated', new Set([stubSocket(), stubSocket()]));
+
+    const hub = makeFakeHub({ streamSubscriptions: subs });
+    collectWsBackpressureMetrics(hub as AnyHub, 1_048_576, 10);
+
+    const all = await readAllStreamLabels();
+    expect(all.size).toBe(2);
+    expect(all.get('empty-stream')).toBe(0);
+    expect(all.get('populated')).toBe(2);
+  });
+
+  it('produces stable output across consecutive identical collections', async () => {
+    const subs = new Map<string, Set<StubSocket>>();
+    subs.set('stable-1', new Set(Array(7).fill(null).map(() => stubSocket())));
+    subs.set('stable-2', new Set(Array(3).fill(null).map(() => stubSocket())));
+
+    const hub = makeFakeHub({ streamSubscriptions: subs });
+
+    collectWsBackpressureMetrics(hub as AnyHub, 1_048_576, 10);
+    const first = await readAllStreamLabels();
+
+    collectWsBackpressureMetrics(hub as AnyHub, 1_048_576, 10);
+    const second = await readAllStreamLabels();
+
+    expect(second).toEqual(first);
+  });
+});


### PR DESCRIPTION
Add `fluxora_ws_stream_subscriber_count{stream_id=…}` Prometheus gauge reporting the top-20 streams by subscriber count so operators can spot a single hot stream driving disproportionate broadcast fan-out before it causes backpressure incidents.

Changes:
- src/ws/hub.ts: add _getStreamSubscriptions() accessor exposing the internal streamSubscriptions map to the metrics collector
- src/metrics/wsBackpressure.ts: add wsStreamSubscriberCount gauge with bounded cardinality (top-N, default 20), stale-series removal via collectStreamSubscriberCardinality(), and updated resetWsBackpressureMetrics()
- tests/ws/hub.subscriptionCardinality.test.ts: 10 stub-based unit tests covering top-N cap, stale-series removal, empty hub, custom top-N, equal counts, reset, and stability across consecutive collections
- docs/observability.md: document the new metric, PromQL examples, thresholding strategy, cardinality/security guarantees, and affected source files

All 63 WS tests pass (including the 10 new tests). The collector reuses the existing periodic collectWsBackpressureMetrics timer with no second timer added. Cardinality is capped at 20 by default and the stream_id label is application-assigned (no PII, no client-controlled data).
closes #753