### PR TITLE
fix: make fingerprintInput key-order-independent with canonical serialization

### DIFF
--- a/src/routes/streams.ts
+++ b/src/routes/streams.ts
@@ -72,6 +72,7 @@ import { recordAuditEvent } from '../lib/auditLog.js';
 import { authenticate, requireAuth, authenticateApiKey, requireScope } from '../middleware/auth.js';
 import { successResponse, idempotentReplayResponse } from '../utils/response.js';
 import { sendEarlyHints } from '../utils/earlyHints.js';
+import { canonicalizeBody } from '../middleware/idempotency.js';
 import { streamRepository } from '../db/repositories/streamRepository.js';
 import { PoolExhaustedError } from '../db/pool.js';
 import {
@@ -408,8 +409,8 @@ function normalizeCreateInput(body: Record<string, unknown>): NormalizedCreateIn
   };
 }
 
-function fingerprintInput(input: NormalizedCreateInput): string {
-  return crypto.createHash('sha256').update(JSON.stringify(input)).digest('hex');
+export function fingerprintInput(input: NormalizedCreateInput): string {
+  return crypto.createHash('sha256').update(canonicalizeBody(input)).digest('hex');
 }
 
 /** Wrap DB errors so pool exhaustion surfaces as 503. */

--- a/tests/routes/streams.test.ts
+++ b/tests/routes/streams.test.ts
@@ -51,6 +51,7 @@ import {
   _resetStreams,
   setStreamListingDependencyState,
   setIdempotencyDependencyState,
+  fingerprintInput,
 } from '../../src/routes/streams.js';
 import { initializeConfig } from '../../src/config/env.js';
 import { generateToken } from '../../src/lib/auth.js';
@@ -341,6 +342,85 @@ describe('streams routes', () => {
     });
   });
 
+
+  // ── fingerprintInput() key-order stability ───────────────────────────────
+
+  describe('fingerprintInput()', () => {
+    it('produces the same digest regardless of NormalizedCreateInput key insertion order', () => {
+      const values = {
+        sender:        'GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN7',
+        recipient:     'GBDEVU63Y6NTHJQQZIKVTC23NWLQVP3WJ2RI2OTSJTNYOIGICST6DUXR',
+        depositAmount: '1000',
+        ratePerSecond: '10',
+        startTime:     1700000000,
+        endTime:       0,
+      };
+
+      // Object A: properties in canonical (sorted) order
+      const objA: Record<string, unknown> = {
+        depositAmount: values.depositAmount,
+        endTime:       values.endTime,
+        ratePerSecond: values.ratePerSecond,
+        recipient:     values.recipient,
+        sender:        values.sender,
+        startTime:     values.startTime,
+      };
+
+      // Object B: properties in reverse order
+      const objB: Record<string, unknown> = {
+        startTime:     values.startTime,
+        sender:        values.sender,
+        recipient:     values.recipient,
+        ratePerSecond: values.ratePerSecond,
+        endTime:       values.endTime,
+        depositAmount: values.depositAmount,
+      };
+
+      // Object C: properties in insertion-order (as returned by normalizeCreateInput)
+      const objC: Record<string, unknown> = {
+        sender:        values.sender,
+        recipient:     values.recipient,
+        depositAmount: values.depositAmount,
+        ratePerSecond: values.ratePerSecond,
+        startTime:     values.startTime,
+        endTime:       values.endTime,
+      };
+
+      const fpA = fingerprintInput(objA as Parameters<typeof fingerprintInput>[0]);
+      const fpB = fingerprintInput(objB as Parameters<typeof fingerprintInput>[0]);
+      const fpC = fingerprintInput(objC as Parameters<typeof fingerprintInput>[0]);
+
+      expect(fpA).toBe(fpB);
+      expect(fpB).toBe(fpC);
+    });
+
+    it('produces different digests for different input values', async () => {
+      const base: Parameters<typeof fingerprintInput>[0] = {
+        sender:        'GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN7',
+        recipient:     'GBDEVU63Y6NTHJQQZIKVTC23NWLQVP3WJ2RI2OTSJTNYOIGICST6DUXR',
+        depositAmount: '1000',
+        ratePerSecond: '10',
+        startTime:     1700000000,
+        endTime:       0,
+      };
+
+      const modified = { ...base, depositAmount: '9999' };
+      expect(fingerprintInput(base)).not.toBe(fingerprintInput(modified));
+    });
+
+    it('returns a 64-character hex string', () => {
+      const input: Parameters<typeof fingerprintInput>[0] = {
+        sender:        'GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN7',
+        recipient:     'GBDEVU63Y6NTHJQQZIKVTC23NWLQVP3WJ2RI2OTSJTNYOIGICST6DUXR',
+        depositAmount: '1000',
+        ratePerSecond: '10',
+        startTime:     1700000000,
+        endTime:       0,
+      };
+      const fp = fingerprintInput(input);
+      expect(fp).toMatch(/^[a-f0-9]{64}$/);
+    });
+  });
 
   // ── POST /api/streams — idempotency ──────────────────────────────────────
 


### PR DESCRIPTION
## Description

`fingerprintInput()` in `src/routes/streams.ts` computes the SHA-256 fingerprint used to detect "same Idempotency-Key, different body" conflicts. It previously used `JSON.stringify(input)`, whose output is sensitive to JavaScript object key insertion order. While the current code path constructs `NormalizedCreateInput` via a single literal in `normalizeCreateInput()`, a future refactor could silently change key order and cause false `409 CONFLICT` responses on legitimate idempotent retries.

## Changes

### `src/routes/streams.ts`
- **Imported `canonicalizeBody`** from `../middleware/idempotency.js` — a pre-existing utility that recursively serializes objects with sorted keys for deterministic output
- **Replaced `JSON.stringify(input)`** with `canonicalizeBody(input)` in `fingerprintInput()` — makes the fingerprint explicitly order-independent
- **Exported `fingerprintInput`** — enables direct unit testing without going through the HTTP layer

### `tests/routes/streams.test.ts`
- **Key-order stability test** — verifies the same digest for three objects with identical values but constructed in sorted, reverse, and natural property insertion orders. This test would fail with the old `JSON.stringify` implementation
- **Different-values test** — confirms that different inputs produce different digests (hash collision resistance sanity check)
- **Format validation** — asserts the output is a 64-character hex string as expected

## Why `canonicalizeBody`?
The `canonicalizeBody` function was already introduced in `src/middleware/idempotency.ts` for the Express middleware-level idempotency handling. It recursively sorts object keys, producing a deterministic JSON-like string regardless of property insertion order. Reusing it here ensures consistent canonicalization across both the route-level and middleware-level idempotency layers.

## Compatibility
Existing idempotency-store entries (stored with the previous `JSON.stringify`-based fingerprint) will not match fingerprints computed with `canonicalizeBody` due to different key ordering. However, since the idempotency TTL defaults to 24 hours and the input shape hasn't changed, this is a narrow transition window. No envelope version bump was required (the `ENVELOPE_VERSION` in `idempotencyStore.ts` governs the stored entry schema, not the fingerprint algorithm).

## Testing
All 3 new tests pass. Existing test coverage remains unchanged.

Close #850