### PR TITLE
fix: mount correlationIdMiddleware earlier to trace rejected requests

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -408,15 +408,17 @@ export function createApp(options: AppOptions = {}): Express {
   app.use(deploymentSlotMiddleware);
 
   app.use(requestTimeoutMiddleware(options.requestTimeoutMs ?? appConfig.requestTimeoutMs));
+  // Correlation ID must run before express.json() so req.correlationId is available
+  // even when JSON parsing throws and the error handler fires immediately.
+  // It must also run before early-reject middlewares (body size, content type) 
+  // so that rejected requests still carry a correlation ID.
+  app.use(correlationIdMiddleware);
   app.use(privacyHeaders);
   app.use(cspNonceMiddleware);
   app.use(createHelmetMiddleware());
   app.use(bodySizeLimitMiddleware);
   app.use('/api', requireJsonContentType);
   app.use('/api', requireJsonAccept);
-  // Correlation ID must run before express.json() so req.correlationId is available
-  // even when JSON parsing throws and the error handler fires immediately.
-  app.use(correlationIdMiddleware);
   app.use(express.json({ limit: BODY_LIMIT_BYTES }));
   app.use(methodOverrideMiddleware);
   app.use(apiVersionMiddleware);

--- a/tests/integration/early-rejection-correlation.test.ts
+++ b/tests/integration/early-rejection-correlation.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from 'vitest';
+import request from 'supertest';
+import { app } from '../../src/app.js';
+import { BODY_LIMIT_BYTES } from '../../src/middleware/requestProtection.js';
+import { CORRELATION_ID_HEADER } from '../../src/middleware/correlationId.js';
+
+describe('Early rejection correlation IDs', () => {
+  it('includes a correlation ID when rejecting an oversized body with 413', async () => {
+    // Generate a payload that exceeds the body size limit
+    const padding = 'x'.repeat(BODY_LIMIT_BYTES + 1);
+    
+    const res = await request(app)
+      .post('/api/streams')
+      .set('Content-Type', 'application/json')
+      .set('Accept', 'application/json')
+      .send(`{"data":"${padding}"}`);
+
+    expect(res.status).toBe(413);
+    const correlationId = res.headers[CORRELATION_ID_HEADER];
+    expect(correlationId).toBeDefined();
+    expect(typeof correlationId).toBe('string');
+    expect(correlationId.length).toBeGreaterThan(0);
+  });
+
+  it('includes a correlation ID when rejecting a wrong Content-Type with 415', async () => {
+    const res = await request(app)
+      .post('/api/streams')
+      .set('Content-Type', 'text/plain')
+      .set('Accept', 'application/json')
+      .send('not json');
+
+    expect(res.status).toBe(415);
+    const correlationId = res.headers[CORRELATION_ID_HEADER];
+    expect(correlationId).toBeDefined();
+    expect(typeof correlationId).toBe('string');
+    expect(correlationId.length).toBeGreaterThan(0);
+  });
+
+  it('includes a correlation ID when rejecting an unsatisfiable Accept header with 406', async () => {
+    const res = await request(app)
+      .get('/api/streams')
+      .set('Accept', 'text/html');
+
+    expect(res.status).toBe(406);
+    const correlationId = res.headers[CORRELATION_ID_HEADER];
+    expect(correlationId).toBeDefined();
+    expect(typeof correlationId).toBe('string');
+    expect(correlationId.length).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
Closes #857 
 This PR addresses an observability gap where requests rejected early by certain middlewares (bodySizeLimitMiddleware, requireJsonContentType, and requireJsonAccept) lacked a correlation ID. This made such requests (often representing probing or malformed payloads) difficult to trace in error logs and API responses during incidents.

Changes:

Reordered app.use() calls in src/app.ts so correlationIdMiddleware runs immediately after requestTimeoutMiddleware, and before bodySizeLimitMiddleware and content negotiation checks.
Added a new integration test (tests/integration/early-rejection-correlation.test.ts) that asserts an x-correlation-id header is successfully attached to 4xx early-rejection responses, specifically:
413 Payload Too Large (oversized body)
415 Unsupported Media Type (wrong Content-Type)
406 Not Acceptable (unsatisfiable Accept header)
Security Notes: This change restores end-to-end trace linkage for abuse-shaped and malformed traffic rejections, closing a critical observability gap without modifying any existing behavior for successfully-processed requests.