### PR TITLE
feat: implement redis-backed webhook rate limiting and per-consumer c…

### DIFF
--- a/src/redis/webhookCircuitBreakerStore.ts
+++ b/src/redis/webhookCircuitBreakerStore.ts
@@ -58,6 +58,8 @@ export const transitionsTotal =
     registers: [registry],
   });
 
+export { webhookRateLimiterFailOpenTotal } from './webhookRateLimit.js';
+
 function closed(): WebhookCircuitBreakerRecord {
   return { state: 'closed', consecutiveFailures: 0, resetAt: 0 };
 }

--- a/src/redis/webhookRateLimit.ts
+++ b/src/redis/webhookRateLimit.ts
@@ -18,7 +18,19 @@
  */
 
 import { createHash } from 'node:crypto';
+import { Counter } from 'prom-client';
 import type { RedisClient } from './client.js';
+import { registry } from '../metrics.js';
+import { logger } from '../lib/logger.js';
+
+export const webhookRateLimiterFailOpenTotal =
+  (registry.getSingleMetric('fluxora_webhook_rate_limiter_fail_open_total') as Counter<'consumer_hash'>) ||
+  new Counter({
+    name: 'fluxora_webhook_rate_limiter_fail_open_total',
+    help: 'Total webhook rate limiter fail-open activations on Redis error',
+    labelNames: ['consumer_hash'] as const,
+    registers: [registry],
+  });
 
 export interface RateLimitConfig {
   /** Maximum delivery attempts allowed within the window. */
@@ -151,7 +163,13 @@ export class WebhookRateLimiter {
     } catch (err) {
       // Fail-open: log and allow the attempt so a Redis outage does not
       // silently halt all webhook deliveries.
-      console.error('[WebhookRateLimiter] Redis error — failing open:', err);
+      const consumerHash = hashUrl(consumerUrl);
+      webhookRateLimiterFailOpenTotal.inc({ consumer_hash: consumerHash });
+      logger.error('WebhookRateLimiter Redis error — failing open', undefined, {
+        operation: 'checkLimit',
+        consumerKey: consumerHash,
+        error: err instanceof Error ? err.message : String(err),
+      });
       return { canAttempt: true, retryAfterMs: null };
     }
   }

--- a/tests/redis/webhookRateLimit.test.ts
+++ b/tests/redis/webhookRateLimit.test.ts
@@ -1,0 +1,170 @@
+/**
+ * WebhookRateLimiter unit and regression tests.
+ *
+ * Covers:
+ *   - Config validation (limit, windowMs)
+ *   - Normal sliding-window rate limiting using FakeRedisClient
+ *   - Consumer config management (set, resolve, remove)
+ *   - Fail-open behavior on Redis failure:
+ *       - Returns canAttempt: true
+ *       - Increments fluxora_webhook_rate_limiter_fail_open_total Prometheus counter
+ *       - Logs via structured logger.error (NOT console.error)
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { createHash } from 'node:crypto';
+import {
+  WebhookRateLimiter,
+  webhookRateLimiterFailOpenTotal,
+  createWebhookRateLimiter,
+  RateLimitConfigError,
+  validateRateLimitConfig,
+} from '../../src/redis/webhookRateLimit.js';
+import { FakeRedisClient } from '../../src/redis/__test__/fakeRedisClient.js';
+import { logger } from '../../src/lib/logger.js';
+
+const consumerUrl = 'https://consumer.example/webhook';
+const defaultConfig = { limit: 5, windowMs: 1000 };
+
+function hashUrl(url: string): string {
+  return createHash('sha256').update(url).digest('hex').slice(0, 16);
+}
+
+describe('WebhookRateLimiter', () => {
+  let redis: FakeRedisClient;
+  let limiter: WebhookRateLimiter;
+
+  beforeEach(() => {
+    redis = new FakeRedisClient();
+    limiter = createWebhookRateLimiter(redis);
+    webhookRateLimiterFailOpenTotal.reset();
+  });
+
+  afterEach(() => {
+    redis.reset();
+    vi.restoreAllMocks();
+  });
+
+  describe('Config validation', () => {
+    it('throws RateLimitConfigError on invalid limit', () => {
+      expect(() => validateRateLimitConfig({ limit: 0, windowMs: 1000 })).toThrow(
+        RateLimitConfigError,
+      );
+      expect(() => validateRateLimitConfig({ limit: -5, windowMs: 1000 })).toThrow(
+        RateLimitConfigError,
+      );
+      expect(() => validateRateLimitConfig({ limit: 200_000, windowMs: 1000 })).toThrow(
+        RateLimitConfigError,
+      );
+    });
+
+    it('throws RateLimitConfigError on invalid windowMs', () => {
+      expect(() => validateRateLimitConfig({ limit: 10, windowMs: 50 })).toThrow(
+        RateLimitConfigError,
+      );
+      expect(() => validateRateLimitConfig({ limit: 10, windowMs: 10_000_000 })).toThrow(
+        RateLimitConfigError,
+      );
+    });
+
+    it('validates config successfully for valid inputs', () => {
+      expect(() => validateRateLimitConfig({ limit: 100, windowMs: 5000 })).not.toThrow();
+    });
+  });
+
+  describe('Consumer config management', () => {
+    it('allows setting, resolving, and removing custom consumer configs', () => {
+      const customConfig = { limit: 20, windowMs: 2000 };
+      limiter.setConsumerConfig(consumerUrl, customConfig);
+
+      expect(limiter.resolveConfig(consumerUrl, defaultConfig)).toEqual(customConfig);
+
+      limiter.removeConsumerConfig(consumerUrl);
+      expect(limiter.resolveConfig(consumerUrl, defaultConfig)).toEqual(defaultConfig);
+    });
+  });
+
+  describe('Sliding-window rate limiting under normal operation', () => {
+    it('allows attempts up to the configured limit', async () => {
+      for (let i = 0; i < 5; i++) {
+        const result = await limiter.checkLimit(consumerUrl, defaultConfig);
+        expect(result.canAttempt).toBe(true);
+        expect(result.retryAfterMs).toBeNull();
+      }
+    });
+
+    it('rejects attempt when limit is exceeded', async () => {
+      for (let i = 0; i < 5; i++) {
+        await limiter.checkLimit(consumerUrl, defaultConfig);
+      }
+
+      const rejected = await limiter.checkLimit(consumerUrl, defaultConfig);
+      expect(rejected.canAttempt).toBe(false);
+      expect(rejected.retryAfterMs).toBe(defaultConfig.windowMs);
+    });
+
+    it('recordFailure is a no-op promise', async () => {
+      await expect(limiter.recordFailure(consumerUrl, defaultConfig)).resolves.toBeUndefined();
+    });
+  });
+
+  describe('Fail-open behavior on Redis failure', () => {
+    it('fails open, logs via structured logger, and increments counter on exec failure', async () => {
+      const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+      const loggerErrorSpy = vi.spyOn(logger, 'error').mockImplementation(() => {});
+
+      // Simulate a pipeline exec failure
+      redis.throwOnNext('exec', 'Redis cluster unreachable');
+
+      const result = await limiter.checkLimit(consumerUrl, defaultConfig);
+
+      // Must fail open
+      expect(result.canAttempt).toBe(true);
+      expect(result.retryAfterMs).toBeNull();
+
+      // Must NOT use console.error
+      expect(consoleErrorSpy).not.toHaveBeenCalled();
+
+      // Must use structured logger.error
+      const expectedHash = hashUrl(consumerUrl);
+      expect(loggerErrorSpy).toHaveBeenCalledTimes(1);
+      expect(loggerErrorSpy).toHaveBeenCalledWith(
+        'WebhookRateLimiter Redis error — failing open',
+        undefined,
+        expect.objectContaining({
+          operation: 'checkLimit',
+          consumerKey: expectedHash,
+          error: 'Redis cluster unreachable',
+        }),
+      );
+
+      // Must increment Prometheus fail-open counter
+      const metricVal = await webhookRateLimiterFailOpenTotal.get();
+      const match = metricVal.values.find((v) => v.labels.consumer_hash === expectedHash);
+      expect(match).toBeDefined();
+      expect(match?.value).toBe(1);
+    });
+
+    it('fails open, logs via structured logger, and increments counter on zcount failure', async () => {
+      const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+      const loggerErrorSpy = vi.spyOn(logger, 'error').mockImplementation(() => {});
+
+      // Simulate a zcount failure
+      redis.throwOnNext('zcount', 'Redis connection timeout');
+
+      const result = await limiter.checkLimit(consumerUrl, defaultConfig);
+
+      expect(result.canAttempt).toBe(true);
+      expect(result.retryAfterMs).toBeNull();
+
+      expect(consoleErrorSpy).not.toHaveBeenCalled();
+      expect(loggerErrorSpy).toHaveBeenCalledTimes(1);
+
+      const expectedHash = hashUrl(consumerUrl);
+      const metricVal = await webhookRateLimiterFailOpenTotal.get();
+      const match = metricVal.values.find((v) => v.labels.consumer_hash === expectedHash);
+      expect(match).toBeDefined();
+      expect(match?.value).toBe(1);
+    });
+  });
+});


### PR DESCRIPTION
closes #823 


Here is a Pull Request title and description based on the completed work:

***

### PR Title
`feat(redis): add fail-open metric and structured logging to WebhookRateLimiter`

### PR Description

#### 📝 Summary
Resolves an availability observability gap in `WebhookRateLimiter.checkLimit()`. Previously, when Redis experienced outages or connectivity errors, `checkLimit()` failed open (allowing delivery attempts) but logged via `console.error` and emitted no Prometheus metric. This degraded rate limiting into an unmonitored open state without operator visibility.

This PR:
1. Replaces `console.error` with the project's canonical structured JSON logger (`logger.error`) in `src/redis/webhookRateLimit.ts`.
2. Defines and registers the Prometheus counter `fluxora_webhook_rate_limiter_fail_open_total` (`webhookRateLimiterFailOpenTotal`) with a bounded `consumer_hash` label.
3. Adds a unit and regression test suite (`tests/redis/webhookRateLimit.test.ts`) proving structured logging, zero console output, and metric incrementation on simulated Redis failures.

---

#### 🧪 Key Changes

- **`src/redis/webhookRateLimit.ts`**:
  - Registered `webhookRateLimiterFailOpenTotal` counter with metric name `fluxora_webhook_rate_limiter_fail_open_total` and label `consumer_hash`.
  - Updated `checkLimit` catch block to call `webhookRateLimiterFailOpenTotal.inc({ consumer_hash })` and `logger.error('WebhookRateLimiter Redis error — failing open', ...)`.
  - Removed all `console.error` usages.
- **`src/redis/webhookCircuitBreakerStore.ts`**:
  - Re-exported `webhookRateLimiterFailOpenTotal` alongside circuit breaker metrics.
- **`tests/redis/webhookRateLimit.test.ts`**:
  - Added unit tests for rate limiter configuration validation, sliding-window checks, and consumer config overrides.
  - Added regression test cases asserting that Redis errors trigger fail-open (`canAttempt: true`), log via `logger.error` with standard metadata, do not output to `console.error`, and increment `fluxora_webhook_rate_limiter_fail_open_total`.

---

#### ✅ Verification

```bash
# Run WebhookRateLimiter test suite
pnpm test tests/redis/webhookRateLimit.test.ts

# Output:
# ✓ tests/redis/webhookRateLimit.test.ts (9 tests passed)
```

- [x] All 9 tests in `webhookRateLimit.test.ts` pass cleanly.
- [x] Zero `console.error` / `console.log` statements remain in `src/redis/webhookRateLimit.ts`.
- [x] Metric `fluxora_webhook_rate_limiter_fail_open_total` is registered on `registry`.