### PR TITLE
test(env): add production profile validation and test matrix (closes #702)

### DIFF
--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -369,6 +369,32 @@ export const EnvSchema = z.object({
       message: 'API_KEY_PEPPER is required when API_KEYS is configured',
     });
   }
+
+  if (env.NODE_ENV === 'production') {
+    if (env.LOG_LEVEL === 'debug') {
+      ctx.addIssue({
+        code: 'custom',
+        path: ['LOG_LEVEL'],
+        message: 'LOG_LEVEL must not be "debug" in production',
+      });
+    }
+
+    if (env.CORS_ALLOWED_ORIGINS !== undefined && env.CORS_ALLOWED_ORIGINS.includes('*')) {
+      ctx.addIssue({
+        code: 'custom',
+        path: ['CORS_ALLOWED_ORIGINS'],
+        message: 'CORS_ALLOWED_ORIGINS must not contain a wildcard "*" origin in production',
+      });
+    }
+
+    if (env.PGCRYPTO_KEY === undefined || env.PGCRYPTO_KEY.length < 32) {
+      ctx.addIssue({
+        code: 'custom',
+        path: ['PGCRYPTO_KEY'],
+        message: 'PGCRYPTO_KEY is required in production (minimum 32 characters)',
+      });
+    }
+  }
 });
 
 type ParsedEnv = z.infer<typeof EnvSchema>;

--- a/tests/config/env.validation.test.ts
+++ b/tests/config/env.validation.test.ts
@@ -2,6 +2,9 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 
 const originalEnv = process.env;
 
+const MAINNET_CONTRACT = 'CBXYBENCWPCNLZXXBAMSUO2MLVXH7EFBWLB5JZPWA4MCSOSLLRWX5OUA';
+const MAINNET_TOKEN = 'CCKKLNWH3DU7UCY4FU7E6YDRQKJ2JNOG27UPSCQ3FQ6U4X3QQGJKHTZ5';
+
 function validEnv(overrides: NodeJS.ProcessEnv = {}): NodeJS.ProcessEnv {
   return {
     NODE_ENV: 'test',
@@ -10,6 +13,21 @@ function validEnv(overrides: NodeJS.ProcessEnv = {}): NodeJS.ProcessEnv {
     INDEXER_WORKER_TOKEN: 'indexer-worker-token-for-testing-only-12345',
     STELLAR_CONTRACT_ADDRESS: 'CASTMR2YNF5IXHFNX3H6B4ICCMSDKRSXNB4YVG5MXXHN74ABCIRTISIC',
     STELLAR_TOKEN_ADDRESS: 'CBFFW3D5R2P3BQOS4P2AKFRHHBEVU234RWPK7QGR4LZQIFJGG5EFTAK6',
+    ...overrides,
+  };
+}
+
+function validProdEnv(overrides: NodeJS.ProcessEnv = {}): NodeJS.ProcessEnv {
+  return {
+    NODE_ENV: 'production',
+    DATABASE_URL: 'postgresql://db.internal/fluxora',
+    JWT_SECRET: 'prod-secret-key-that-is-at-least-32-chars-long',
+    INDEXER_WORKER_TOKEN: 'prod-indexer-token-at-least-thirty-two-chars',
+    STELLAR_NETWORK: 'mainnet',
+    STELLAR_CONTRACT_ADDRESS: MAINNET_CONTRACT,
+    STELLAR_TOKEN_ADDRESS: MAINNET_TOKEN,
+    PGCRYPTO_KEY: 'prod-pgcrypto-key-min-thirty-two-chars',
+    CORS_ALLOWED_ORIGINS: 'https://app.fluxora.example.com',
     ...overrides,
   };
 }
@@ -98,5 +116,102 @@ describe('EnvSchema startup validation', () => {
 
     const { loadConfig } = await importEnvWith(env);
     expect(() => loadConfig()).not.toThrow();
+  });
+});
+
+describe('production env validation', () => {
+  afterEach(() => {
+    process.env = originalEnv;
+    vi.resetModules();
+  });
+
+  it('passes for a fully valid production env', async () => {
+    const { loadConfig } = await importEnvWith(validProdEnv());
+
+    const config = loadConfig();
+    expect(config.nodeEnv).toBe('production');
+    expect(config.stellarNetwork).toBe('mainnet');
+    expect(config.logLevel).toBe('info');
+  });
+
+  it('fails when LOG_LEVEL is debug in production', async () => {
+    await expect(importEnvWith(validProdEnv({ LOG_LEVEL: 'debug' }))).rejects.toMatchObject({
+      name: 'EnvironmentError',
+      issues: expect.arrayContaining(['LOG_LEVEL: LOG_LEVEL must not be "debug" in production']),
+    });
+  });
+
+  it('fails when CORS_ALLOWED_ORIGINS is a wildcard in production', async () => {
+    await expect(importEnvWith(validProdEnv({ CORS_ALLOWED_ORIGINS: '*' }))).rejects.toMatchObject({
+      name: 'EnvironmentError',
+      issues: expect.arrayContaining(['CORS_ALLOWED_ORIGINS: CORS_ALLOWED_ORIGINS must not contain a wildcard "*" origin in production']),
+    });
+  });
+
+  it('fails when CORS_ALLOWED_ORIGINS contains a wildcard alongside other origins in production', async () => {
+    await expect(
+      importEnvWith(validProdEnv({ CORS_ALLOWED_ORIGINS: 'https://app.example.com,*,https://admin.example.com' })),
+    ).rejects.toMatchObject({
+      name: 'EnvironmentError',
+      issues: expect.arrayContaining(['CORS_ALLOWED_ORIGINS: CORS_ALLOWED_ORIGINS must not contain a wildcard "*" origin in production']),
+    });
+  });
+
+  it('passes when CORS_ALLOWED_ORIGINS is explicit origins in production', async () => {
+    const { loadConfig } = await importEnvWith(
+      validProdEnv({ CORS_ALLOWED_ORIGINS: 'https://app.fluxora.example.com,https://admin.fluxora.example.com' }),
+    );
+    expect(() => loadConfig()).not.toThrow();
+  });
+
+  it('passes when CORS_ALLOWED_ORIGINS is unset in production', async () => {
+    const env = validProdEnv();
+    delete env.CORS_ALLOWED_ORIGINS;
+
+    const { loadConfig } = await importEnvWith(env);
+    expect(() => loadConfig()).not.toThrow();
+  });
+
+  it('fails when PGCRYPTO_KEY is missing in production', async () => {
+    const env = validProdEnv();
+    delete env.PGCRYPTO_KEY;
+
+    await expect(importEnvWith(env)).rejects.toMatchObject({
+      name: 'EnvironmentError',
+      issues: expect.arrayContaining(['PGCRYPTO_KEY: PGCRYPTO_KEY is required in production (minimum 32 characters)']),
+    });
+  });
+
+  it('fails when PGCRYPTO_KEY is too short in production', async () => {
+    await expect(importEnvWith(validProdEnv({ PGCRYPTO_KEY: 'too-short' }))).rejects.toMatchObject({
+      name: 'EnvironmentError',
+      issues: expect.arrayContaining(['PGCRYPTO_KEY: PGCRYPTO_KEY is required in production (minimum 32 characters)']),
+    });
+  });
+
+  it('fails when multiple production invariants are violated', async () => {
+    await expect(
+      importEnvWith(
+        validProdEnv({
+          LOG_LEVEL: 'debug',
+          CORS_ALLOWED_ORIGINS: '*',
+        }),
+      ),
+    ).rejects.toMatchObject({
+      name: 'EnvironmentError',
+    });
+
+    try {
+      await importEnvWith(
+        validProdEnv({
+          LOG_LEVEL: 'debug',
+          CORS_ALLOWED_ORIGINS: '*',
+        }),
+      );
+    } catch (error) {
+      const e = error as Error;
+      expect(e.message).toContain('LOG_LEVEL');
+      expect(e.message).toContain('CORS_ALLOWED_ORIGINS');
+    }
   });
 });


### PR DESCRIPTION
## Summary
- Add production-specific checks to : secrets required, debug off, CORS not wildcard
- Add comprehensive tests for missing/violating production config
- Add passing-case for fully valid production env

Closes #702