### PR TITLE
feat(dlq): add admin endpoint for optimistic replay of dead-letter en…

### DIFF
--- a/migrations/1784888700000_add_dead_letter_queue_status.ts
+++ b/migrations/1784888700000_add_dead_letter_queue_status.ts
@@ -1,0 +1,19 @@
+
+import { ColumnDefinitions, MigrationBuilder } from 'node-pg-migrate';
+
+export const shorthands: ColumnDefinitions | undefined = undefined;
+
+export async function up(pgm: MigrationBuilder): Promise<void> {
+  pgm.addColumn('dead_letter_queue', {
+    status: {
+      type: 'text',
+      notNull: true,
+      default: 'dead',
+      check: "status IN ('dead', 'replayed')",
+    },
+  });
+}
+
+export async function down(pgm: MigrationBuilder): Promise<void> {
+  pgm.dropColumn('dead_letter_queue', 'status');
+}

--- a/src/db/repositories/dlqRepository.ts
+++ b/src/db/repositories/dlqRepository.ts
@@ -91,6 +91,7 @@ function rowToEntry(row: Record<string, unknown>): DlqEntry {
     correlationId: row['correlation_id'] as string | undefined,
     firstFailedAt: (row['first_failed_at'] as Date).toISOString(),
     lastFailedAt:  (row['last_failed_at']  as Date).toISOString(),
+    status:        row['status']         as 'dead' | 'replayed',
   };
 }
 
@@ -116,8 +117,8 @@ export const dlqRepository = {
     await query(
       pool,
       `INSERT INTO dead_letter_queue
-         (id, topic, payload, error, attempts, correlation_id, first_failed_at, last_failed_at)
-       VALUES ($1, $2, $3, $4, $5, $6, $7, $8)`,
+         (id, topic, payload, error, attempts, correlation_id, first_failed_at, last_failed_at, status)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)`,
       [
         entry.id,
         entry.topic,
@@ -127,6 +128,7 @@ export const dlqRepository = {
         entry.correlationId ?? null,
         entry.firstFailedAt,
         entry.lastFailedAt,
+        entry.status ?? 'dead',
       ],
     );
   },
@@ -201,6 +203,25 @@ export const dlqRepository = {
     }
     const result = await query(pool, 'DELETE FROM dead_letter_queue');
     return result.rowCount ?? 0;
+  },
+
+  async replayEntry(id: string, patch: Partial<Pick<DlqEntry, 'attempts' | 'lastFailedAt'>>): Promise<boolean> {
+    const pool = getPool();
+    const sets: string[] = [];
+    const params: unknown[] = [];
+    let idx = 1;
+
+    if (patch.attempts !== undefined) { sets.push(`attempts = $${idx++}`); params.push(patch.attempts); }
+    if (patch.lastFailedAt !== undefined) { sets.push(`last_failed_at = $${idx++}`); params.push(patch.lastFailedAt); }
+    sets.push(`status = $${idx++}`); params.push('replayed');
+
+    params.push(id);
+    const result = await query(
+      pool,
+      `UPDATE dead_letter_queue SET ${sets.join(', ')} WHERE id = $${idx} AND status = 'dead'`,
+      params
+    );
+    return (result.rowCount ?? 0) > 0;
   },
 
   // ── Consumer suspension ─────────────────────────────────────────────────────

--- a/src/routes/dlq.ts
+++ b/src/routes/dlq.ts
@@ -47,6 +47,7 @@ export interface DlqEntry {
   firstFailedAt: string;
   lastFailedAt: string;
   correlationId?: string;
+  status?: 'dead' | 'replayed';
 }
 
 /** Enqueue a dead-letter entry. Called by internal workers. */
@@ -179,10 +180,19 @@ dlqRouter.post(
       return;
     }
 
-    // ── Reset attempt counter and record outcome ──────────────────────────────
+    // ── Reset attempt counter and record outcome, with optimistic concurrency ──
     const replayFailed = req.body?.failed === true;
 
-    await dlqRepository.update(entry.id, { attempts: 0, lastFailedAt: new Date().toISOString() });
+    const replayed = await dlqRepository.replayEntry(entry.id, { attempts: 0, lastFailedAt: new Date().toISOString() });
+    if (!replayed) {
+      res.status(409).json(errorResponse(
+        'ENTRY_ALREADY_REPLAYED',
+        `DLQ entry '${entry.id}' has already been replayed or resolved.`,
+        undefined,
+        req.id,
+      ));
+      return;
+    }
 
     if (replayFailed) {
       const updated = await dlqRepository.recordReplayFailure(entry.topic);

--- a/tests/routes/admin.dlq.test.ts
+++ b/tests/routes/admin.dlq.test.ts
@@ -30,6 +30,7 @@ const mockRepo = vi.hoisted(() => ({
   recordReplayFailure:     vi.fn(),
   recordReplaySuccess:     vi.fn(),
   resumeConsumer:          vi.fn(),
+  replayEntry:             vi.fn(),
 }));
 
 vi.mock('../../src/db/repositories/dlqRepository.js', () => ({
@@ -71,6 +72,7 @@ const ENTRY = {
   firstFailedAt: '2026-01-01T00:00:00.000Z',
   lastFailedAt:  '2026-01-02T00:00:00.000Z',
   correlationId: 'corr-1',
+  status: 'dead' as const,
 };
 
 const SUSPENSION_NONE = null;
@@ -274,12 +276,13 @@ describe('POST /admin/dlq/:id/replay', () => {
     expect(res.body.error.code).toBe('CONSUMER_SUSPENDED');
     expect(res.body.error.message).toContain('stream.created');
     // Replay must NOT proceed when suspended
-    expect(mockRepo.update).not.toHaveBeenCalled();
+    expect(mockRepo.replayEntry).not.toHaveBeenCalled();
   });
 
   it('resets attempt counter and records success on successful replay', async () => {
     mockRepo.findById.mockResolvedValue(ENTRY);
     mockRepo.getConsumerSuspension.mockResolvedValue(SUSPENSION_NONE);
+    mockRepo.replayEntry.mockResolvedValue(true);
 
     const res = await request(app)
       .post('/admin/dlq/dlq-001/replay')
@@ -287,14 +290,28 @@ describe('POST /admin/dlq/:id/replay', () => {
 
     expect(res.status).toBe(200);
     expect(res.body.data.id).toBe('dlq-001');
-    expect(mockRepo.update).toHaveBeenCalledWith('dlq-001', expect.objectContaining({ attempts: 0 }));
+    expect(mockRepo.replayEntry).toHaveBeenCalledWith('dlq-001', expect.objectContaining({ attempts: 0 }));
     expect(mockRepo.recordReplaySuccess).toHaveBeenCalledWith('stream.created');
     expect(mockRepo.recordReplayFailure).not.toHaveBeenCalled();
+  });
+
+  it('returns 409 ENTRY_ALREADY_REPLAYED when entry is not dead (already replayed)', async () => {
+    mockRepo.findById.mockResolvedValue(ENTRY);
+    mockRepo.getConsumerSuspension.mockResolvedValue(SUSPENSION_NONE);
+    mockRepo.replayEntry.mockResolvedValue(false);
+
+    const res = await request(app)
+      .post('/admin/dlq/dlq-001/replay')
+      .set('Authorization', `Bearer ${operatorToken}`);
+
+    expect(res.status).toBe(409);
+    expect(res.body.error.code).toBe('ENTRY_ALREADY_REPLAYED');
   });
 
   it('records failure and emits audit when failed=true (#349)', async () => {
     mockRepo.findById.mockResolvedValue(ENTRY);
     mockRepo.getConsumerSuspension.mockResolvedValue(SUSPENSION_NONE);
+    mockRepo.replayEntry.mockResolvedValue(true);
     mockRepo.recordReplayFailure.mockResolvedValue({
       ...SUSPENSION_HEALTHY,
       consecutiveFailures: 3,
@@ -306,6 +323,7 @@ describe('POST /admin/dlq/:id/replay', () => {
       .send({ failed: true });
 
     expect(res.status).toBe(200);
+    expect(mockRepo.replayEntry).toHaveBeenCalled();
     expect(mockRepo.recordReplayFailure).toHaveBeenCalledWith('stream.created');
     expect(mockRepo.recordReplaySuccess).not.toHaveBeenCalled();
   });
@@ -313,6 +331,7 @@ describe('POST /admin/dlq/:id/replay', () => {
   it('emits DLQ_CONSUMER_SUSPENDED audit event when threshold is reached (#349)', async () => {
     mockRepo.findById.mockResolvedValue(ENTRY);
     mockRepo.getConsumerSuspension.mockResolvedValue(SUSPENSION_NONE);
+    mockRepo.replayEntry.mockResolvedValue(true);
     // Simulate threshold being reached on this failure
     mockRepo.recordReplayFailure.mockResolvedValue({
       ...SUSPENSION_ACTIVE,
@@ -334,6 +353,7 @@ describe('POST /admin/dlq/:id/replay', () => {
   it('emits DLQ_REPLAYED audit event on success', async () => {
     mockRepo.findById.mockResolvedValue(ENTRY);
     mockRepo.getConsumerSuspension.mockResolvedValue(SUSPENSION_NONE);
+    mockRepo.replayEntry.mockResolvedValue(true);
 
     await request(app)
       .post('/admin/dlq/dlq-001/replay')


### PR DESCRIPTION
closes #678 
…tries

# Add Optimistic Concurrency Control for DLQ Entry Replay

## Summary

Add optimistic concurrency control (OCC) to the DLQ entry replay endpoint to prevent accidental double-processing of dead-lettered entries when concurrent replay requests are processed at the same time.

## Problem Statement

The existing `POST /admin/dlq/:id/replay` endpoint at [src/routes/dlq.ts](file:///c:/Users/yunus/Desktop/Fluxora-Backend678/src/routes/dlq.ts) had a race condition:

```
1. Request A: fetch entry, status = 'dead' → ok
2. Request B: fetch entry, status = 'dead' → ok (race!)
3. Request A: update status to 'replayed', attempts 0, lastFailedAt now
4. Request B: update status to 'replayed', attempts 0, lastFailedAt now
```

**Impact**: This could lead to double-processing of webhook deliveries, invoices, or other events, causing duplicate side effects and potential financial or business logic errors.

## Root Cause Analysis

The issue was that there was no status check or locking mechanism when updating the entry during replay operation. The `dlqRepository.update` method didn't verify that the entry was still in the 'dead' state before applying the update.

## Solution

### 1. Add `status` column to `dead_letter_queue` table
**File**: [migrations/1784888700000_add_dead_letter_queue_status.ts](file:///c:/Users/yunus/Desktop/Fluxora-Backend678/migrations/1784888700000_add_dead_letter_queue_status.ts)

- Add a `status` column to track the entry state:
  - Default value: `'dead'`
  - Check constraint to only allow values: `'dead'` or `'replayed'`

### 2. Update DlqEntry type
**File**: [src/routes/dlq.ts](file:///c:/Users/yunus/Desktop/Fluxora-Backend678/src/routes/dlq.ts)

Add `status?: 'dead' | 'replayed'` to the DlqEntry interface

### 3. Update dlqRepository
**File**: [src/db/repositories/dlqRepository.ts](file:///c:/Users/yunus/Desktop/Fluxora-Backend678/src/db/repositories/dlqRepository.ts)

- Update `rowToEntry` to map the status column from DB
- Update `insert` to include status when inserting a new entry
- Add `replayEntry` method with optimistic concurrency control
  - Only updates the entry if `status = 'dead'`
  - Uses `rowCount > 0` to determine success/failure
  - Returns true if successful, false if not

### 4. Update replay endpoint
**File**: [src/routes/dlq.ts](file:///c:/Users/yunus/Desktop/Fluxora-Backend678/src/routes/dlq.ts)

- Use `dlqRepository.replayEntry` instead of `dlqRepository.update`
- If `replayEntry` returns false → returns 409 Conflict with error code `ENTRY_ALREADY_REPLAYED`

### 5. Update tests
**File**: [tests/routes/admin.dlq.test.ts](file:///c:/Users/yunus/Desktop/Fluxora-Backend678/tests/routes/admin.dlq.test.ts)

- Add replayEntry to the mock repository
- Add test case for concurrent replay conflict
- Update existing tests for new method

## Testing

```bash
# Run admin dlq tests specifically
pnpm test -- tests/routes/admin.dlq.test.ts

# Expected output:
# Test Files  1 passed (1)
#      Tests  28 passed (28)
```

## Files Changed

- [migrations/1784888700000_add_dead_letter_queue_status.ts](file:///c:/Users/yunus/Desktop/Fluxora-Backend678/migrations/1784888700000_add_dead_letter_queue_status.ts)
- [src/routes/dlq.ts](file:///c:/Users/yunus/Desktop/Fluxora-Backend678/src/routes/dlq.ts)
- [src/db/repositories/dlqRepository.ts](file:///c:/Users/yunus/Desktop/Fluxora-Backend678/src/db/repositories/dlqRepository.ts)
- [tests/routes/admin.dlq.test.ts](file:///c:/Users/yunus/Desktop/Fluxora-Backend678/tests/routes/admin.dlq.test.ts)

## Security Notes

- The replay endpoint now uses optimistic concurrency control:
  - Only successful if the entry's status is still 'dead' when the update is applied
  - Uses database-level check ensures atomicity
  - Returns 409 Conflict if already replayed
  - Audit logging remains intact (existing DLQ_REPLAYED event is still recorded)
