### PR TITLE
Closes #831

### DIFF
--- a/src/db/writeFencePin.ts
+++ b/src/db/writeFencePin.ts
@@ -47,6 +47,20 @@
  * `0` disables pin enforcement entirely (all reads go to replica/primary per
  * normal routing).
  *
+ * ## Clock-skew tolerance
+ *
+ * In multi-instance deployments, `issueWriteFencePin()` may run on one
+ * replica and `verifyWriteFencePin()` on another moments later.  If the
+ * verifier's wall clock is slightly behind the issuer's, `ageMs` can be
+ * briefly negative (`Date.now() - issuedAt < 0`) and a freshly issued pin
+ * would be rejected with a strict `ageMs < 0` check.
+ *
+ * Verification therefore allows a small **one-sided** leeway of
+ * {@link CLOCK_SKEW_TOLERANCE_MS} (2 s): pins that appear up to that far
+ * in the future are still honored.  The upper-bound TTL check is **not**
+ * loosened — expired pins remain rejected — so replay resistance is not
+ * meaningfully weakened.
+ *
  * @module db/writeFencePin
  */
 
@@ -63,6 +77,18 @@ export const WRITE_FENCE_HEADER = 'X-Fluxora-Write-Fence' as const;
  * applies.  30 s is generous for most replica lag configurations.
  */
 const DEFAULT_TTL_SECONDS = 30;
+
+/**
+ * Maximum negative `ageMs` (pin timestamp ahead of verifier clock) still
+ * accepted at verify time.
+ *
+ * Chosen small enough that it does not extend the effective TTL / replay
+ * window in any meaningful way, but large enough to absorb typical NTP
+ * jitter and brief cross-instance clock disagreement in multi-replica
+ * deployments.  Only softens the "issued in the future" edge — see module
+ * JSDoc "Clock-skew tolerance".
+ */
+export const CLOCK_SKEW_TOLERANCE_MS = 2_000;
 
 /** Protocol version embedded at the start of every pin. */
 const PIN_VERSION = 'v1' as const;
@@ -145,6 +171,11 @@ export function issueWriteFencePin(): string {
  * pin — callers should treat a `false` result as "use normal routing" rather
  * than as an error.
  *
+ * Pins whose embedded timestamp is slightly ahead of the verifier's clock
+ * (negative `ageMs` within {@link CLOCK_SKEW_TOLERANCE_MS}) are accepted so
+ * cross-instance clock skew does not drop a fresh fence.  Age beyond the
+ * configured TTL is still rejected strictly.
+ *
  * **Timing safety**: signature comparison uses `crypto.timingSafeEqual` so
  * the function does not leak key material through response timing.
  *
@@ -195,7 +226,11 @@ export function verifyWriteFencePin(
 
   const issuedAt = parseInt(tsMs, 10);
   const ageMs = Date.now() - issuedAt;
-  if (ageMs < 0 || ageMs > ttlSeconds * 1000) return false;
+  // One-sided skew leeway: allow a pin that looks slightly "in the future"
+  // (issuer clock ahead of verifier). Do not loosen the TTL upper bound.
+  if (ageMs < -CLOCK_SKEW_TOLERANCE_MS || ageMs > ttlSeconds * 1000) {
+    return false;
+  }
 
   // Derive expected signature
   let key: Buffer;

--- a/tests/db/replicaPool.readYourWrites.test.ts
+++ b/tests/db/replicaPool.readYourWrites.test.ts
@@ -10,6 +10,7 @@
  *   5. Security assumptions — HMAC forging, replay after TTL, constant-time
  *   6. Edge cases — boundary timestamps, RYW_PIN_TTL_SECONDS=0, missing env
  *   7. streamRepository.findWithCursor options forwarding (forcePrimary)
+ *   8. Clock-skew tolerance — future timestamps within/beyond leeway (#831)
  *
  * @module tests/db/replicaPool.readYourWrites.test.ts
  */
@@ -54,6 +55,7 @@ import {
   verifyWriteFencePin,
   shouldForcePrimaryFromHeaders,
   WRITE_FENCE_HEADER,
+  CLOCK_SKEW_TOLERANCE_MS,
 } from '../../src/db/writeFencePin.js';
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -212,7 +214,8 @@ describe('writeFencePin', () => {
       expect(verifyWriteFencePin(pin)).toBe(true);
     });
 
-    it('returns false for a pin with a future timestamp (clock skew / replay guard)', () => {
+    it('returns false for a pin far in the future (beyond clock-skew tolerance)', () => {
+      // Well beyond CLOCK_SKEW_TOLERANCE_MS — must still reject.
       const futureMs = (Date.now() + 10_000).toString();
       const sig = makeHmac(VALID_SECRET, 'v1', futureMs);
       const pin = buildPin('v1', futureMs, sig);
@@ -358,6 +361,58 @@ describe('writeFencePin', () => {
     it('returns false when JWT_SECRET is too short at verification time', () => {
       const pin = issueWriteFencePin();
       process.env['JWT_SECRET'] = 'short';
+      expect(verifyWriteFencePin(pin)).toBe(false);
+    });
+  });
+
+  // ── Clock-skew tolerance (#831) ───────────────────────────────────────────
+
+  describe('clock-skew tolerance (issue/verify across instances)', () => {
+    it('exports a small positive CLOCK_SKEW_TOLERANCE_MS', () => {
+      expect(CLOCK_SKEW_TOLERANCE_MS).toBe(2_000);
+      expect(CLOCK_SKEW_TOLERANCE_MS).toBeGreaterThan(0);
+      // Must stay well below the default TTL so it does not extend replay window.
+      expect(CLOCK_SKEW_TOLERANCE_MS).toBeLessThan(30_000);
+    });
+
+    it('accepts a pin issued slightly ahead of verifier clock (within tolerance)', () => {
+      // Simulates issuer clock ahead of verifier by (tolerance - 1 ms).
+      const aheadMs = (Date.now() + CLOCK_SKEW_TOLERANCE_MS - 1).toString();
+      const sig = makeHmac(VALID_SECRET, 'v1', aheadMs);
+      const pin = buildPin('v1', aheadMs, sig);
+      expect(verifyWriteFencePin(pin)).toBe(true);
+    });
+
+    it('accepts a pin at the exact CLOCK_SKEW_TOLERANCE_MS boundary', () => {
+      const aheadMs = (Date.now() + CLOCK_SKEW_TOLERANCE_MS).toString();
+      const sig = makeHmac(VALID_SECRET, 'v1', aheadMs);
+      const pin = buildPin('v1', aheadMs, sig);
+      // ageMs === -CLOCK_SKEW_TOLERANCE_MS → still accepted (>= -tolerance).
+      expect(verifyWriteFencePin(pin)).toBe(true);
+    });
+
+    it('rejects a pin issued ahead of verifier clock beyond tolerance', () => {
+      const aheadMs = (Date.now() + CLOCK_SKEW_TOLERANCE_MS + 1).toString();
+      const sig = makeHmac(VALID_SECRET, 'v1', aheadMs);
+      const pin = buildPin('v1', aheadMs, sig);
+      expect(verifyWriteFencePin(pin)).toBe(false);
+    });
+
+    it('accepts a pin issued slightly behind verifier clock (normal past age)', () => {
+      // Issuer clock behind verifier → positive ageMs; still within TTL.
+      const behindMs = (Date.now() - 500).toString();
+      const sig = makeHmac(VALID_SECRET, 'v1', behindMs);
+      const pin = buildPin('v1', behindMs, sig);
+      expect(verifyWriteFencePin(pin)).toBe(true);
+    });
+
+    it('keeps the TTL upper bound strict (no skew loosening on expiry)', () => {
+      process.env['RYW_PIN_TTL_SECONDS'] = '30';
+      // Past the TTL by 1 ms — must reject even though skew leeway exists on
+      // the future edge only.
+      const expiredMs = (Date.now() - 30_000 - 1).toString();
+      const sig = makeHmac(VALID_SECRET, 'v1', expiredMs);
+      const pin = buildPin('v1', expiredMs, sig);
       expect(verifyWriteFencePin(pin)).toBe(false);
     });
   });


### PR DESCRIPTION
Closes #831

---

## Summary
- Accept write-fence pins that look up to 2s in the future at verify time (cross-instance clock skew)
- Keep the TTL expiry check strict — no extra lifetime for expired pins
- Document `CLOCK_SKEW_TOLERANCE_MS` in `writeFencePin.ts` and add regression tests

## Test plan
- [x] `npx vitest run tests/db/replicaPool.readYourWrites.test.ts` (63 passed)