### PR TITLE
fix(auth): stop throwing unhandled ReferenceError on X-API-Key requests (closes #836)

### DIFF
--- a/src/lib/apiKey.ts
+++ b/src/lib/apiKey.ts
@@ -268,6 +268,39 @@ export function getApiKeyFromRequest(
 }
 
 /**
+ * Resolves a raw API key to its full {@link ApiKeyRecord} (including scopes),
+ * or `undefined` if the key is unknown or inactive.
+ *
+ * Uses the same prefix-lookup + constant-time hash comparison as
+ * {@link isValidApiKey} but returns the record instead of a boolean so the
+ * auth middleware can attach scopes and key identity to the request.
+ *
+ * @param rawKey - The raw key presented by the caller.
+ */
+export async function findRecordByRawKey(rawKey: string): Promise<ApiKeyRecord | undefined> {
+  const endTimer = authApiKeyLookupDurationSeconds.startTimer();
+
+  if (!rawKey || typeof rawKey !== 'string') {
+    endTimer({ outcome: 'failure' });
+    return undefined;
+  }
+
+  const prefix = rawKey.slice(0, PREFIX_LENGTH);
+  const candidates = await apiKeyRepository.findActiveByPrefix(prefix);
+
+  let matchedRecord: ApiKeyRecord | undefined;
+  for (const candidate of candidates) {
+    // Compare every candidate (do not early-return) so timing does not reveal
+    // which row, if any, matched within a colliding prefix bucket.
+    if (hashesMatch(hashKey(rawKey, candidate.salt), candidate.keyHash)) {
+      matchedRecord = candidate;
+    }
+  }
+  endTimer({ outcome: matchedRecord ? 'success' : 'failure' });
+  return matchedRecord;
+}
+
+/**
  * Retrieves the scopes for an API key by its ID.
  * Returns the scopes array or undefined if the key is not found.
  */

--- a/src/middleware/auth.ts
+++ b/src/middleware/auth.ts
@@ -5,7 +5,7 @@ import { warn, info, debug } from '../utils/logger.js';
 import { z } from 'zod';
 import { isRevoked } from '../redis/jwtRevocationStore.js';
 import { authJwtVerifyDurationSeconds } from '../metrics/businessMetrics.js';
-import { getApiKeyFromRequest, getApiKeyRecord } from '../lib/apiKey.js';
+import { getApiKeyFromRequest, findRecordByRawKey } from '../lib/apiKey.js';
 
 
 /**
@@ -24,7 +24,7 @@ export async function authenticateApiKey(req: Request, res: Response, next: Next
   }
 
   try {
-    const record = getApiKeyRecord(rawKey);
+    const record = await findRecordByRawKey(rawKey);
     
     if (!record) {
       warn('API y authentication failed — key not found', { requestId });
@@ -61,7 +61,7 @@ export async function authenticateApiKey(req: Request, res: Response, next: Next
     });
     return res.status(401).json({
       error: {
-        code: ApiError.UNAUTHORIZED,
+        code: ApiErrorCode.UNAUTHORIZED,
         message: 'Authentication failed',
         requestId,
       },

--- a/tests/unit/middleware/auth.test.ts
+++ b/tests/unit/middleware/auth.test.ts
@@ -352,3 +352,74 @@ describe('requirePermission', () => {
     expect(next).not.toHaveBeenCalled();
   });
 });
+
+// ── Issue #836: API-key auth must never throw an unhandled exception ──
+
+vi.mock('../../../src/lib/apiKey.js', () => ({
+  getApiKeyFromRequest: vi.fn(),
+  findRecordByRawKey: vi.fn(),
+  isValidApiKey: vi.fn(),
+}));
+
+import { authenticateApiKey } from '../../../src/middleware/auth.js';
+import { findRecordByRawKey, getApiKeyFromRequest } from '../../../src/lib/apiKey.js';
+
+function mockReqWithApiKey(key?: string): Partial<Request> {
+  return {
+    headers: key ? { 'x-api-key': key } : {},
+    id: 'req-836',
+    correlationId: 'req-836',
+  };
+}
+
+describe('authenticateApiKey (issue #836)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns a clean 401 (not 500) for an unknown API key', async () => {
+    (getApiKeyFromRequest as any).mockReturnValue('flx_unknownkeyvalue');
+    (findRecordByRawKey as any).mockResolvedValue(undefined);
+
+    const req = mockReqWithApiKey('flx_unknownkeyvalue') as Request;
+    const res = mockRes() as Response;
+    const next = mockNext();
+
+    await authenticateApiKey(req, res, next);
+
+    expect(res.statusCode).toBe(401);
+    expect((res as any).jsonBody.error.code).toBe('UNAUTHORIZED');
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it('authenticates a valid active key and attaches scopes', async () => {
+    (getApiKeyFromRequest as any).mockReturnValue('flx_validkeyvalue');
+    (findRecordByRawKey as any).mockResolvedValue({
+      id: 'key-1',
+      active: true,
+      scopes: ['streams:read', 'streams:write'],
+    });
+
+    const req = mockReqWithApiKey('flx_validkeyvalue') as Request;
+    const res = mockRes() as Response;
+    const next = mockNext();
+
+    await authenticateApiKey(req, res, next);
+
+    expect(next).toHaveBeenCalled();
+    expect((req as any).keyId).toBe('key-1');
+    expect((req as any).keyScopes).toEqual(['streams:read', 'streams:write']);
+  });
+
+  it('proceeds without keyScopes when no API key header is present', async () => {
+    (getApiKeyFromRequest as any).mockReturnValue(undefined);
+
+    const req = mockReqWithApiKey() as Request;
+    const res = mockRes() as Response;
+    const next = mockNext();
+
+    await authenticateApiKey(req, res, next);
+
+    expect(next).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #836 — `authenticateApiKey` threw an unhandled `ReferenceError` on every `X-API-Key` request, breaking API-key auth entirely.

### Root cause
1. `authenticateApiKey` called the dead in-memory `getApiKeyRecord()`, which referenced undefined `store` / `sha256hex` and always threw.
2. The `catch` block referenced `ApiError.UNAUTHORIZED` (undefined) instead of the imported `ApiErrorCode.UNAUTHORIZED`, so the failure path itself crashed.

### Changes
- Added repo-backed async helper `findRecordByRawKey(rawKey)` in `src/lib/apiKey.ts` (constant-time compare via `apiKeyRepository.findActiveByPrefix`).
- `authenticateApiKey` now awaits `findRecordByRawKey` instead of the dead sync call.
- Fixed `ApiError.UNAUTHORIZED` → `ApiErrorCode.UNAUTHORIZED` in the catch block.

### Verification
- `npx tsc --noEmit` clean for `src/middleware/auth.ts` and `src/lib/apiKey.ts` (other repo errors are pre-existing, unrelated).
- `npx vitest run tests/unit/middleware/auth.test.ts` → 19/19 pass, including 3 new tests:
  - unknown key → clean 401 (no unhandled exception / 500)
  - valid active key → authenticates, attaches keyId + keyScopes
  - no key header → proceeds to next()

Closes #836