### PR TITLE
fix: validate limit/offset on webhook management routes with OffsetPaginationSchema

### DIFF
--- a/src/routes/webhooks.ts
+++ b/src/routes/webhooks.ts
@@ -11,6 +11,7 @@ import { getWebhookCircuitBreakerStore } from '../redis/webhookCircuitBreakerSto
 import { verifyWebhookSignature } from '../webhooks/signature.js';
 import { logger } from '../lib/logger.js';
 import { successResponse, errorResponse } from '../utils/response.js';
+import { OffsetPaginationSchema } from '../validation/paginationSchema.js';
 
 export const webhooksRouter = express.Router();
 
@@ -179,7 +180,21 @@ webhooksRouter.get('/deliveries/:deliveryId', (req: Request, res: Response): voi
  * List all webhook deliveries (for monitoring/debugging)
  */
 webhooksRouter.get('/deliveries', (req, res) => {
-  const { status, limit = 100, offset = 0 } = req.query;
+  const parsed = OffsetPaginationSchema.safeParse(req.query);
+  if (!parsed.success) {
+    const first = parsed.error.issues[0];
+    res.status(400).json({
+      error: {
+        code: 'INVALID_PAGINATION',
+        message: first?.message ?? 'Invalid pagination parameters',
+      },
+    });
+    return;
+  }
+
+  const limit  = parsed.data.limit  ?? 100;
+  const offset = parsed.data.offset ?? 0;
+  const { status } = req.query;
   
   let deliveries = webhookDeliveryStore.getAll();
   
@@ -188,7 +203,7 @@ webhooksRouter.get('/deliveries', (req, res) => {
   }
   
   const total = deliveries.length;
-  const paginated = deliveries.slice(Number(offset), Number(offset) + Number(limit));
+  const paginated = deliveries.slice(offset, offset + limit);
 
   res.json({
     total,
@@ -249,9 +264,21 @@ webhooksRouter.get('/outbox', (req, res) => {
  * List dead-letter queue items
  */
 webhooksRouter.get('/dlq', (req, res) => {
-  const { limit = 50 } = req.query;
+  const parsed = OffsetPaginationSchema.safeParse(req.query);
+  if (!parsed.success) {
+    const first = parsed.error.issues[0];
+    res.status(400).json({
+      error: {
+        code: 'INVALID_PAGINATION',
+        message: first?.message ?? 'Invalid pagination parameters',
+      },
+    });
+    return;
+  }
+
+  const limit = parsed.data.limit ?? 50;
   
-  const items = webhookDeliveryStore.getDeadLetterQueueItems(Number(limit));
+  const items = webhookDeliveryStore.getDeadLetterQueueItems(limit);
 
   res.json({
     total: items.length,

--- a/src/validation/paginationSchema.ts
+++ b/src/validation/paginationSchema.ts
@@ -66,4 +66,52 @@ export const PaginationSchema = z.object({
   include_total: z.enum(['true', 'false']).optional(),
 });
 
+/**
+ * Zod schema for offset-based pagination query parameters used by
+ * webhook management and other list endpoints.
+ *
+ * Both `limit` and `offset` are coerced from strings (query params) to
+ * integers and validated as non-negative integers within sane bounds.
+ * `limit` is capped at {@link MAX_PAGE_LIMIT} to prevent unbounded
+ * in-memory slice / serialize operations.
+ *
+ * Each field is optional to allow route-specific defaults.
+ *
+ * @module validation/paginationSchema
+ */
+export const OffsetPaginationSchema = z.object({
+  /**
+   * Maximum number of results to return. Capped at MAX_PAGE_LIMIT (100).
+   * The string is coerced to an integer because query params arrive as strings.
+   */
+  limit: z
+    .string()
+    .regex(/^\d+$/, 'limit must be a positive integer')
+    .transform((v) => Number.parseInt(v, 10))
+    .pipe(
+      z
+        .number()
+        .int('limit must be an integer')
+        .min(MIN_PAGE_LIMIT, `limit must be at least ${MIN_PAGE_LIMIT}`)
+        .max(MAX_PAGE_LIMIT, `limit must be at most ${MAX_PAGE_LIMIT}`),
+    )
+    .optional(),
+
+  /**
+   * Number of results to skip. Must be non-negative.
+   * The string is coerced to an integer because query params arrive as strings.
+   */
+  offset: z
+    .string()
+    .regex(/^\d+$/, 'offset must be a non-negative integer')
+    .transform((v) => Number.parseInt(v, 10))
+    .pipe(
+      z
+        .number()
+        .int('offset must be an integer')
+        .min(0, 'offset must be non-negative'),
+    )
+    .optional(),
+});
+
 export type PaginationQuery = z.infer<typeof PaginationSchema>;

--- a/tests/webhooks-pagination.test.ts
+++ b/tests/webhooks-pagination.test.ts
@@ -1,0 +1,198 @@
+/**
+ * Tests for pagination validation on webhook management routes.
+ *
+ * Covers the following acceptance criteria:
+ *  - Non-numeric limit/offset values return a clear 400 instead of a
+ *    silently empty/wrong page.
+ *  - A maximum page size is enforced server-side regardless of caller input.
+ *  - Negative values are rejected with a 400.
+ *  - Valid values pass through successfully.
+ */
+
+import express from 'express';
+import request from 'supertest';
+import { webhooksRouter } from '../src/routes/webhooks.js';
+import { webhookDeliveryStore } from '../src/webhooks/store.js';
+import { MAX_PAGE_LIMIT } from '../src/validation/paginationSchema.js';
+import type { WebhookDelivery } from '../src/webhooks/types.js';
+
+function buildApp() {
+  const app = express();
+  app.use('/internal/webhooks', webhooksRouter);
+  return app;
+}
+
+function createDelivery(overrides?: Partial<WebhookDelivery>): WebhookDelivery {
+  const now = Date.now();
+  return {
+    id: `delivery_${now}_${Math.random().toString(36).substr(2, 9)}`,
+    deliveryId: `deliv_${Math.random().toString(36).substr(2, 9)}`,
+    eventId: 'event_test',
+    eventType: 'stream.created',
+    endpointUrl: 'https://example.com/webhook',
+    status: 'delivered',
+    attempts: [],
+    createdAt: now,
+    updatedAt: now,
+    payload: '{}',
+    ...overrides,
+  };
+}
+
+describe('GET /internal/webhooks/deliveries — pagination validation', () => {
+  const app = buildApp();
+  const ENDPOINT = '/internal/webhooks/deliveries';
+
+  beforeEach(() => {
+    webhookDeliveryStore.clear();
+    // Seed some deliveries so we can test slicing
+    for (let i = 0; i < 5; i++) {
+      webhookDeliveryStore.store(createDelivery());
+    }
+  });
+
+  it('returns 400 for non-numeric limit', async () => {
+    const res = await request(app).get(ENDPOINT).query({ limit: 'abc' });
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe('INVALID_PAGINATION');
+  });
+
+  it('returns 400 for non-numeric offset', async () => {
+    const res = await request(app).get(ENDPOINT).query({ offset: 'xyz' });
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe('INVALID_PAGINATION');
+  });
+
+  it('returns 400 for negative limit', async () => {
+    const res = await request(app).get(ENDPOINT).query({ limit: '-1' });
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe('INVALID_PAGINATION');
+  });
+
+  it('returns 400 for negative offset', async () => {
+    const res = await request(app).get(ENDPOINT).query({ offset: '-5' });
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe('INVALID_PAGINATION');
+  });
+
+  it('returns 400 for limit exceeding MAX_PAGE_LIMIT', async () => {
+    const res = await request(app).get(ENDPOINT).query({ limit: String(MAX_PAGE_LIMIT + 1) });
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe('INVALID_PAGINATION');
+  });
+
+  it('returns 400 for zero limit', async () => {
+    const res = await request(app).get(ENDPOINT).query({ limit: '0' });
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe('INVALID_PAGINATION');
+  });
+
+  it('returns 400 for non-integer decimal limit', async () => {
+    const res = await request(app).get(ENDPOINT).query({ limit: '1.5' });
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe('INVALID_PAGINATION');
+  });
+
+  it('returns 200 for valid limit and offset (both provided)', async () => {
+    const res = await request(app).get(ENDPOINT).query({ limit: '3', offset: '1' });
+    expect(res.status).toBe(200);
+    // deliveries.slice(1, 1 + 3) → indices 1..3 → 3 items
+    expect(res.body.deliveries).toHaveLength(3);
+  });
+
+  it('returns 200 and uses default limit=100 when limit is omitted', async () => {
+    const res = await request(app).get(ENDPOINT);
+    expect(res.status).toBe(200);
+    expect(res.body.deliveries).toHaveLength(5);
+    expect(res.body.total).toBe(5);
+  });
+
+  it('returns 200 for limit at MAX_PAGE_LIMIT boundary', async () => {
+    const res = await request(app).get(ENDPOINT).query({ limit: String(MAX_PAGE_LIMIT) });
+    expect(res.status).toBe(200);
+  });
+
+  it('returns 200 for offset 0', async () => {
+    const res = await request(app).get(ENDPOINT).query({ offset: '0' });
+    expect(res.status).toBe(200);
+    expect(res.body.deliveries).toHaveLength(5);
+  });
+
+  it('returns empty deliveries array for offset beyond total', async () => {
+    const res = await request(app).get(ENDPOINT).query({ offset: '100' });
+    expect(res.status).toBe(200);
+    expect(res.body.deliveries).toHaveLength(0);
+  });
+});
+
+describe('GET /internal/webhooks/dlq — pagination validation', () => {
+  const app = buildApp();
+  const ENDPOINT = '/internal/webhooks/dlq';
+
+  function addDlqItem() {
+    const delivery = createDelivery({ status: 'permanent_failure' });
+    webhookDeliveryStore.addToDeadLetterQueue(delivery, 'Test failure');
+  }
+
+  beforeEach(() => {
+    webhookDeliveryStore.clear();
+    // Seed some DLQ items
+    for (let i = 0; i < 3; i++) {
+      addDlqItem();
+    }
+  });
+
+  it('returns 400 for non-numeric limit', async () => {
+    const res = await request(app).get(ENDPOINT).query({ limit: 'abc' });
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe('INVALID_PAGINATION');
+  });
+
+  it('returns 400 for negative limit', async () => {
+    const res = await request(app).get(ENDPOINT).query({ limit: '-1' });
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe('INVALID_PAGINATION');
+  });
+
+  it('returns 400 for limit exceeding MAX_PAGE_LIMIT', async () => {
+    const res = await request(app).get(ENDPOINT).query({ limit: String(MAX_PAGE_LIMIT + 1) });
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe('INVALID_PAGINATION');
+  });
+
+  it('returns 400 for zero limit', async () => {
+    const res = await request(app).get(ENDPOINT).query({ limit: '0' });
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe('INVALID_PAGINATION');
+  });
+
+  it('returns 400 for non-integer decimal limit', async () => {
+    const res = await request(app).get(ENDPOINT).query({ limit: '2.5' });
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe('INVALID_PAGINATION');
+  });
+
+  it('returns 200 for valid limit', async () => {
+    const res = await request(app).get(ENDPOINT).query({ limit: '2' });
+    expect(res.status).toBe(200);
+    expect(res.body.items).toHaveLength(2);
+  });
+
+  it('returns 200 and uses default limit=50 when limit is omitted', async () => {
+    const res = await request(app).get(ENDPOINT);
+    expect(res.status).toBe(200);
+    expect(res.body.items).toHaveLength(3);
+    expect(res.body.total).toBe(3);
+  });
+
+  it('returns 200 for limit at MAX_PAGE_LIMIT boundary', async () => {
+    const res = await request(app).get(ENDPOINT).query({ limit: String(MAX_PAGE_LIMIT) });
+    expect(res.status).toBe(200);
+  });
+
+  it('accepts offset query param on dlq route (validated but ignored)', async () => {
+    const res = await request(app).get(ENDPOINT).query({ offset: '5' });
+    // offset is accepted by the schema but ignored by the route handler
+    expect(res.status).toBe(200);
+  });
+});


### PR DESCRIPTION
## Summary

Add offset-based pagination validation to webhook management routes (GET /deliveries and GET /dlq) using a new OffsetPaginationSchema in the shared pagination validation module. Non-numeric, negative, zero, and excessively large limit/offset values now return a clear **400 INVALID_PAGINATION** error instead of silently producing empty or wrong-sized pages.

Fixes #847

## Problem

Unlike streamRepository's MAX_PAGE_SIZE clamp (enforced regardless of caller-supplied limit) and routes/streams.ts's parseLimit() (strict integer + range validation), the webhook management routes in src/routes/webhooks.ts passed query parameters straight into Number() and array slicing with no validation:

```ts
// GET /deliveries
const { status, limit = 100, offset = 0 } = req.query;
const paginated = deliveries.slice(Number(offset), Number(offset) + Number(limit));

// GET /dlq
const { limit = 50 } = req.query;
const items = webhookDeliveryStore.getDeadLetterQueueItems(Number(limit));
```

Number(limit) on a non-numeric string (e.g. ?limit=abc) produces NaN; Array.prototype.slice(NaN, NaN) silently returns an empty array rather than erroring — a confusing, silent failure mode for a debugging/monitoring endpoint. There was also no upper bound — ?limit=999999999 was accepted as-is.

## Changes

### src/validation/paginationSchema.ts
- Added `OffsetPaginationSchema` — a Zod schema for offset-based pagination with `limit` (1–100) and `offset` (>= 0) fields, both optional to allow route-specific defaults.
- Reuses the existing `MAX_PAGE_LIMIT` (100) constant for consistency with `PaginationSchema` and `streamRepository.MAX_PAGE_SIZE`.
- Follows the same validation pattern as the existing `PaginationSchema` (regex → transform → pipe with min/max).

### src/routes/webhooks.ts
- **GET /deliveries**: Validates `limit` and `offset` via `OffsetPaginationSchema.safeParse()`. Returns 400 INVALID_PAGINATION on bad input. Default limit: 100, default offset: 0.
- **GET /dlq**: Validates `limit` via `OffsetPaginationSchema.safeParse()`. Returns 400 INVALID_PAGINATION on bad input. Default limit: 50.

### tests/webhooks-pagination.test.ts (new)
21 tests covering:
- Non-numeric limit/offset → 400
- Negative limit/offset → 400
- Zero limit → 400
- Decimal (non-integer) limit → 400
- Limit exceeding MAX_PAGE_LIMIT (100) → 400
- Valid values → 200
- Defaults when omitted
- Offset beyond total → empty array

## Acceptance Criteria

- [x] Non-numeric limit/offset values return a clear 400 instead of silently empty/wrong page
- [x] A maximum page size is enforced server-side regardless of caller input
- [x] Tests cover the identified edge cases for both routes
- [x] Reuses existing pagination validation infrastructure from paginationSchema.ts
- [x] Negative values reject with clear 400
- [x] All 21 new tests pass (pre-existing failures are unrelated metrics counter issues)

## Testing

```
✓ tests/webhooks-pagination.test.ts (21 tests) 87ms
  21 passed
```

Pre-existing failures in tests/webhooks.test.ts (9 tests failing due to unmocked metrics counter) are unrelated to these changes.

Closes #847