### PR TITLE
test: verify StreamHub.broadcast tolerates mid-fan-out client disconn…

### DIFF
--- a/docs/websocket.md
+++ b/docs/websocket.md
@@ -293,3 +293,19 @@ rate(fluxora_ws_batch_events_coalesced_total[5m])
 - Each outbound frame is checked against `MAX_MESSAGE_BYTES` before delivery.
   Oversized frames are truncated to the largest event prefix that fits, rather
   than silently dropped.
+
+### Broadcast Resilience
+
+`StreamHub.broadcast()` fans out to all matching subscribers in a tight loop.
+The hub tolerates client disconnects (abrupt `terminate()` or clean `close()`)
+that occur **during** the fan-out iteration:
+
+- Disconnected clients are silently skipped via the `readyState` check before
+  each `ws.send()` call, and the loop continues to the next subscriber without
+  interruption.
+- The `broadcast()` promise always resolves cleanly — no exception escapes.
+- `BackpressureMetrics` counters (`sentMessages`, `droppedMessages`,
+  `terminatedConnections`) remain consistent: no double-count or under-count
+  for the disconnected client.
+- Pending batch-accumulator timers for the disconnected client are cancelled
+  by `onDisconnect`, preventing stale frame delivery.

--- a/issue746.md
+++ b/issue746.md
@@ -1,0 +1,30 @@
+Description
+Add a concurrency test in tests/ws/ws.concurrency.test.ts that subscribes several clients to a stream, begins a StreamHub.broadcast() call, and forcibly terminates one client's socket while fan-out to the remaining clients is still in progress, asserting the broadcast promise resolves cleanly, no exception escapes src/ws/hub.ts, and remaining clients still receive the event.
+
+Requirements and context
+Must assert BackpressureMetrics counters in src/ws/hub.ts are updated consistently (no double-count, no undercount) when a client disappears mid-fan-out.
+Must cover both abrupt socket termination and a clean ws.close() occurring during the same tick as the broadcast loop.
+Must be secure, tested, and documented
+Should be efficient and easy to review
+Suggested execution
+Fork the repo and create a branch
+
+git checkout -b feature/ws-mid-broadcast-disconnect-test
+Implement changes
+
+Update/Write: tests/ws/ws.concurrency.test.ts
+Update/Write: src/ws/hub.ts
+Write comprehensive tests: tests/ws/ws.concurrency.test.ts
+Add documentation: docs/websocket.md
+Include NatSpec / doc-comment style
+Validate security assumptions
+Test and commit
+Run tests: pnpm test
+Cover edge cases
+Include test output and security notes
+Example commit message
+
+test: verify StreamHub.broadcast tolerates mid-fan-out client disconnects
+Guidelines
+Minimum 95 percent test coverage
+Clear documentation

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,8 @@
       "license": "MIT",
       "dependencies": {
         "@asteasolutions/zod-to-openapi": "8.5.0",
+        "@grpc/grpc-js": "1.14.4",
+        "@grpc/proto-loader": "0.8.1",
         "@opentelemetry/api": "^1.9.0",
         "@opentelemetry/exporter-trace-otlp-http": "^0.57.2",
         "@opentelemetry/instrumentation-express": "^0.46.0",
@@ -29,6 +31,7 @@
         "node-pg-migrate": "^7.6.0",
         "pg": "^8.11.3",
         "prom-client": "^15.0.0",
+        "protobufjs": "7.6.4",
         "swagger-ui-express": "5.0.1",
         "ws": "^8.14.2",
         "zod": "^4.3.6"

--- a/src/ws/hub.ts
+++ b/src/ws/hub.ts
@@ -1029,7 +1029,12 @@ export class StreamHub extends EventEmitter {
       return;
     }
 
-    ws.send(message);
+    try {
+      ws.send(message);
+    } catch {
+      this.metrics.droppedMessages += safeEvents.length;
+      return;
+    }
     this.metrics.sentMessages++;
 
     const state = this.clients.get(ws);
@@ -1094,7 +1099,13 @@ export class StreamHub extends EventEmitter {
         continue;
       }
 
-      ws.send(message);
+      try {
+        ws.send(message);
+      } catch {
+        // If send throws (e.g. a race with concurrent terminate), skip this
+        // client without counting it as sent or crashing the broadcast.
+        continue;
+      }
       this.metrics.sentMessages++;
       sent++;
 

--- a/tests/ws/ws.concurrency.test.ts
+++ b/tests/ws/ws.concurrency.test.ts
@@ -3,6 +3,7 @@ import http from 'http';
 import { WebSocket } from 'ws';
 import { StreamHub } from '../../src/ws/hub.js';
 import { _resetLimiter } from '../../src/ws/connectionLimiter.js';
+import { connectClient, sendJson, wait } from './fixtures/slowClient.js';
 
 /**
  * Concurrency test suite for WebSocket upgrade TOCTOU race condition fix.
@@ -336,6 +337,217 @@ describe('WebSocket upgrade TOCTOU concurrency', () => {
 
     // Ensure memory is released
     expect(hub.getStreamSubscriptionCount(streamId)).toBe(0);
+  });
+});
+
+/**
+ * Concurrency test suite verifying StreamHub.broadcast() tolerates client
+ * disconnects that occur **during** the fan-out delivery loop.
+ *
+ * SECURITY NOTES:
+ * - Uses vi.spyOn on a server-side WebSocket.send() to trigger the disconnect
+ *   of a *different* subscriber mid-iteration, creating a deterministic
+ *   mid-fan-out scenario without race conditions.
+ * - Clients are connected sequentially (not with Promise.all) so that the
+ *   hub._getClients() insertion order matches the client array index, keeping
+ *   server-socket lookup deterministic.
+ * - The backpressure collector is disabled (intervalMs: 0) so that metrics
+ *   reflect only the broadcast under test.
+ */
+describe('StreamHub broadcast mid-fan-out client disconnect', () => {
+  let server: http.Server;
+  let hub: StreamHub;
+  let port: number;
+  const openClients: WebSocket[] = [];
+
+  beforeEach(async () => {
+    server = http.createServer();
+    hub = new StreamHub(server, {
+      backpressureCollector: { intervalMs: 0 },
+    });
+    hub._resetMetrics();
+    await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+    port = (server.address() as { port: number }).port;
+    openClients.length = 0;
+  });
+
+  afterEach(async () => {
+    for (const ws of openClients) {
+      if (ws.readyState === WebSocket.OPEN || ws.readyState === WebSocket.CONNECTING) {
+        ws.close();
+      }
+    }
+    await new Promise<void>((resolve) => hub.close(() => resolve()));
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+  });
+
+  /** Return server-side WebSocket handles in Map-insertion order. */
+  function getServerSockets(): WebSocket[] {
+    const sockets: WebSocket[] = [];
+    for (const [ws] of hub._getClients()) {
+      sockets.push(ws);
+    }
+    return sockets;
+  }
+
+  /** Connect `count` clients sequentially and track them for cleanup. */
+  async function connectClients(count: number): Promise<WebSocket[]> {
+    const clients: WebSocket[] = [];
+    for (let i = 0; i < count; i++) {
+      const ws = await connectClient(port);
+      openClients.push(ws);
+      clients.push(ws);
+    }
+    return clients;
+  }
+
+  it('handles abrupt ws.terminate() mid-broadcast fan-out', async () => {
+    /**
+     * SCENARIO: Five clients subscribe to a stream. A broadcast() call begins
+     * fan-out to all five. Mid-iteration (when client[1]'s send fires), client[3]
+     * is forcibly terminated via ws.terminate().
+     *
+     * EXPECTED:
+     *   - broadcast() promise resolves cleanly (no exception escapes hub.ts).
+     *   - The terminated client receives zero messages.
+     *   - The remaining 4 clients all receive the stream_update event.
+     *   - BackpressureMetrics: sentMessages=4, droppedMessages=0,
+     *     terminatedConnections=0 (the disconnect was external, not backpressure).
+     *   - hub.clientCount drops to 4 (terminated client is cleaned up).
+     *
+     * SECURITY PROPERTY: Abrupt client termination mid-fan-out does not corrupt
+     * the broadcast loop, leak unhandled exceptions, or skew metrics.
+     */
+    const CLIENT_COUNT = 5;
+    const streamId = 'test-stream-term';
+
+    const clients = await connectClients(CLIENT_COUNT);
+
+    const messages: unknown[][] = clients.map(() => []);
+    clients.forEach((ws, i) => {
+      ws.on('message', (data) => {
+        messages[i].push(JSON.parse(data.toString()));
+      });
+    });
+
+    await wait(20);
+
+    clients.forEach((ws) => sendJson(ws, { type: 'subscribe', filter: { streamId } }));
+    await wait(20);
+
+    const serverSockets = getServerSockets();
+    expect(serverSockets).toHaveLength(CLIENT_COUNT);
+
+    // Trigger terminate on index 3 when index 1's send is called.
+    const terminateTarget = serverSockets[3];
+    const spy = vi.spyOn(serverSockets[1], 'send');
+    spy.mockImplementationOnce(function mock(data: string) {
+      terminateTarget.terminate();
+      spy.mockRestore();
+      return serverSockets[1].send(data);
+    });
+
+    await expect(
+      hub.broadcast({ streamId, eventId: 'evt-mid', payload: { n: 1 } })
+    ).resolves.toBeUndefined();
+
+    await wait(30);
+
+    for (let i = 0; i < CLIENT_COUNT; i++) {
+      if (i === 3) {
+        expect(messages[i]).toHaveLength(0);
+      } else {
+        expect(messages[i]).toHaveLength(1);
+        expect(messages[i][0]).toMatchObject({
+          type: 'stream_update',
+          streamId,
+          eventId: 'evt-mid',
+        });
+      }
+    }
+
+    const metrics = hub.getMetrics();
+    expect(metrics.sentMessages).toBe(CLIENT_COUNT - 1);
+    expect(metrics.droppedMessages).toBe(0);
+    expect(metrics.terminatedConnections).toBe(0);
+    expect(hub.clientCount).toBe(CLIENT_COUNT - 1);
+  });
+
+  it('handles clean ws.close() mid-broadcast fan-out', async () => {
+    /**
+     * SCENARIO: Five clients subscribe to a stream. A broadcast() call begins
+     * fan-out to all five. Mid-iteration (when client[1]'s send fires), client[3]
+     * is cleanly closed via ws.close().
+     *
+     * EXPECTED:
+     *   - broadcast() promise resolves cleanly.
+     *   - The closed client receives zero messages.
+     *   - The remaining 4 clients all receive the stream_update event.
+     *   - BackpressureMetrics: sentMessages=4, droppedMessages=0,
+     *     terminatedConnections=0.
+     *   - hub.clientCount drops to 4.
+     *
+     * SECURITY PROPERTY: Clean close during the same tick as the broadcast loop
+     * is handled gracefully — no exception escapes, no leaking sockets,
+     * no inconsistent counters.
+     *
+     * DIFFERENCE FROM TERMINATE TEST: ws.close() performs the WebSocket close
+     * handshake (sends a close frame) rather than immediately destroying the
+     * underlying TCP socket. Both code paths must be covered.
+     */
+    const CLIENT_COUNT = 5;
+    const streamId = 'test-stream-close';
+
+    const clients = await connectClients(CLIENT_COUNT);
+
+    const messages: unknown[][] = clients.map(() => []);
+    clients.forEach((ws, i) => {
+      ws.on('message', (data) => {
+        messages[i].push(JSON.parse(data.toString()));
+      });
+    });
+
+    await wait(20);
+
+    clients.forEach((ws) => sendJson(ws, { type: 'subscribe', filter: { streamId } }));
+    await wait(20);
+
+    const serverSockets = getServerSockets();
+    expect(serverSockets).toHaveLength(CLIENT_COUNT);
+
+    // Trigger close on index 3 when index 1's send is called.
+    const closeTarget = serverSockets[3];
+    const spy = vi.spyOn(serverSockets[1], 'send');
+    spy.mockImplementationOnce(function mock(data: string) {
+      closeTarget.close();
+      spy.mockRestore();
+      return serverSockets[1].send(data);
+    });
+
+    await expect(
+      hub.broadcast({ streamId, eventId: 'evt-mid-close', payload: { n: 2 } })
+    ).resolves.toBeUndefined();
+
+    await wait(30);
+
+    for (let i = 0; i < CLIENT_COUNT; i++) {
+      if (i === 3) {
+        expect(messages[i]).toHaveLength(0);
+      } else {
+        expect(messages[i]).toHaveLength(1);
+        expect(messages[i][0]).toMatchObject({
+          type: 'stream_update',
+          streamId,
+          eventId: 'evt-mid-close',
+        });
+      }
+    }
+
+    const metrics = hub.getMetrics();
+    expect(metrics.sentMessages).toBe(CLIENT_COUNT - 1);
+    expect(metrics.droppedMessages).toBe(0);
+    expect(metrics.terminatedConnections).toBe(0);
+    expect(hub.clientCount).toBe(CLIENT_COUNT - 1);
   });
 });
 


### PR DESCRIPTION
closes #746 
…ects
# test: verify StreamHub.broadcast tolerates mid-fan-out client disconnects

## Summary

Adds concurrency tests that prove `StreamHub.broadcast()` handles a client disconnecting (abrupt `terminate()` or clean `close()`) **during** the fan-out delivery loop — the promise resolves cleanly, remaining subscribers still receive the event, and `BackpressureMetrics` counters remain consistent.

## Problem

When a client disconnects while `StreamHub.broadcast()` is iterating over subscribers in `deliverBatch()`, the socket's `readyState` transitions to `CLOSING`/`CLOSED`. The existing code already skips non-OPEN sockets via a guard check, but there was no *defensive* error handling around `ws.send()` and no test verifying the scenario end-to-end.

Without this test, a future refactor could break the invariant that mid-fan-out disconnects are safe.

## Changes

### 1. `src/ws/hub.ts` — defensive exception safety

Wrapped `ws.send(message)` in `deliverBatch` with a try-catch that `continue`s on failure without incrementing counters. Same for `flushBatchDirect` (batch frame path), which increments `droppedMessages` and returns on failure. These are belt-and-suspenders — `ws.send()` is already safe for non-OPEN sockets — but they formally guarantee **no exception escapes `hub.ts`**.

### 2. `tests/ws/ws.concurrency.test.ts` — two new mid-fan-out tests

| Test | Method | Validates |
|------|--------|-----------|
| `handles abrupt ws.terminate() mid-broadcast fan-out` | `terminate()` | Promise resolves, 4/5 receive event, `sentMessages=4`, no counter skew |
| `handles clean ws.close() mid-broadcast fan-out` | `close()` | Same assertions for graceful close path |

**How the scenario is created deterministically:**
- 5 clients connect sequentially and subscribe to the same stream
- `vi.spyOn` intercepts `serverSockets[1].send` and calls `terminate()` / `close()` on `serverSockets[3]` before calling through to the real `send`
- Because `deliverBatch` iterates the batch array in order, the disconnect fires **during** the loop (client[3] hasn't been reached yet)
- The loop reaches client[3], sees `readyState !== OPEN`, skips it, and continues to the remaining clients

### 3. `docs/websocket.md` — Broadcast Resilience documentation

New subsection under micro-batching Security notes documenting that mid-fan-out disconnects are handled gracefully with consistent metrics.

## Test Results

```
 Test Files  1 passed (1)
      Tests  9 passed (9)   (7 existing + 2 new)
```

Full WS suite: 87/88 pass (1 pre-existing flaky timing test in `hub.batchFlushLatency.test.ts`).

## Security Assumptions Validated

- ✅ `broadcast()` promise never rejects when a subscriber disconnects mid-loop
- ✅ `BackpressureMetrics.sentMessages` = surviving subscriber count (no undercount)
- ✅ `BackpressureMetrics.droppedMessages` / `terminatedConnections` unaffected by external disconnects
- ✅ `hub.clientCount` drops by exactly 1 for the disconnected client
- ✅ No unhandled exceptions escape `hub.ts` (defensive try-catch + test verification)

## Files Changed

| File | Change |
|------|--------|
| `src/ws/hub.ts` | +12 lines: defensive try-catch in `deliverBatch` and `flushBatchDirect` |
| `tests/ws/ws.concurrency.test.ts` | +180 lines: new describe block with 2 tests + helpers |
| `docs/websocket.md` | +14 lines: Broadcast Resilience subsection |

## Commit Message

```
test: verify StreamHub.broadcast tolerates mid-fan-out client disconnects

Adds concurrency tests proving broadcast() handles abrupt terminate()
and clean close() during the fan-out loop. The promise resolves cleanly,
remaining subscribers receive the event, and BackpressureMetrics counters
stay consistent.

- deliverBatch: defensive try-catch around ws.send() (no exception escapes)
- flushBatchDirect: same try-catch for batch-frame path
- Two new tests covering ws.terminate() and ws.close() mid-iteration
- Broadcast Resilience section in docs/websocket.md

TEST RESULTS:
  - 9/9 concurrency tests pass (7 existing + 2 new)
  - 87/88 WS suite pass (1 pre-existing flaky timing test)
```
