### PR TITLE
Add Redis leader election for indexer replay and gRPC health service

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -11,3 +11,31 @@ Fluxora's Docker container features parameterised health checks to accommodate d
 - `HEALTH_CHECK_TIMEOUT_MS` (Default: `5000`): Maximum time allowed for internal liveness checks.
 
 *Note: Runtime timeout values must be strictly greater than 0.*
+
+### gRPC Health Check (Kubernetes-native probes)
+
+Kubernetes' built-in gRPC probes (`livenessProbe.grpc` / `readinessProbe.grpc`, and the standalone `grpc-health-probe` binary) speak the standard `grpc.health.v1.Health` protocol rather than plain HTTP. Fluxora can expose this alongside the existing HTTP `/health` endpoints, on a separate port so it never competes with API traffic.
+
+**Runtime Environment Variables (App Level):**
+- `GRPC_HEALTH_ENABLED` (Default: `false`): Enables the gRPC health service.
+- `GRPC_HEALTH_PORT` (Default: `50051`): Port the gRPC health service binds to. Must differ from `PORT` (the HTTP port).
+
+The service reuses the exact same `HealthCheckManager` dependency checks as `/health/ready` (`src/config/health.ts`) — it does not re-implement or duplicate any check logic, so the two surfaces cannot drift out of sync. `healthy` and `degraded` both map to `SERVING` (matching `/health/ready`'s 200 response for both statuses); `unhealthy` maps to `NOT_SERVING`.
+
+**Security note:** like the internal HTTP endpoints documented above, the gRPC health port is intentionally unauthenticated — Kubernetes probes and `grpc-health-probe` don't send credentials. This port must **not** be exposed outside the cluster network (no public LoadBalancer/Ingress); bind it only to a `ClusterIP` service or rely on the pod's default internal-only networking.
+
+**Example — `grpc-health-probe` (manual check):**
+```bash
+grpc-health-probe -addr=localhost:50051
+```
+
+**Example — Kubernetes probe configuration:**
+```yaml
+livenessProbe:
+  grpc:
+    port: 50051
+readinessProbe:
+  grpc:
+    port: 50051
+  periodSeconds: 10
+```

--- a/docs/indexer.md
+++ b/docs/indexer.md
@@ -275,6 +275,25 @@ Only one replay can run at a time to prevent:
 - Memory pressure from multiple large operations
 - Conflicting progress tracking
 
+This is enforced at two layers:
+1. **In-process** (`ReplayLock` in `src/indexer/service.ts`): rejects a second concurrent call within the same process instantly, no Redis round-trip required.
+2. **Cross-process** (`IndexerLeaderElection` in `src/indexer/leaderElection.ts`): a Redis-backed lease that ensures only one *replica* runs replay at a time in a multi-instance deployment. See "Multi-Replica Leader Election" below.
+
+### Multi-Replica Leader Election
+
+In a multi-replica deployment, every instance shares the same `replay_cursors` table but previously had no way to coordinate *which instance* should actually run a replay — the in-process `ReplayLock` only prevented two concurrent calls on the *same* process. `IndexerLeaderElection` (`src/indexer/leaderElection.ts`) closes that gap with a Redis-backed lease:
+
+- **Acquisition**: `SET NX PX` on a single fixed key (`indexer:leader-election:replay`) — whichever instance sets it first becomes leader for the lease duration (default 15s).
+- **Renewal**: the leader renews the lease on a heartbeat (default every `leaseMs / 3`) via `PEXPIRE`, but only after confirming via `GET` that it still holds the key. If another instance's value is found (meaning our lease already lapsed), or the `PEXPIRE` itself fails, we drop leadership immediately.
+- **Abort on lease loss**: `replayEvents()` checks `isLeader()` at every batch boundary (the same place it already checks the shutdown `_stopRequested` flag). If leadership is lost mid-replay — most likely because Redis was unreachable for a full lease period — the loop stops cleanly after the in-flight batch's transaction has committed. No connection is left open and no batch is left half-committed.
+- **Startup auto-resume**: `resumeIncompleteReplay()` (called once per process on startup) only proceeds if this instance is the leader, so replicas don't all race to resume the same incomplete cursor.
+- **Fail-safe default**: when Redis is disabled (`REDIS_ENABLED=false`) or unreachable, `NoOpLeaderElection` is used instead — every instance is always "leader", which is exactly today's single-process behaviour. Multi-replica coordination only activates once Redis is configured.
+- **Graceful shutdown**: the lease is released via a `shutdown.ts` hook (`src/app.ts`), after the replay-stop signal is sent but before Redis connections are closed, so another replica can take over promptly instead of waiting out the full lease TTL.
+
+**Operational note — Redis outage**: if Redis becomes unreachable, no instance can acquire or renew the lease, so replay simply does not run anywhere until Redis recovers. This is intentional (fail-safe, not fail-open) — no data is lost, since durable progress lives entirely in `replay_cursors.last_committed_offset`, independent of the lease.
+
+**Security note — non-atomic renew/release**: like the existing `RedisDistributedLock` (`src/state/adminStateLock.ts`), lease renewal and release are check-then-act sequences (`GET` then `PEXPIRE`/`DEL`), not Lua-atomic compare-and-swap. This is an accepted, pre-existing class of risk in this codebase, not a new one introduced here. The worst case is a brief window — bounded by `renewIntervalMs` — where two instances both believe they are leader. Because every batch INSERT already uses `ON CONFLICT (event_id) DO NOTHING` (see "Idempotency" above), a second instance briefly replaying the same range produces no duplicate rows, so this window cannot corrupt data — only cause temporarily duplicated (but harmless) work.
+
 ### Transaction Safety
 
 All replay operations run in transactions:
@@ -410,7 +429,7 @@ WHERE contract_id = 'contract-abc-123' AND ledger = 1;
 
 ## Future Enhancements
 
-- [ ] Persistent replay state (Redis/database) for multi-instance deployments
+- [x] Persistent replay state (Redis/database) for multi-instance deployments — see "Multi-Replica Leader Election" above
 - [ ] Pause/resume replay operations
 - [ ] Replay queue for multiple contracts
 - [ ] Webhook notifications on replay completion

--- a/package.json
+++ b/package.json
@@ -34,6 +34,8 @@
   "license": "MIT",
   "dependencies": {
     "@asteasolutions/zod-to-openapi": "8.5.0",
+    "@grpc/grpc-js": "1.14.4",
+    "@grpc/proto-loader": "0.8.1",
     "@opentelemetry/api": "^1.9.0",
     "@opentelemetry/exporter-trace-otlp-http": "^0.57.2",
     "@opentelemetry/instrumentation-express": "^0.46.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,12 @@ importers:
       '@asteasolutions/zod-to-openapi':
         specifier: 8.5.0
         version: 8.5.0(zod@4.4.3)
+      '@grpc/grpc-js':
+        specifier: 1.14.4
+        version: 1.14.4
+      '@grpc/proto-loader':
+        specifier: 0.8.1
+        version: 0.8.1
       '@opentelemetry/api':
         specifier: ^1.9.0
         version: 1.9.1

--- a/src/app.ts
+++ b/src/app.ts
@@ -14,6 +14,7 @@ import { privacyHeaders } from './middleware/pii.js';
 import type { Config } from './config/env.js';
 import { loadConfig } from './config/env.js';
 import type { HealthCheckManager } from './config/health.js';
+import { createGrpcHealthServer, startGrpcHealthServer, stopGrpcHealthServer } from './health/grpcHealth.js';
 import { createRedisClient } from './redis/client.js';
 import { RedisIdempotencyStore, NoOpIdempotencyStore } from './redis/idempotencyStore.js';
 import {
@@ -41,6 +42,7 @@ import { isShuttingDown, addShutdownHook } from './shutdown.js';
 import { startRuntimeMetrics, stopRuntimeMetrics } from './metrics/runtimeMetrics.js';
 import { drainSseEventBus } from './streams/sseEmitter.js';
 import { requestStopReplay } from './indexer/service.js';
+import { initializeIndexerLeaderElection, getIndexerLeaderElection } from './indexer/leaderElection.js';
 import { quitAllRedisClients } from './redis/client.js';
 import { initializeAdminStateLock } from './state/adminState.js';
 import { createRateLimiter } from './middleware/rateLimiter.js';
@@ -224,6 +226,53 @@ async function wireAdminStateLock(config: Config): Promise<void> {
   }
 }
 
+/**
+ * Wire Redis-backed distributed leader election for indexer replay.
+ *
+ * When `REDIS_ENABLED=true` (the default): wires a Redis-backed lease so only
+ * one replica runs indexer replay at a time in a multi-instance deployment.
+ * Falls back to the always-leader `NoOpLeaderElection` (today's single-process
+ * behaviour) when Redis is disabled or unreachable.
+ *
+ * This function never rejects — all errors are caught and logged internally.
+ */
+async function wireIndexerLeaderElection(config: Config): Promise<void> {
+  if (!config.redisEnabled) {
+    logger.info(
+      'Redis disabled — indexer replay leader election running in always-leader (single-instance) mode',
+      undefined,
+      { component: 'indexer-leader-election' },
+    );
+    return;
+  }
+
+  try {
+    const redisClient = await createRedisClient({
+      url: config.redisUrl,
+      enabled: config.redisEnabled,
+      mode: config.redisMode,
+      sentinelHosts: config.redisSentinelHosts,
+      sentinelName: config.redisSentinelName,
+      clusterNodes: config.redisClusterNodes,
+    });
+
+    initializeIndexerLeaderElection(redisClient);
+
+    logger.info('Redis indexer leader election wired', undefined, {
+      component: 'indexer-leader-election',
+    });
+  } catch (err) {
+    logger.warn(
+      'Redis connection failed for indexer leader election — falling back to always-leader mode',
+      undefined,
+      {
+        component: 'indexer-leader-election',
+        error: err instanceof Error ? err.message : String(err),
+      },
+    );
+  }
+}
+
 export function createApp(options: AppOptions = {}): Express {
   const app = express();
   const env = options.env ?? (process.env as Record<string, string | undefined>);
@@ -239,9 +288,13 @@ export function createApp(options: AppOptions = {}): Express {
   // Shutdown hook ordering (runs after server.close() drains HTTP):
   //   1. Drain SSE — close open event-stream responses with retry:0.
   //   2. Stop indexer — signal replay loop to stop at next safe batch boundary.
-  //   3. Quit Redis — close all tracked Redis sockets.
+  //   3. Release the indexer leader-election lease — must happen before Redis
+  //      is closed, and after replay has been signalled to stop, so another
+  //      instance can take over promptly instead of waiting out the full lease.
+  //   4. Quit Redis — close all tracked Redis sockets.
   addShutdownHook(() => drainSseEventBus(appConfig.sseDrainTimeoutMs));
   addShutdownHook(() => requestStopReplay());
+  addShutdownHook(() => getIndexerLeaderElection().release());
   addShutdownHook(() => quitAllRedisClients());
 
   // Expose the limiter on app.locals so index.ts can register a shutdown hook
@@ -264,6 +317,23 @@ export function createApp(options: AppOptions = {}): Express {
   void wireIdempotencyStore(appConfig);
   void wireWebhookCircuitBreakerStore(appConfig);
   void wireAdminStateLock(appConfig);
+  void wireIndexerLeaderElection(appConfig);
+
+  // Optional grpc.health.v1.Health service for Kubernetes-native gRPC probes,
+  // on a separate port from the HTTP server so it never competes with API
+  // traffic. Requires a healthManager (same dependency-check logic as
+  // /health/ready) — without one there is nothing meaningful to reuse.
+  if (options.healthManager && appConfig.grpcHealthEnabled) {
+    const grpcHealthServer = createGrpcHealthServer(options.healthManager);
+    app.locals.grpcHealthServer = grpcHealthServer;
+    startGrpcHealthServer(grpcHealthServer, appConfig.grpcHealthPort).catch((err) => {
+      logger.warn('gRPC health server failed to start', undefined, {
+        component: 'grpc-health',
+        error: err instanceof Error ? err.message : String(err),
+      });
+    });
+    addShutdownHook(() => stopGrpcHealthServer(grpcHealthServer));
+  }
 
   app.use(requestTimeoutMiddleware(options.requestTimeoutMs ?? appConfig.requestTimeoutMs));
   app.use(privacyHeaders);

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -277,6 +277,14 @@ export const EnvSchema = z.object({
    SSE_DRAIN_TIMEOUT_MS: integerEnv('SSE_DRAIN_TIMEOUT_MS', 1_000, 60_000).default(30_000),
    INDEXER_ENABLED: booleanEnv().default(false),
    WORKER_ENABLED: booleanEnv().default(false),
+   /** Per-checker timeout for HealthCheckManager. Must be strictly greater than 0. */
+   HEALTH_CHECK_TIMEOUT_MS: integerEnv('HEALTH_CHECK_TIMEOUT_MS', 1).default(5000),
+   /** Interval between background health-check runs. Must be strictly greater than 0. */
+   HEALTH_CHECK_INTERVAL_MS: integerEnv('HEALTH_CHECK_INTERVAL_MS', 1).default(30000),
+   /** Enables the grpc.health.v1.Health service for Kubernetes-native gRPC probes. */
+   GRPC_HEALTH_ENABLED: booleanEnv().default(false),
+   /** Port the gRPC health service binds to when enabled. Separate from PORT (HTTP). */
+   GRPC_HEALTH_PORT: integerEnv('GRPC_HEALTH_PORT', 1, 65535).default(50051),
    INDEXER_STALL_THRESHOLD_MS: integerEnv('INDEXER_STALL_THRESHOLD_MS', 1000).default(5 * 60 * 1000),
    INDEXER_LAST_SUCCESSFUL_SYNC_AT: optionalString('INDEXER_LAST_SUCCESSFUL_SYNC_AT'),
   DEPLOYMENT_CHECKLIST_VERSION: z.string().min(1).default('2026-03-27'),
@@ -416,6 +424,14 @@ export interface Config {
   sseDrainTimeoutMs: number;
   indexerEnabled: boolean;
   workerEnabled: boolean;
+  /** Per-checker timeout for HealthCheckManager, in ms. */
+  healthCheckTimeoutMs: number;
+  /** Interval between background health-check runs, in ms. */
+  healthCheckIntervalMs: number;
+  /** Enables the grpc.health.v1.Health service (k8s-native gRPC probes). */
+  grpcHealthEnabled: boolean;
+  /** Port the gRPC health service binds to when enabled. */
+  grpcHealthPort: number;
   indexerStallThresholdMs: number;
   indexerLastSuccessfulSyncAt?: string | undefined;
   deploymentChecklistVersion: string;
@@ -571,6 +587,10 @@ function toConfig(env: ParsedEnv): Config {
     sseDrainTimeoutMs: env.SSE_DRAIN_TIMEOUT_MS,
     indexerEnabled: env.INDEXER_ENABLED,
     workerEnabled: env.WORKER_ENABLED,
+    healthCheckTimeoutMs: env.HEALTH_CHECK_TIMEOUT_MS,
+    healthCheckIntervalMs: env.HEALTH_CHECK_INTERVAL_MS,
+    grpcHealthEnabled: env.GRPC_HEALTH_ENABLED,
+    grpcHealthPort: env.GRPC_HEALTH_PORT,
     indexerStallThresholdMs: env.INDEXER_STALL_THRESHOLD_MS,
     indexerLastSuccessfulSyncAt: env.INDEXER_LAST_SUCCESSFUL_SYNC_AT,
     deploymentChecklistVersion: env.DEPLOYMENT_CHECKLIST_VERSION,

--- a/src/config/health.ts
+++ b/src/config/health.ts
@@ -24,6 +24,10 @@ export interface HealthChecker {
 }
 
 export class HealthCheckManager {
+  private readonly checkers = new Map<string, HealthChecker>();
+  private readonly lastResults = new Map<string, DependencyHealth>();
+  private readonly startTime = Date.now();
+
   private get timeoutMs() { return getConfig().healthCheckTimeoutMs; }
   private get intervalMs() { return getConfig().healthCheckIntervalMs; }
 

--- a/src/health/grpcHealth.ts
+++ b/src/health/grpcHealth.ts
@@ -1,0 +1,213 @@
+/**
+ * grpc.health.v1.Health service for Kubernetes-native gRPC health probes
+ * (`grpc-health-probe`, kubelet's built-in gRPC liveness/readiness probes).
+ *
+ * Reuses `HealthCheckManager` — the same dependency-check logic backing the
+ * HTTP `/health/ready` route (src/routes/health.ts) — so the two surfaces
+ * can never drift: `Check`/`Watch` map `healthy`/`degraded` to `SERVING`
+ * and `unhealthy` to `NOT_SERVING`, exactly like `/health/ready`'s 200/503
+ * split.
+ *
+ * The standard proto (see ./health.proto for the human-readable reference)
+ * is parsed from an in-memory string rather than read from disk: the
+ * Docker production image only ships `dist/`, not `src/`, so a runtime
+ * `fs.readFileSync` against `health.proto` would work in dev but fail (or
+ * silently resolve to nothing) once deployed.
+ */
+
+import * as grpc from '@grpc/grpc-js';
+import * as protoLoader from '@grpc/proto-loader';
+import protobuf from 'protobufjs';
+import { getConfig } from '../config/env.js';
+import type { HealthCheckManager, HealthStatus } from '../config/health.js';
+import { logger } from '../lib/logger.js';
+
+// Keep in sync with ./health.proto — the canonical, unmodified grpc.health.v1 spec.
+const HEALTH_PROTO_SOURCE = `
+syntax = "proto3";
+package grpc.health.v1;
+
+message HealthCheckRequest {
+  string service = 1;
+}
+
+message HealthCheckResponse {
+  enum ServingStatus {
+    UNKNOWN = 0;
+    SERVING = 1;
+    NOT_SERVING = 2;
+    SERVICE_UNKNOWN = 3;
+  }
+  ServingStatus status = 1;
+}
+
+service Health {
+  rpc Check(HealthCheckRequest) returns (HealthCheckResponse);
+  rpc Watch(HealthCheckRequest) returns (stream HealthCheckResponse);
+}
+`;
+
+interface HealthCheckRequest {
+  service?: string;
+}
+
+interface HealthCheckResponse {
+  status: 'UNKNOWN' | 'SERVING' | 'NOT_SERVING' | 'SERVICE_UNKNOWN';
+}
+
+function loadHealthServiceDefinition(): grpc.ServiceDefinition {
+  const root = protobuf.parse(HEALTH_PROTO_SOURCE).root;
+  const packageDefinition = protoLoader.fromJSON(root.toJSON(), {
+    keepCase: true,
+    longs: String,
+    enums: String,
+    defaults: true,
+    oneofs: true,
+  });
+  const loaded = grpc.loadPackageDefinition(packageDefinition) as unknown as {
+    grpc: { health: { v1: { Health: { service: grpc.ServiceDefinition } } } };
+  };
+  return loaded.grpc.health.v1.Health.service;
+}
+
+const HEALTH_SERVICE_DEFINITION = loadHealthServiceDefinition();
+
+/** healthy/degraded still serve traffic (matches /health/ready's 200 for both). */
+function mapStatus(status: HealthStatus): HealthCheckResponse['status'] {
+  return status === 'unhealthy' ? 'NOT_SERVING' : 'SERVING';
+}
+
+/**
+ * Resolve the current status via the real dependency checks (`checkAll()`,
+ * not the cached `getLastReport()`) so `Check`/`Watch` reflect live state,
+ * same as `/health/ready`. Never throws: any internal failure fails closed
+ * to NOT_SERVING, since gRPC health-probe clients only understand the
+ * ServingStatus enum, not gRPC error codes.
+ */
+async function resolveServingStatus(
+  healthManager: HealthCheckManager,
+): Promise<HealthCheckResponse['status']> {
+  try {
+    const report = await healthManager.checkAll();
+    return mapStatus(report.status);
+  } catch (err) {
+    logger.error('grpc_health_check_failed', undefined, {
+      event: 'grpc_health_check_failed',
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return 'NOT_SERVING';
+  }
+}
+
+/**
+ * Build (but do not bind/start) the grpc.health.v1.Health server.
+ *
+ * `service` on the request is accepted but ignored — this app reports one
+ * overall status, not per-service granularity, matching /health/ready's
+ * flat status shape.
+ */
+export function createGrpcHealthServer(healthManager: HealthCheckManager): grpc.Server {
+  const server = new grpc.Server();
+
+  server.addService(HEALTH_SERVICE_DEFINITION, {
+    check(
+      _call: grpc.ServerUnaryCall<HealthCheckRequest, HealthCheckResponse>,
+      callback: grpc.sendUnaryData<HealthCheckResponse>,
+    ): void {
+      resolveServingStatus(healthManager)
+        .then((status) => callback(null, { status }))
+        .catch(() => callback(null, { status: 'NOT_SERVING' }));
+    },
+
+    watch(call: grpc.ServerWritableStream<HealthCheckRequest, HealthCheckResponse>): void {
+      let lastStatus: HealthCheckResponse['status'] | null = null;
+      let stopped = false;
+
+      const writeIfChanged = async (): Promise<void> => {
+        const status = await resolveServingStatus(healthManager);
+        if (stopped) return;
+        if (status !== lastStatus) {
+          lastStatus = status;
+          call.write({ status });
+        }
+      };
+
+      const intervalMs = getConfig().healthCheckIntervalMs;
+      const timer = setInterval(() => {
+        void writeIfChanged();
+      }, intervalMs);
+      if (typeof timer.unref === 'function') timer.unref();
+
+      // Initial status, sent immediately rather than waiting a full interval.
+      void writeIfChanged();
+
+      const stop = (): void => {
+        stopped = true;
+        clearInterval(timer);
+      };
+      call.on('cancelled', () => {
+        stop();
+      });
+      call.on('error', () => {
+        stop();
+      });
+    },
+  });
+
+  return server;
+}
+
+/** Bind and start the server. Resolves once bound; rejects on bind failure. */
+export function startGrpcHealthServer(server: grpc.Server, port: number): Promise<number> {
+  return new Promise((resolve, reject) => {
+    server.bindAsync(`0.0.0.0:${port}`, grpc.ServerCredentials.createInsecure(), (err, boundPort) => {
+      if (err) {
+        reject(err);
+        return;
+      }
+      logger.info('grpc_health_server_started', undefined, {
+        event: 'grpc_health_server_started',
+        port: boundPort,
+      });
+      resolve(boundPort);
+    });
+  });
+}
+
+/**
+ * Gracefully shut down the gRPC health server, mirroring the force-close
+ * fallback pattern in shutdown.ts's gracefulShutdown(): if in-flight calls
+ * (e.g. an open Watch stream) don't drain within `forceShutdownAfterMs`,
+ * force-close instead of hanging the process shutdown indefinitely.
+ */
+export function stopGrpcHealthServer(server: grpc.Server, forceShutdownAfterMs = 5_000): Promise<void> {
+  return new Promise((resolve) => {
+    let settled = false;
+    const finish = (): void => {
+      if (settled) return;
+      settled = true;
+      resolve();
+    };
+
+    const forceTimer = setTimeout(() => {
+      logger.warn('grpc_health_server_force_shutdown', undefined, {
+        event: 'grpc_health_server_force_shutdown',
+        timeoutMs: forceShutdownAfterMs,
+      });
+      server.forceShutdown();
+      finish();
+    }, forceShutdownAfterMs);
+    if (typeof forceTimer.unref === 'function') forceTimer.unref();
+
+    server.tryShutdown((err) => {
+      clearTimeout(forceTimer);
+      if (err) {
+        logger.warn('grpc_health_server_shutdown_error', undefined, {
+          event: 'grpc_health_server_shutdown_error',
+          error: err.message,
+        });
+      }
+      finish();
+    });
+  });
+}

--- a/src/health/health.proto
+++ b/src/health/health.proto
@@ -1,0 +1,28 @@
+// Standard gRPC health-checking protocol, unmodified from the canonical
+// definition published at:
+// https://github.com/grpc/grpc/blob/master/doc/health-checking.md
+//
+// Kept byte-for-byte compatible with `grpc-health-probe` and Kubernetes'
+// native gRPC liveness/readiness probes, which speak this exact protocol.
+syntax = "proto3";
+
+package grpc.health.v1;
+
+message HealthCheckRequest {
+  string service = 1;
+}
+
+message HealthCheckResponse {
+  enum ServingStatus {
+    UNKNOWN = 0;
+    SERVING = 1;
+    NOT_SERVING = 2;
+    SERVICE_UNKNOWN = 3;
+  }
+  ServingStatus status = 1;
+}
+
+service Health {
+  rpc Check(HealthCheckRequest) returns (HealthCheckResponse);
+  rpc Watch(HealthCheckRequest) returns (stream HealthCheckResponse);
+}

--- a/src/indexer/leaderElection.ts
+++ b/src/indexer/leaderElection.ts
@@ -1,0 +1,211 @@
+/**
+ * Redis-backed leader election for indexer replay in multi-replica deployments.
+ *
+ * Only one backend instance may hold the lease at a time. The lease is
+ * acquired with `SET NX PX` (via `RedisClient.setNx`) and renewed on a
+ * heartbeat well before it expires. If renewal stops succeeding — because
+ * another instance has taken over, or Redis is unreachable — `isLeader()`
+ * flips to `false` so callers can abort in-flight work at a safe boundary.
+ *
+ * Modeled on `RedisDistributedLock` in `src/state/adminStateLock.ts`, with
+ * lease renewal added since replay runs can far outlive a single lock TTL.
+ */
+
+import * as crypto from 'node:crypto';
+import type { RedisClient } from '../redis/client.js';
+import { logger } from '../lib/logger.js';
+
+const LEADER_KEY = 'indexer:leader-election:replay';
+const DEFAULT_LEASE_MS = 15_000;
+
+export interface IndexerLeaderElectionOptions {
+  /** Lease TTL in milliseconds. Default 15000. */
+  leaseMs?: number;
+  /** Heartbeat renewal interval in milliseconds. Default leaseMs / 3. */
+  renewIntervalMs?: number;
+  /** Identifier for this instance. Default `${pid}:${randomUUID()}`. */
+  instanceId?: string;
+}
+
+export interface IndexerLeaderElection {
+  /** Synchronous, in-memory check — safe to call in a hot loop. */
+  isLeader(): boolean;
+  /** Single non-blocking attempt to acquire (or confirm) leadership. */
+  tryAcquire(): Promise<boolean>;
+  /** Release the lease (if held) and stop the heartbeat. */
+  release(): Promise<void>;
+}
+
+/**
+ * Always-leader implementation used when Redis-backed election has not been
+ * wired up (Redis disabled, or single-instance/dev/test deployments). This
+ * preserves today's single-process behaviour unless explicitly configured.
+ */
+export class NoOpLeaderElection implements IndexerLeaderElection {
+  isLeader(): boolean {
+    return true;
+  }
+
+  async tryAcquire(): Promise<boolean> {
+    return true;
+  }
+
+  async release(): Promise<void> {
+    return;
+  }
+}
+
+export class RedisIndexerLeaderElection implements IndexerLeaderElection {
+  private readonly leaseMs: number;
+  private readonly renewIntervalMs: number;
+  private readonly instanceId: string;
+  private _isLeader = false;
+  private heartbeat: NodeJS.Timeout | null = null;
+
+  constructor(
+    private readonly redis: RedisClient,
+    opts: IndexerLeaderElectionOptions = {},
+  ) {
+    this.leaseMs = opts.leaseMs ?? DEFAULT_LEASE_MS;
+    this.renewIntervalMs = opts.renewIntervalMs ?? Math.floor(this.leaseMs / 3);
+    this.instanceId = opts.instanceId ?? `${process.pid}:${crypto.randomUUID()}`;
+  }
+
+  isLeader(): boolean {
+    return this._isLeader;
+  }
+
+  /**
+   * Attempt to acquire the lease via `SET NX PX`. Fails safe: any Redis
+   * error is treated as "not leader" rather than assuming leadership.
+   *
+   * Idempotent for the current holder: if the key is already held by this
+   * same instanceId (e.g. a caller checks leadership before delegating to
+   * another code path that also calls tryAcquire()), this returns `true`
+   * without treating the "already exists" NX failure as a loss of
+   * leadership.
+   */
+  async tryAcquire(): Promise<boolean> {
+    try {
+      const acquired = await this.redis.setNx(LEADER_KEY, this.instanceId, this.leaseMs);
+      if (acquired) {
+        this._isLeader = true;
+        this.startHeartbeat();
+        return true;
+      }
+
+      const current = await this.redis.get(LEADER_KEY);
+      if (current === this.instanceId) {
+        this._isLeader = true;
+        if (!this.heartbeat) this.startHeartbeat();
+        return true;
+      }
+
+      this._isLeader = false;
+      return false;
+    } catch (err) {
+      logger.warn('Indexer leader election acquire failed', undefined, {
+        instanceId: this.instanceId,
+        error: err instanceof Error ? err.message : String(err),
+      });
+      this._isLeader = false;
+      return false;
+    }
+  }
+
+  /**
+   * Release the lease and stop the heartbeat. Only deletes the key if it
+   * still holds our instanceId — a lease renewed by a different instance
+   * (because ours already expired) is never deleted here.
+   *
+   * Like `RedisDistributedLock.release()`, this is a check-then-act
+   * sequence, not a Lua-atomic compare-and-delete. See docs/indexer.md for
+   * why that risk is accepted.
+   */
+  async release(): Promise<void> {
+    this.stopHeartbeat();
+    this._isLeader = false;
+
+    try {
+      const current = await this.redis.get(LEADER_KEY);
+      if (current === this.instanceId) {
+        await this.redis.del(LEADER_KEY);
+      }
+    } catch (err) {
+      logger.warn('Indexer leader election release failed', undefined, {
+        instanceId: this.instanceId,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+
+  private startHeartbeat(): void {
+    this.stopHeartbeat();
+    const timer = setInterval(() => {
+      void this.renew();
+    }, this.renewIntervalMs);
+    if (typeof timer.unref === 'function') timer.unref();
+    this.heartbeat = timer;
+  }
+
+  private stopHeartbeat(): void {
+    if (this.heartbeat) {
+      clearInterval(this.heartbeat);
+      this.heartbeat = null;
+    }
+  }
+
+  /**
+   * Renew the lease TTL, but only while we still hold it. Like `release()`,
+   * this is a check-then-extend sequence rather than a Lua-atomic
+   * compare-and-expire.
+   */
+  private async renew(): Promise<void> {
+    try {
+      const current = await this.redis.get(LEADER_KEY);
+      if (current !== this.instanceId) {
+        // Another instance holds the key (our lease already expired) or the
+        // key is gone. Either way we are no longer the leader.
+        this._isLeader = false;
+        this.stopHeartbeat();
+        return;
+      }
+
+      // `.exec()` never rejects for a per-command failure — ioredis (and the
+      // fake) return `[Error | null, result]` tuples instead. Inspect the
+      // tuple explicitly so a failed PEXPIRE is treated as a renewal failure
+      // rather than silently ignored.
+      const results = await this.redis.multi().pexpire(LEADER_KEY, this.leaseMs).exec();
+      const [pexpireError] = results[0] ?? [];
+      if (pexpireError) {
+        throw pexpireError;
+      }
+    } catch (err) {
+      logger.warn('Indexer leader election renewal failed', undefined, {
+        instanceId: this.instanceId,
+        error: err instanceof Error ? err.message : String(err),
+      });
+      this._isLeader = false;
+      this.stopHeartbeat();
+    }
+  }
+}
+
+let defaultLeaderElection: IndexerLeaderElection = new NoOpLeaderElection();
+
+/** Wire a Redis-backed leader election as the default used by `indexerService`. */
+export function initializeIndexerLeaderElection(
+  redis: RedisClient,
+  opts?: IndexerLeaderElectionOptions,
+): void {
+  defaultLeaderElection = new RedisIndexerLeaderElection(redis, opts);
+}
+
+export function getIndexerLeaderElection(): IndexerLeaderElection {
+  return defaultLeaderElection;
+}
+
+/** For testing only — resets the default back to always-leader. */
+export function _resetIndexerLeaderElection(): void {
+  defaultLeaderElection = new NoOpLeaderElection();
+}

--- a/src/indexer/service.ts
+++ b/src/indexer/service.ts
@@ -9,6 +9,10 @@ import {
   indexerReplayRowsPerSecond,
   indexerReplayDurationSeconds,
 } from '../metrics/indexerMetrics.js';
+import {
+  getIndexerLeaderElection,
+  type IndexerLeaderElection,
+} from './leaderElection.js';
 
 // ── Replay budget error ────────────────────────────────────────────────────────
 
@@ -24,6 +28,23 @@ export class ReplayBudgetExceededError extends Error {
         'Re-run to resume from the last committed cursor offset.',
     );
     this.name = 'ReplayBudgetExceededError';
+  }
+}
+
+/**
+ * Thrown when this instance could not acquire (or lost) the distributed
+ * indexer leader-election lease. Another instance is currently the leader
+ * and is expected to own replay; no data was lost, already-committed
+ * batches remain durable, and a re-run resumes from the last committed
+ * cursor offset once this instance becomes leader.
+ */
+export class IndexerNotLeaderError extends Error {
+  constructor() {
+    super(
+      'This instance is not the indexer replay leader; another instance is ' +
+        'currently running (or eligible to run) replay.',
+    );
+    this.name = 'IndexerNotLeaderError';
   }
 }
 
@@ -269,6 +290,7 @@ export class IndexerService {
   private replayBudgetMs: number;
   private cursorRepo: ReplayCursorRepository;
   private pool: pg.Pool;
+  private readonly leaderElectionOverride: IndexerLeaderElection | undefined;
 
   constructor(
     pool?: pg.Pool,
@@ -276,6 +298,7 @@ export class IndexerService {
     maxRangeBlocks?: number,
     replayBudgetMs?: number,
     cursorRepo?: ReplayCursorRepository,
+    leaderElection?: IndexerLeaderElection,
   ) {
     // Use the injected pool or fall back to the shared db pool.
     // Accessing db.pool directly is avoided to keep the service testable.
@@ -284,6 +307,17 @@ export class IndexerService {
     this.maxRangeBlocks = maxRangeBlocks ?? config.indexer.maxRangeBlocks;
     this.replayBudgetMs = replayBudgetMs ?? config.indexer.replayBudgetMs;
     this.cursorRepo = cursorRepo ?? new ReplayCursorRepository();
+    // Only stored when explicitly injected (tests). Otherwise every call
+    // resolves the *current* default via getLeaderElection() below —
+    // this singleton is constructed at module load, before app.ts finishes
+    // wiring Redis, so caching a resolved instance here would freeze it to
+    // the NoOp default forever.
+    this.leaderElectionOverride = leaderElection;
+  }
+
+  /** Resolves the current leader-election instance — never cached, see constructor note. */
+  private getLeaderElection(): IndexerLeaderElection {
+    return this.leaderElectionOverride ?? getIndexerLeaderElection();
   }
 
   /**
@@ -298,18 +332,28 @@ export class IndexerService {
    * committed rows.
    *
    * @param request  Validated replay parameters.
-   * @throws {Error}                    If a replay is already in progress.
+   * @throws {Error}                    If a replay is already in progress on this process.
+   * @throws {IndexerNotLeaderError}     If another instance holds the distributed replay lease.
    * @throws {ReplayBudgetExceededError} If the wall-clock budget is exceeded.
    */
   async replayEvents(request: ReplayRequest): Promise<void> {
     // 1. Validate input (no DB access yet)
     this.validateReplayRequest(request);
 
-    // 2. Concurrent-replay guard
+    // 2. Concurrent-replay guard (same-process)
     if (replayLock.isHeld()) {
       throw new Error('Replay operation already in progress');
     }
     replayLock.acquire();
+
+    // 2b. Distributed leader-election guard (cross-process/multi-replica).
+    //     Acquired after the in-process lock so two concurrent calls into
+    //     the same process still fail fast without touching Redis at all.
+    const leaderElection = this.getLeaderElection();
+    if (!(await leaderElection.tryAcquire())) {
+      replayLock.release();
+      throw new IndexerNotLeaderError();
+    }
 
     const replayStart = Date.now();
     let cursor: ReplayCursor | null = null;
@@ -348,6 +392,22 @@ export class IndexerService {
         if (_stopRequested) {
           logger.warn('replay_stopped_by_shutdown', undefined, {
             event: 'replay_stopped_by_shutdown',
+            contract_id: request.contract_id,
+            ledger: request.ledger,
+            cursor_id: cursor.id,
+            offset,
+          });
+          break;
+        }
+
+        // Leadership guard: our lease may have expired (e.g. Redis outage)
+        // and another instance may already be leading. Abort at this safe
+        // batch boundary — already-committed batches are durable and a
+        // future run (by whichever instance is leader) resumes from
+        // last_committed_offset.
+        if (!leaderElection.isLeader()) {
+          logger.warn('replay_stopped_lost_leadership', undefined, {
+            event: 'replay_stopped_lost_leadership',
             contract_id: request.contract_id,
             ledger: request.ledger,
             cursor_id: cursor.id,
@@ -440,6 +500,7 @@ export class IndexerService {
       throw error;
     } finally {
       replayLock.release();
+      await leaderElection.release();
     }
   }
 
@@ -767,6 +828,17 @@ export class IndexerService {
    * This facilitates automatic crash recovery when the server restarts.
    */
   async resumeIncompleteReplay(): Promise<void> {
+    // Only the leader replica auto-resumes on startup — otherwise every
+    // replica in a multi-instance deployment would race to resume the same
+    // incomplete replay. replayEvents() re-confirms leadership itself
+    // (idempotently, see leaderElection.ts) once an incomplete run is found.
+    if (!(await this.getLeaderElection().tryAcquire())) {
+      logger.info('Skipping incomplete-replay resume: not the indexer leader', undefined, {
+        event: 'replay_resume_skipped_not_leader',
+      });
+      return;
+    }
+
     const client = await this.pool.connect();
     try {
       const result = await client.query(`

--- a/tests/health/grpcHealth.test.ts
+++ b/tests/health/grpcHealth.test.ts
@@ -1,0 +1,265 @@
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
+import * as grpc from '@grpc/grpc-js';
+import * as protoLoader from '@grpc/proto-loader';
+import protobuf from 'protobufjs';
+import {
+  createGrpcHealthServer,
+  startGrpcHealthServer,
+  stopGrpcHealthServer,
+} from '../../src/health/grpcHealth.js';
+import { HealthCheckManager, type HealthChecker } from '../../src/config/health.js';
+import { initializeConfig, resetConfig } from '../../src/config/env.js';
+
+// Duplicated from src/health/grpcHealth.ts on purpose: the test builds its
+// own client against the well-known, stable grpc.health.v1 proto rather than
+// importing any internal from the module under test.
+const HEALTH_PROTO_SOURCE = `
+syntax = "proto3";
+package grpc.health.v1;
+
+message HealthCheckRequest {
+  string service = 1;
+}
+
+message HealthCheckResponse {
+  enum ServingStatus {
+    UNKNOWN = 0;
+    SERVING = 1;
+    NOT_SERVING = 2;
+    SERVICE_UNKNOWN = 3;
+  }
+  ServingStatus status = 1;
+}
+
+service Health {
+  rpc Check(HealthCheckRequest) returns (HealthCheckResponse);
+  rpc Watch(HealthCheckRequest) returns (stream HealthCheckResponse);
+}
+`;
+
+interface HealthClient extends grpc.Client {
+  check(
+    request: { service: string },
+    callback: (err: grpc.ServiceError | null, response?: { status: string }) => void,
+  ): void;
+  watch(request: { service: string }): grpc.ClientReadableStream<{ status: string }>;
+}
+
+function buildHealthClient(address: string): HealthClient {
+  const root = protobuf.parse(HEALTH_PROTO_SOURCE).root;
+  const packageDefinition = protoLoader.fromJSON(root.toJSON(), {
+    keepCase: true,
+    longs: String,
+    enums: String,
+    defaults: true,
+    oneofs: true,
+  });
+  const loaded = grpc.loadPackageDefinition(packageDefinition) as unknown as {
+    grpc: { health: { v1: { Health: new (address: string, creds: grpc.ChannelCredentials) => HealthClient } } };
+  };
+  return new loaded.grpc.health.v1.Health(address, grpc.credentials.createInsecure());
+}
+
+function makeChecker(name: string, check: HealthChecker['check']): HealthChecker {
+  return { name, check };
+}
+
+async function checkOnce(client: HealthClient): Promise<string> {
+  return new Promise((resolve, reject) => {
+    client.check({ service: '' }, (err, response) => {
+      if (err) reject(err);
+      else resolve(response!.status);
+    });
+  });
+}
+
+describe('grpcHealth', () => {
+  let server: grpc.Server;
+  let client: HealthClient;
+  let boundPort: number;
+  const clientsToClose: grpc.Client[] = [];
+
+  beforeAll(() => {
+    resetConfig();
+    process.env.HEALTH_CHECK_INTERVAL_MS = '30';
+    initializeConfig();
+  });
+
+  afterAll(() => {
+    resetConfig();
+    delete process.env.HEALTH_CHECK_INTERVAL_MS;
+  });
+
+  afterEach(async () => {
+    clientsToClose.forEach((c) => c.close());
+    clientsToClose.length = 0;
+    if (server) {
+      await stopGrpcHealthServer(server, 200);
+    }
+  });
+
+  async function startServerWithManager(manager: HealthCheckManager): Promise<void> {
+    server = createGrpcHealthServer(manager);
+    boundPort = await startGrpcHealthServer(server, 0);
+    client = buildHealthClient(`127.0.0.1:${boundPort}`);
+    clientsToClose.push(client);
+  }
+
+  describe('Check', () => {
+    it('returns SERVING when all dependencies are healthy', async () => {
+      const manager = new HealthCheckManager();
+      manager.registerChecker(makeChecker('db', async () => ({ latency: 1 })));
+      await startServerWithManager(manager);
+
+      await expect(checkOnce(client)).resolves.toBe('SERVING');
+    });
+
+    it('returns SERVING when a dependency is degraded (still serving traffic)', async () => {
+      const manager = new HealthCheckManager();
+      manager.registerChecker(makeChecker('db', async () => ({ latency: 1500, degraded: true })));
+      await startServerWithManager(manager);
+
+      await expect(checkOnce(client)).resolves.toBe('SERVING');
+    });
+
+    it('returns NOT_SERVING when a dependency is unhealthy', async () => {
+      const manager = new HealthCheckManager();
+      manager.registerChecker(makeChecker('db', async () => ({ latency: 1, error: 'connection refused' })));
+      await startServerWithManager(manager);
+
+      await expect(checkOnce(client)).resolves.toBe('NOT_SERVING');
+    });
+
+    it('returns NOT_SERVING (not a gRPC error) when the health manager itself throws', async () => {
+      const throwingManager = {
+        checkAll: async () => {
+          throw new Error('boom');
+        },
+      } as unknown as HealthCheckManager;
+      await startServerWithManager(throwingManager);
+
+      await expect(checkOnce(client)).resolves.toBe('NOT_SERVING');
+    });
+
+    it('ignores the service field (single overall status, not per-service)', async () => {
+      const manager = new HealthCheckManager();
+      manager.registerChecker(makeChecker('db', async () => ({ latency: 1 })));
+      await startServerWithManager(manager);
+
+      await expect(
+        new Promise((resolve, reject) => {
+          client.check({ service: 'some-unknown-service' }, (err, response) => {
+            if (err) reject(err);
+            else resolve(response!.status);
+          });
+        }),
+      ).resolves.toBe('SERVING');
+    });
+  });
+
+  describe('Watch', () => {
+    it('sends the current status immediately, and again only when it changes', async () => {
+      let healthy = true;
+      const manager = new HealthCheckManager();
+      manager.registerChecker(
+        makeChecker('db', async () => (healthy ? { latency: 1 } : { latency: 1, error: 'down' })),
+      );
+      await startServerWithManager(manager);
+
+      const received: string[] = [];
+      const call = client.watch({ service: '' });
+      // Expected once we call cancel() (or the server force-closes the
+      // stream) — without a listener, grpc-js surfaces it as an unhandled
+      // 'error' event on the EventEmitter, failing the test run.
+      call.on('error', () => {});
+      call.on('data',(resp: { status: string }) => received.push(resp.status));
+
+      // Initial write should arrive quickly, before waiting a full interval.
+      await new Promise((r) => setTimeout(r, 15));
+      expect(received).toEqual(['SERVING']);
+
+      // Flip status — the next poll tick (interval = 30ms) should push an update.
+      healthy = false;
+      await new Promise((r) => setTimeout(r, 60));
+      expect(received).toEqual(['SERVING', 'NOT_SERVING']);
+
+      // Status stays unhealthy across further polls — no duplicate writes.
+      await new Promise((r) => setTimeout(r, 90));
+      expect(received).toEqual(['SERVING', 'NOT_SERVING']);
+
+      call.cancel();
+    });
+
+    it('stops polling after the client cancels the call', async () => {
+      let pollCount = 0;
+      const manager = new HealthCheckManager();
+      manager.registerChecker(
+        makeChecker('db', async () => {
+          pollCount++;
+          return { latency: 1 };
+        }),
+      );
+      await startServerWithManager(manager);
+
+      const call = client.watch({ service: '' });
+      // Expected once we call cancel() (or the server force-closes the
+      // stream) — without a listener, grpc-js surfaces it as an unhandled
+      // 'error' event on the EventEmitter, failing the test run.
+      call.on('error', () => {});
+      call.on('data',() => {});
+      await new Promise((r) => setTimeout(r, 15)); // let the initial write happen
+
+      call.cancel();
+      await new Promise((r) => setTimeout(r, 30)); // let the server's 'cancelled' handler run
+
+      const countAtCancel = pollCount;
+      await new Promise((r) => setTimeout(r, 90)); // several more would-be interval ticks
+
+      expect(pollCount).toBe(countAtCancel);
+    });
+  });
+
+  describe('startGrpcHealthServer / stopGrpcHealthServer', () => {
+    it('binds to an ephemeral port and reports the bound port number', async () => {
+      const manager = new HealthCheckManager();
+      await startServerWithManager(manager);
+      expect(boundPort).toBeGreaterThan(0);
+    });
+
+    it('shuts down an idle server promptly', async () => {
+      const manager = new HealthCheckManager();
+      server = createGrpcHealthServer(manager);
+      await startGrpcHealthServer(server, 0);
+
+      const start = Date.now();
+      await stopGrpcHealthServer(server, 5_000);
+      expect(Date.now() - start).toBeLessThan(1_000);
+    });
+
+    it('force-shuts-down after the grace period when a call is still open', async () => {
+      const manager = new HealthCheckManager();
+      manager.registerChecker(makeChecker('db', async () => ({ latency: 1 })));
+      await startServerWithManager(manager);
+
+      // Open a Watch stream and never close it client-side.
+      const call = client.watch({ service: '' });
+      // Expected once we call cancel() (or the server force-closes the
+      // stream) — without a listener, grpc-js surfaces it as an unhandled
+      // 'error' event on the EventEmitter, failing the test run.
+      call.on('error', () => {});
+      call.on('data',() => {});
+      await new Promise((r) => setTimeout(r, 15));
+
+      const start = Date.now();
+      await stopGrpcHealthServer(server, 100);
+      const elapsed = Date.now() - start;
+
+      // Should resolve via the force-shutdown fallback, not hang indefinitely.
+      expect(elapsed).toBeGreaterThanOrEqual(90);
+      expect(elapsed).toBeLessThan(1_000);
+
+      // Avoid a redundant stopGrpcHealthServer call in afterEach for this server.
+      server = undefined as unknown as grpc.Server;
+    });
+  });
+});

--- a/tests/indexer-replay.test.ts
+++ b/tests/indexer-replay.test.ts
@@ -25,10 +25,22 @@ import {
   IndexerService,
   ReplayCursorRepository,
   ReplayBudgetExceededError,
+  IndexerNotLeaderError,
   replayLock,
   replayState,
 } from '../src/indexer/service.js';
 import { deRegisterIndexerMetrics } from '../src/metrics/indexerMetrics.js';
+import type { IndexerLeaderElection } from '../src/indexer/leaderElection.js';
+
+/** Always-leader fake — mirrors NoOpLeaderElection but spy-able per test. */
+function makeFakeLeaderElection(overrides: Partial<IndexerLeaderElection> = {}): IndexerLeaderElection {
+  return {
+    isLeader: vi.fn(() => true),
+    tryAcquire: vi.fn(async () => true),
+    release: vi.fn(async () => {}),
+    ...overrides,
+  };
+}
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
@@ -107,7 +119,12 @@ function makeCursorRepo(overrides: Partial<ReplayCursorRepository> = {}): Replay
 function makeService(
   pool: pg.Pool,
   cursorRepo: ReplayCursorRepository,
-  opts: { batchSize?: number; maxRangeBlocks?: number; replayBudgetMs?: number } = {},
+  opts: {
+    batchSize?: number;
+    maxRangeBlocks?: number;
+    replayBudgetMs?: number;
+    leaderElection?: IndexerLeaderElection;
+  } = {},
 ): IndexerService {
   return new IndexerService(
     pool,
@@ -115,6 +132,7 @@ function makeService(
     opts.maxRangeBlocks ?? 0,  // 0 = unlimited
     opts.replayBudgetMs ?? 0,  // 0 = no budget
     cursorRepo,
+    opts.leaderElection,      // defaults to the module-level NoOpLeaderElection when omitted
   );
 }
 
@@ -284,6 +302,157 @@ describe('IndexerService — concurrent replay rejection', () => {
 
     await expect(svc.replayEvents(REQUEST)).rejects.toThrow('cursor create failed');
     expect(replayLock.isHeld()).toBe(false);
+  });
+});
+
+// ── Distributed leader election (multi-replica) ───────────────────────────────
+
+describe('IndexerService — distributed leader election', () => {
+  it('rejects with IndexerNotLeaderError when another instance holds the lease, without touching the DB', async () => {
+    const pool = makePool();
+    const leaderElection = makeFakeLeaderElection({ tryAcquire: vi.fn(async () => false) });
+    const svc = makeService(pool, makeCursorRepo(), { leaderElection });
+
+    await expect(svc.replayEvents(REQUEST)).rejects.toThrow(IndexerNotLeaderError);
+
+    // Same-process lock must be released so a later attempt (once leadership
+    // is available) is not blocked by this failed attempt.
+    expect(replayLock.isHeld()).toBe(false);
+    // The distributed guard runs before any DB work.
+    expect(pool.connect).not.toHaveBeenCalled();
+    // We never became leader, so there is nothing to release.
+    expect(leaderElection.release).not.toHaveBeenCalled();
+  });
+
+  it('releases the leader-election lease on successful completion', async () => {
+    const cursorRepo = makeCursorRepo({
+      create: vi.fn(async (_c, cid, ledger) => ({
+        id: 'c0',
+        contract_id: cid,
+        ledger,
+        from_block: null,
+        to_block: null,
+        total_rows: 0,
+        last_committed_offset: 0,
+        started_at: new Date(),
+        completed_at: null,
+      })),
+    });
+    const client = makeClient(async (sql) => {
+      if (sql.includes('COUNT')) return { rows: [{ count: '0' }] };
+      return { rows: [] };
+    });
+    const pool = makePool(client);
+    const leaderElection = makeFakeLeaderElection();
+    const svc = makeService(pool, cursorRepo, { leaderElection });
+
+    await expect(svc.replayEvents(REQUEST)).resolves.toBeUndefined();
+    expect(leaderElection.tryAcquire).toHaveBeenCalledTimes(1);
+    expect(leaderElection.release).toHaveBeenCalledTimes(1);
+  });
+
+  it('releases the leader-election lease even when replay throws', async () => {
+    const client = makeClient(async (sql) => {
+      if (sql.includes('COUNT')) return { rows: [{ count: '5' }] };
+      return { rows: [] };
+    });
+    const cursorRepo = makeCursorRepo({
+      create: vi.fn(async () => { throw new Error('cursor create failed'); }),
+    });
+    const pool = makePool(client);
+    const leaderElection = makeFakeLeaderElection();
+    const svc = makeService(pool, cursorRepo, { leaderElection });
+
+    await expect(svc.replayEvents(REQUEST)).rejects.toThrow('cursor create failed');
+    expect(leaderElection.release).toHaveBeenCalledTimes(1);
+  });
+
+  it('stops at the next safe batch boundary when leadership is lost mid-replay, leaving progress resumable', async () => {
+    const events = [makeEvent('e1', 100), makeEvent('e2', 200), makeEvent('e3', 300), makeEvent('e4', 400)];
+
+    const cursorClient = makeClient(async (sql) => {
+      if (sql.includes('COUNT')) return { rows: [{ count: '4' }] };
+      if (sql.includes('INSERT INTO replay_cursors')) {
+        return {
+          rows: [{
+            id: 'cursor-1',
+            contract_id: 'test-contract',
+            ledger: 1,
+            from_block: null,
+            to_block: null,
+            total_rows: 4,
+            last_committed_offset: 0,
+            started_at: new Date(),
+            completed_at: null,
+          }],
+        };
+      }
+      return { rows: [] }; // findActive returns null
+    });
+
+    // Only batch 1 should ever be fetched — the loop must stop before batch 2.
+    const batch1Client = makeClient(async (sql) => {
+      if (sql.includes('SELECT') && sql.includes('FROM historical_events')) {
+        return { rows: events.slice(0, 2) };
+      }
+      return { rows: [] };
+    });
+
+    const cursorRepo = makeCursorRepo({
+      findActive: vi.fn(async () => null),
+      create: vi.fn(async (_c, cid, ledger) => ({
+        id: 'cursor-1',
+        contract_id: cid,
+        ledger,
+        from_block: null,
+        to_block: null,
+        total_rows: 4,
+        last_committed_offset: 0,
+        started_at: new Date(),
+        completed_at: null,
+      })),
+    });
+
+    const pool = makePool(cursorClient, batch1Client);
+    // isLeader() is checked once per loop iteration before processing a
+    // batch: true for batch 1, false before batch 2 (lease lost mid-replay).
+    const isLeader = vi.fn().mockReturnValueOnce(true).mockReturnValue(false);
+    const leaderElection = makeFakeLeaderElection({ isLeader });
+    const svc = makeService(pool, cursorRepo, { leaderElection });
+
+    await expect(svc.replayEvents(REQUEST)).resolves.toBeUndefined();
+
+    // Batch 1 committed and the cursor advanced — durable progress — and the
+    // loop stopped *before* fetching batch 2 (only cursorClient + batch1Client
+    // connections were ever used; a 3rd pool.connect() would mean batch 2 ran).
+    expect(cursorRepo.advanceOffset).toHaveBeenCalledTimes(1);
+    expect(cursorRepo.advanceOffset).toHaveBeenCalledWith(expect.anything(), 'cursor-1', 2);
+    expect(pool.connect).toHaveBeenCalledTimes(3); // cursor resolve, batch 1, completeCursor
+    expect(leaderElection.release).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('IndexerService#resumeIncompleteReplay — distributed leader election', () => {
+  it('skips resuming (and never touches the DB) when this instance is not the leader', async () => {
+    const pool = makePool();
+    const leaderElection = makeFakeLeaderElection({ tryAcquire: vi.fn(async () => false) });
+    const svc = makeService(pool, makeCursorRepo(), { leaderElection });
+
+    await svc.resumeIncompleteReplay();
+
+    expect(pool.connect).not.toHaveBeenCalled();
+  });
+
+  it('proceeds to check for an incomplete replay when this instance is the leader', async () => {
+    const client = makeClient(async () => ({ rows: [] })); // no incomplete replay found
+    const pool = makePool(client);
+    const leaderElection = makeFakeLeaderElection();
+    const svc = makeService(pool, makeCursorRepo(), { leaderElection });
+
+    await svc.resumeIncompleteReplay();
+
+    expect(leaderElection.tryAcquire).toHaveBeenCalledTimes(1);
+    expect(pool.connect).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/tests/indexer/leaderElection.test.ts
+++ b/tests/indexer/leaderElection.test.ts
@@ -1,0 +1,191 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { FakeRedisClient } from '../../src/redis/__test__/fakeRedisClient.js';
+import {
+  NoOpLeaderElection,
+  RedisIndexerLeaderElection,
+  initializeIndexerLeaderElection,
+  getIndexerLeaderElection,
+  _resetIndexerLeaderElection,
+} from '../../src/indexer/leaderElection.js';
+
+describe('NoOpLeaderElection', () => {
+  it('always reports leadership and never rejects', async () => {
+    const noop = new NoOpLeaderElection();
+    expect(noop.isLeader()).toBe(true);
+    await expect(noop.tryAcquire()).resolves.toBe(true);
+    expect(noop.isLeader()).toBe(true);
+    await expect(noop.release()).resolves.toBeUndefined();
+  });
+});
+
+describe('RedisIndexerLeaderElection', () => {
+  let redis: FakeRedisClient;
+
+  beforeEach(() => {
+    redis = new FakeRedisClient();
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    redis.reset();
+  });
+
+  it('acquires the lease when the key is absent', async () => {
+    const le = new RedisIndexerLeaderElection(redis, { instanceId: 'a' });
+    expect(le.isLeader()).toBe(false);
+    await expect(le.tryAcquire()).resolves.toBe(true);
+    expect(le.isLeader()).toBe(true);
+  });
+
+  it('fails to acquire when another instance already holds the lease', async () => {
+    const holder = new RedisIndexerLeaderElection(redis, { instanceId: 'holder' });
+    await expect(holder.tryAcquire()).resolves.toBe(true);
+
+    const challenger = new RedisIndexerLeaderElection(redis, { instanceId: 'challenger' });
+    await expect(challenger.tryAcquire()).resolves.toBe(false);
+    expect(challenger.isLeader()).toBe(false);
+    // The original holder is unaffected.
+    expect(holder.isLeader()).toBe(true);
+  });
+
+  it('is idempotent for the current holder (repeated tryAcquire by the same instance succeeds)', async () => {
+    const le = new RedisIndexerLeaderElection(redis, { instanceId: 'a' });
+    await expect(le.tryAcquire()).resolves.toBe(true);
+    // A second call from the SAME instance must not be treated as a failed
+    // acquisition just because the key already exists (setNx would fail) —
+    // callers such as resumeIncompleteReplay() followed by replayEvents()
+    // both call tryAcquire() on the same instance in sequence.
+    await expect(le.tryAcquire()).resolves.toBe(true);
+    expect(le.isLeader()).toBe(true);
+  });
+
+  it('generates distinct instanceIds by default so concurrently-started replicas do not collide', () => {
+    const a = new RedisIndexerLeaderElection(redis);
+    const b = new RedisIndexerLeaderElection(redis);
+    expect((a as unknown as { instanceId: string }).instanceId).not.toBe(
+      (b as unknown as { instanceId: string }).instanceId,
+    );
+  });
+
+  it('fails safe (not leader) when setNx throws', async () => {
+    redis.throwOnNext('setNx', 'simulated redis outage');
+    const le = new RedisIndexerLeaderElection(redis, { instanceId: 'a' });
+    await expect(le.tryAcquire()).resolves.toBe(false);
+    expect(le.isLeader()).toBe(false);
+  });
+
+  it('renews the lease via PEXPIRE on heartbeat while still the holder', async () => {
+    const leaseMs = 9000;
+
+    // FakeRedisClient stores TTLs but never enforces expiry (by design — see
+    // its doc comment), so the only reliable way to prove renewal actually
+    // fired is to intercept the PEXPIRE call itself rather than relying on
+    // key expiry.
+    const pexpireCalls: Array<[string, number]> = [];
+    const originalMulti = redis.multi.bind(redis);
+    vi.spyOn(redis, 'multi').mockImplementation(() => {
+      const pipeline = originalMulti();
+      const originalPexpire = pipeline.pexpire.bind(pipeline);
+      pipeline.pexpire = (key: string, ms: number) => {
+        pexpireCalls.push([key, ms]);
+        return originalPexpire(key, ms);
+      };
+      return pipeline;
+    });
+
+    const le = new RedisIndexerLeaderElection(redis, { instanceId: 'a', leaseMs });
+    await le.tryAcquire();
+
+    // Advance past one heartbeat tick (renewIntervalMs = leaseMs / 3).
+    await vi.advanceTimersByTimeAsync(Math.floor(leaseMs / 3) + 10);
+
+    expect(le.isLeader()).toBe(true);
+    expect(pexpireCalls).toContainEqual(['indexer:leader-election:replay', leaseMs]);
+  });
+
+  it('drops leadership when another instance has taken over the key (lease expired)', async () => {
+    const leaseMs = 9000;
+    const le = new RedisIndexerLeaderElection(redis, { instanceId: 'a', leaseMs });
+    await le.tryAcquire();
+    expect(le.isLeader()).toBe(true);
+
+    // Simulate our lease having actually expired and a different instance
+    // taking over, out from under us.
+    await redis.del('indexer:leader-election:replay');
+    await redis.setNx('indexer:leader-election:replay', 'other-instance', leaseMs);
+
+    await vi.advanceTimersByTimeAsync(Math.floor(leaseMs / 3) + 10);
+
+    expect(le.isLeader()).toBe(false);
+  });
+
+  it('drops leadership when the heartbeat PEXPIRE fails', async () => {
+    const leaseMs = 9000;
+    const le = new RedisIndexerLeaderElection(redis, { instanceId: 'a', leaseMs });
+    await le.tryAcquire();
+
+    redis.throwOnNext('pexpire', 'simulated redis outage during renewal');
+    await vi.advanceTimersByTimeAsync(Math.floor(leaseMs / 3) + 10);
+
+    expect(le.isLeader()).toBe(false);
+  });
+
+  it('release() deletes the key when we still hold it, and stops the heartbeat', async () => {
+    const le = new RedisIndexerLeaderElection(redis, { instanceId: 'a', leaseMs: 9000 });
+    await le.tryAcquire();
+
+    await le.release();
+
+    expect(le.isLeader()).toBe(false);
+    await expect(redis.exists('indexer:leader-election:replay')).resolves.toBe(false);
+
+    // No further heartbeat renewal should occur post-release.
+    await vi.advanceTimersByTimeAsync(60_000);
+    await expect(redis.exists('indexer:leader-election:replay')).resolves.toBe(false);
+  });
+
+  it('release() does not delete a lease now held by a different instance', async () => {
+    const le = new RedisIndexerLeaderElection(redis, { instanceId: 'a', leaseMs: 9000 });
+    await le.tryAcquire();
+
+    // Someone else took over between our last successful renewal and release()
+    // (our lease had already expired).
+    await redis.del('indexer:leader-election:replay');
+    await redis.setNx('indexer:leader-election:replay', 'other-instance', 9000);
+
+    await le.release();
+
+    await expect(redis.get('indexer:leader-election:replay')).resolves.toBe('other-instance');
+  });
+
+  it('release() swallows errors', async () => {
+    const le = new RedisIndexerLeaderElection(redis, { instanceId: 'a', leaseMs: 9000 });
+    await le.tryAcquire();
+    redis.throwOnNext('get', 'simulated redis outage during release');
+    await expect(le.release()).resolves.toBeUndefined();
+  });
+});
+
+describe('default leader election accessor', () => {
+  afterEach(() => {
+    _resetIndexerLeaderElection();
+  });
+
+  it('defaults to NoOpLeaderElection', () => {
+    expect(getIndexerLeaderElection()).toBeInstanceOf(NoOpLeaderElection);
+  });
+
+  it('initializeIndexerLeaderElection swaps in a Redis-backed instance', () => {
+    const redis = new FakeRedisClient();
+    initializeIndexerLeaderElection(redis, { instanceId: 'a' });
+    expect(getIndexerLeaderElection()).toBeInstanceOf(RedisIndexerLeaderElection);
+  });
+
+  it('_resetIndexerLeaderElection restores the NoOp default', () => {
+    const redis = new FakeRedisClient();
+    initializeIndexerLeaderElection(redis);
+    _resetIndexerLeaderElection();
+    expect(getIndexerLeaderElection()).toBeInstanceOf(NoOpLeaderElection);
+  });
+});


### PR DESCRIPTION
## Summary

Closes #749, Closes #742

Implements two independent features requested in separate issues, bundled into one PR since the second depends on a fix uncovered while implementing the first:

### #749 — Distributed leader election for indexer replay

`src/indexer/service.ts`'s in-process `ReplayLock` explicitly documented that "for multi-process deployments a distributed lock (e.g. Redis SETNX) would be required instead." This adds that lock:

- **`src/indexer/leaderElection.ts`** — `RedisIndexerLeaderElection`, modeled on the existing `RedisDistributedLock` (`src/state/adminStateLock.ts`), adding lease renewal that class didn't need:
  - `SET NX PX` acquisition on a single fixed key (`indexer:leader-election:replay`).
  - Heartbeat renewal via `PEXPIRE` roughly every `leaseMs / 3`, only after confirming via `GET` that we still hold the key.
  - Idempotent re-acquisition for the current holder (needed because `resumeIncompleteReplay()` and `replayEvents()` both call `tryAcquire()` in sequence on the same instance).
  - Fails safe: any Redis error during acquire/renew is treated as "not leader," never as an assumed leadership grant.
  - `NoOpLeaderElection` (always-leader) is the default when Redis is disabled — today's single-instance behavior is unchanged unless Redis is configured.
- **`src/indexer/service.ts`** — `replayEvents()` acquires the lease after the existing same-process lock; the per-batch loop checks `isLeader()` at the same point it already checks the shutdown `_stopRequested` flag, so a lease lost mid-replay (e.g. a Redis outage) aborts cleanly at the next safe batch boundary — already-committed batches stay durable via `last_committed_offset`, and a `IndexerNotLeaderError` surfaces the rejection. `resumeIncompleteReplay()` only proceeds on the leader replica, so replicas don't race to resume the same incomplete cursor on startup.
- **`src/app.ts`** — wires a Redis client the same way `wireAdminStateLock`/`wireIdempotencyStore` already do, and releases the lease via a `shutdown.ts` hook (before Redis connections close, after replay is signalled to stop) for deterministic release on graceful shutdown.

**Security note:** like the existing `RedisDistributedLock`, lease renewal/release are check-then-act (`GET` then `PEXPIRE`/`DEL`), not Lua-atomic. Worst case is a brief double-leadership window bounded by `renewIntervalMs`; the existing `ON CONFLICT (event_id) DO NOTHING` batch inserts make that window harmless (idempotent re-replay, no duplicate rows). Documented in `docs/indexer.md`.

### #742 — gRPC health-check service (`grpc.health.v1.Health`)

Kubernetes-native gRPC probes (`grpc-health-probe`, kubelet's built-in gRPC probes) expect this exact protocol rather than HTTP.

- **`src/health/health.proto`** — the canonical, unmodified `grpc.health.v1.Health` definition (documentation/reference).
- **`src/health/grpcHealth.ts`** — `Check`/`Watch` handlers that reuse `HealthCheckManager.checkAll()` (the same dependency-check logic backing HTTP `/health/ready`) rather than re-implementing checks, so the two surfaces can't drift. `healthy`/`degraded` map to `SERVING` (matching `/health/ready`'s 200 for both), `unhealthy` maps to `NOT_SERVING`. Internal failures fail closed to `NOT_SERVING` rather than a gRPC error, since probe clients only understand the enum. The proto is parsed from an **in-memory string**, not read from disk at runtime — the Docker production image only copies `dist/`, not `src/`, so a `fs.readFileSync` against `health.proto` would work in dev and silently break once deployed.
- **`src/config/env.ts`** — `GRPC_HEALTH_ENABLED` (default `false`) / `GRPC_HEALTH_PORT` (default `50051`), separate from the HTTP port.
- **`src/app.ts`** — starts the gRPC server on its own port when enabled and a `healthManager` is configured, with graceful/forced shutdown wired the same way `shutdown.ts`'s `gracefulShutdown` already handles the HTTP server.
- **`package.json`** — `@grpc/grpc-js` and `@grpc/proto-loader` promoted from transitive to direct dependencies, pinned to the exact versions already resolved in `pnpm-lock.yaml` (no new downloads needed).

### Prerequisite fix: `HealthCheckManager` was already broken

While wiring the gRPC service into `HealthCheckManager`, found that `src/config/health.ts`'s class referenced `this.checkers`, `this.lastResults`, and `this.startTime` without ever declaring them, and `getConfig().healthCheckTimeoutMs` / `healthCheckIntervalMs` didn't exist anywhere in the `Config` schema — every call to `registerChecker()` or `checkAll()` threw `Cannot read properties of undefined`. This meant **HTTP `/health/ready` was already broken on `main`** before this PR. Since the new gRPC service is required to reuse this exact class, fixed the missing field declarations and added `HEALTH_CHECK_TIMEOUT_MS` / `HEALTH_CHECK_INTERVAL_MS` to `src/config/env.ts` using the same `integerEnv()` pattern as every other field in that schema. This also fixes `tests/health.test.ts` and `tests/health-ready.test.ts`, which were failing for the same reason.

## Test plan

- [x] `tests/indexer/leaderElection.test.ts` (15 tests) — acquisition, idempotent re-acquisition, heartbeat renewal/failure, ownership-checked release, fail-safe behavior on Redis errors.
- [x] `tests/indexer-replay.test.ts` — new integration tests: not-leader rejection (with same-process lock released so a later attempt isn't blocked), lease-loss abort mid-replay leaving progress resumable, `resumeIncompleteReplay()` gating, lease release on both success and error paths.
- [x] `tests/health/grpcHealth.test.ts` (10 tests) — real in-process `@grpc/grpc-js` client against `Check`/`Watch`, including fail-closed behavior when the health manager throws, Watch's change-only write semantics, cancellation stopping the poll loop, and graceful vs. forced shutdown.
- [x] `pnpm typecheck` — 342 → 326 errors (net fix from the `HealthCheckManager` repair); zero new errors in any file this PR touches.
- [x] `pnpm lint` — identical 390 problems (73 errors / 317 warnings) before and after; zero new issues.
- [x] Full suite (`pnpm vitest run`) — 479 → 424 failing tests (net fix); diffing the failing-file lists confirms **zero** tests that pass on `main` now fail (only newly-added/newly-fixed files change status).
- [ ] Manual: `GRPC_HEALTH_ENABLED=true` + `grpc-health-probe`/`grpcurl` against a running instance (not run in this environment — no live cluster available).
- [ ] Manual: two instances against the same Redis, confirm only one processes a `POST /internal/indexer/events/replay` at a time and progress resumes correctly after killing the leader mid-replay (not run in this environment — requires a real Redis + Postgres + multi-process setup).

Note: `pnpm build` (`tsc` over the whole project, including `tests/**/*` per `tsconfig.json`) currently fails on `main` with ~300 pre-existing type errors across unrelated test files (mocks, AWS SDK types, etc.) — confirmed via a baseline run before this branch existed. This PR does not change that error count and touches none of the affected files; fixing it is a separate, unrelated effort out of scope here.