### PR TITLE
feat: add canary release routing via header-based traffic split

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -634,3 +634,166 @@ readinessProbe:
     port: 50051
   periodSeconds: 10
 ```
+
+
+---
+
+## Canary Routing
+
+Fluxora supports a deterministic, header-based canary traffic split. A
+configurable percentage of requests are tagged as canary by setting
+`req.isCanary = true` on the Express request object and echoing an
+`X-Fluxora-Canary: true` response header. This lets operators route, observe,
+and roll back canary builds without any client-side changes.
+
+### How it works
+
+The `canaryRoutingMiddleware` (`src/middleware/canaryRouting.ts`) runs
+immediately after the correlation-ID middleware so every canary-tagged request
+carries a traceable `x-correlation-id` through logs and metrics.
+
+**Decision algorithm (per request):**
+
+1. **Identify the client.** Prefers the `X-API-Key` request header (stable
+   across proxy/CDN topologies). Falls back to `req.ip` when no API key is
+   present.
+2. **Hash the identity.** Computes `SHA-256(CANARY_SALT + ':' + clientIdentity)`.
+3. **Derive a bucket.** Takes the first 8 hex digits of the digest, interprets
+   them as a `uint32`, and applies `% 100` to yield a value in `[0, 100)`.
+4. **Apply the threshold.** Tags the request as canary when
+   `bucket < CANARY_TRAFFIC_PERCENT`.
+
+The decision is a pure function of `(clientIdentity, CANARY_SALT,
+CANARY_TRAFFIC_PERCENT)` — the same client always lands in the same bucket for
+the lifetime of a deployment.
+
+### Configuration
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `CANARY_TRAFFIC_PERCENT` | `0` | Integer `0–100`. Percentage of clients to route to the canary path. `0` disables canary tagging entirely. |
+| `CANARY_SALT` | `canary-routing-v1` | Arbitrary string used to namespace the hash. Change this between unrelated experiments to avoid correlated bucketing. **Never log this value.** |
+
+The `CANARY_TRAFFIC_PERCENT` value is validated by the Zod config schema
+(`src/config/env.ts`) to be an integer in `[0, 100]`. Out-of-range values
+cause a `ConfigError` at startup.
+
+### Observability
+
+**Response header** — `X-Fluxora-Canary: true` is set on every canary-tagged
+response. Absent on non-canary responses. Useful for:
+- Load-balancer routing rules (e.g. route `X-Fluxora-Canary: true` to the
+  canary upstream).
+- Integration test assertions.
+- Browser devtools or curl inspection during manual verification.
+
+**Structured logs** — The middleware emits a `debug`-level log for every
+canary-tagged request:
+
+```json
+{
+  "level": "debug",
+  "message": "Canary routing: request tagged as canary",
+  "correlationId": "<uuid>",
+  "component": "canary-routing",
+  "bucket": 23,
+  "trafficPercent": 30
+}
+```
+
+The `bucket` field enables operators to verify the distribution is as expected.
+The raw client identity (API key or IP) is **never** included in logs.
+
+**Prometheus metrics** — The existing `http_requests_total` and
+`http_request_duration_seconds` counters (emitted by `httpMetrics`) record
+all requests regardless of canary status. To split metrics by canary, add a
+custom label in your route handlers using `req.isCanary`:
+
+```typescript
+import type { Request, Response } from 'express';
+
+router.get('/api/feature', (req: Request, res: Response) => {
+  myCounter.inc({ canary: String(req.isCanary ?? false) });
+  // ...
+});
+```
+
+### Security considerations
+
+- The **raw client identity** (API key or IP address) is hashed before the
+  bucket computation and is **never stored or logged** by the middleware.
+- The **salt** (`CANARY_SALT`) is read from the environment and never
+  reflected in any log record or response header.
+- The salt is **intentionally different** from any feature-flag hash salt to
+  prevent correlated bucketing between independent experiments. Using the same
+  salt for two experiments means the same clients opt-in to both, which
+  confounds A/B measurement.
+- The `X-Fluxora-Canary` response header reveals only the canary decision
+  (`true`), not the client identity or bucket value.
+
+### Operator runbook
+
+#### Enable canary for 10 % of traffic
+
+```bash
+# Rolling deploy — set on the canary pod only
+CANARY_TRAFFIC_PERCENT=10
+CANARY_SALT=canary-routing-v1   # keep default unless running two experiments
+```
+
+Verify with:
+
+```bash
+# Find a client that lands in the canary bucket
+curl -I https://api.example.com/health -H 'X-API-Key: <key>'
+# Look for: X-Fluxora-Canary: true
+```
+
+#### Increase to 50 %
+
+```bash
+CANARY_TRAFFIC_PERCENT=50
+```
+
+Because the hash is stable, clients already in the canary set at 10 % remain
+in the canary set at 50 %. No client "flips" unexpectedly.
+
+#### Disable canary (full rollback)
+
+```bash
+CANARY_TRAFFIC_PERCENT=0
+```
+
+Setting to `0` short-circuits the hash computation entirely. All requests get
+`req.isCanary = false` with zero overhead.
+
+#### Run a second, independent experiment
+
+Use a different salt so the two experiments' buckets are uncorrelated:
+
+```bash
+# Experiment A — already running
+CANARY_TRAFFIC_PERCENT=20
+CANARY_SALT=experiment-a-v1
+
+# Experiment B — independent
+# Deploy a separate flag or use a different env variable pattern
+CANARY_SALT=experiment-b-v1
+```
+
+### Testing
+
+The middleware's unit and integration tests live in
+`tests/middleware/canaryRouting.test.ts`. Run them with:
+
+```bash
+pnpm test tests/middleware/canaryRouting.test.ts
+```
+
+Key assertions:
+- `computeCanaryBucket` is deterministic and matches the reference formula.
+- `resolveClientIdentity` prefers API key over IP.
+- `req.isCanary` is set correctly for the disabled, partial, and full-split cases.
+- `X-Fluxora-Canary` header is echoed only on canary responses.
+- Raw client identity and salt are never present in log calls.
+- `createApp()` integration confirms the header is visible on real HTTP responses.

--- a/src/app.ts
+++ b/src/app.ts
@@ -41,6 +41,7 @@ import { requireJsonContentType } from './middleware/contentType.js';
 import { requireJsonAccept } from './middleware/acceptNegotiation.js';
 import { methodOverrideMiddleware } from './middleware/methodOverride.js';
 import { httpMetrics } from './middleware/httpMetrics.js';
+import { canaryRoutingMiddleware } from './middleware/canaryRouting.js';
 import { serverTimingMiddleware } from './middleware/serverTiming.js';
 import { setMtlsRequired } from './indexer/mtls.js';
 import { isShuttingDown, addShutdownHook } from './shutdown.js';
@@ -419,6 +420,9 @@ export function createApp(options: AppOptions = {}): Express {
   // It must also run before early-reject middlewares (body size, content type) 
   // so that rejected requests still carry a correlation ID.
   app.use(correlationIdMiddleware);
+  // Canary routing runs immediately after correlation-ID assignment so that
+  // every canary-tagged request carries a correlation ID end-to-end in logs.
+  app.use(canaryRoutingMiddleware);
   app.use(privacyHeaders);
   app.use(cspNonceMiddleware);
   app.use(createHelmetMiddleware());

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -348,6 +348,14 @@ export const EnvSchema = z.object({
   STARTUP_PROBE_POSTGRES_TIMEOUT_MS: integerEnv('STARTUP_PROBE_POSTGRES_TIMEOUT_MS', 1).default(5_000),
   STARTUP_PROBE_REDIS_TIMEOUT_MS: integerEnv('STARTUP_PROBE_REDIS_TIMEOUT_MS', 1).default(3_000),
   STARTUP_PROBE_STELLAR_TIMEOUT_MS: integerEnv('STARTUP_PROBE_STELLAR_TIMEOUT_MS', 1).default(5_000),
+
+  /**
+   * Percentage of traffic (0–100) to route through the canary code path.
+   * 0 disables canary tagging entirely (default). Set to e.g. 10 to tag
+   * 10 % of clients deterministically as canary based on a SHA-256 hash
+   * of their identity (API key or IP).
+   */
+  CANARY_TRAFFIC_PERCENT: integerEnv('CANARY_TRAFFIC_PERCENT', 0, 100).default(0),
 }).passthrough().superRefine((env, ctx) => {
   const stellarNetwork = resolvedStellarNetwork(env);
   const expectedPassphrase = STELLAR_NETWORK_PASSPHRASES[stellarNetwork];
@@ -501,6 +509,12 @@ export interface Config {
   startupProbeRedisTimeoutMs: number;
   /** Per-attempt timeout for each Stellar RPC (soft-tier) retry attempt, ms. */
   startupProbeStellarTimeoutMs: number;
+
+  /**
+   * Percentage of traffic (0–100) to tag as canary.
+   * 0 means no canary tagging. Sourced from CANARY_TRAFFIC_PERCENT.
+   */
+  canaryTrafficPercent: number;
 }
 
 export class ConfigError extends Error {
@@ -672,6 +686,8 @@ function toConfig(env: ParsedEnv): Config {
     startupProbePostgresTimeoutMs: env.STARTUP_PROBE_POSTGRES_TIMEOUT_MS,
     startupProbeRedisTimeoutMs: env.STARTUP_PROBE_REDIS_TIMEOUT_MS,
     startupProbeStellarTimeoutMs: env.STARTUP_PROBE_STELLAR_TIMEOUT_MS,
+
+    canaryTrafficPercent: env.CANARY_TRAFFIC_PERCENT,
   };
 }
 

--- a/src/middleware/canaryRouting.ts
+++ b/src/middleware/canaryRouting.ts
@@ -1,0 +1,251 @@
+/**
+ * Canary Routing Middleware
+ *
+ * Performs a stable, deterministic per-request canary traffic split using a
+ * SHA-256 hash of the client identity (API key when present, falling back to
+ * client IP). A configurable percentage of requests are tagged as canary by
+ * setting `req.isCanary = true` and echoing an `X-Fluxora-Canary: true`
+ * response header so operators can correlate canary traffic in logs and
+ * metrics.
+ *
+ * Design goals
+ * ─────────────
+ * 1. Determinism — the same client always lands in the same bucket for the
+ *    lifetime of a deployment. Routing is a pure function of
+ *    (clientIdentity, CANARY_SALT, CANARY_TRAFFIC_PERCENT).
+ *
+ * 2. Independence — uses its own CANARY_SALT so canary bucketing is
+ *    completely uncorrelated from any feature-flag rollout hashes that may
+ *    share the same client-identity inputs. Correlated hashes would silently
+ *    confound A/B measurements.
+ *
+ * 3. Graceful degradation — when the client identity cannot be determined
+ *    (no IP, no API-key) the middleware skips tagging and calls next()
+ *    without raising an error.
+ *
+ * 4. Correlation-ID integration — the canary decision is logged at debug
+ *    level with the request's correlation ID so canary requests are
+ *    traceable end-to-end through the structured log pipeline.
+ *
+ * 5. Security — the raw client IP is never reflected in logs. The API key
+ *    is never reflected in logs. The salt is held in CANARY_SALT env var
+ *    and never logged.
+ *
+ * Configuration
+ * ─────────────
+ * CANARY_TRAFFIC_PERCENT  integer 0–100, default 0 (all traffic stable)
+ * CANARY_SALT             arbitrary string, default 'canary-routing-v1'
+ *
+ * Algorithm
+ * ─────────
+ * 1. Identify the client: prefer the `X-API-Key` request header; fall back
+ *    to `req.ip` (Express-resolved, trusts proxy when app trust-proxy is set).
+ * 2. Compute: SHA-256(CANARY_SALT + ':' + clientIdentity)
+ * 3. Take the first 8 hex characters of the digest → parse as uint32.
+ * 4. Map to [0, 100) via: bucket = uint32 % 100
+ * 5. Tag as canary when: bucket < CANARY_TRAFFIC_PERCENT
+ *
+ * This gives a uniform distribution over 100 buckets. Operators who need
+ * finer granularity (e.g. 0.5%) should scale CANARY_TRAFFIC_PERCENT to an
+ * integer in [0, 10000] and update the modulus — the exported helper
+ * `computeCanaryBucket` accepts a custom modulus for that.
+ */
+
+import { createHash } from 'crypto';
+import type { Request, Response, NextFunction } from 'express';
+import { logger } from '../lib/logger.js';
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/**
+ * Response header echoed to the caller so that proxies, dashboards, and
+ * integration tests can observe the canary decision without inspecting logs.
+ */
+export const CANARY_HEADER = 'X-Fluxora-Canary';
+
+/**
+ * Default salt used when CANARY_SALT is not set.
+ *
+ * The salt is intentionally namespaced differently from any feature-flag salt
+ * to guarantee that the canary and feature-flag hash spaces are independent
+ * even when the underlying client identity string is the same.
+ */
+export const DEFAULT_CANARY_SALT = 'canary-routing-v1';
+
+/**
+ * Total number of buckets used for the modulo operation.
+ * 100 maps directly to "percent", making CANARY_TRAFFIC_PERCENT intuitive.
+ */
+export const CANARY_BUCKET_COUNT = 100;
+
+// ---------------------------------------------------------------------------
+// Core helpers (exported for unit testing)
+// ---------------------------------------------------------------------------
+
+/**
+ * Derive a stable bucket number [0, modulus) for a given (salt, identity)
+ * pair using the first 8 hex characters of SHA-256 as a uint32.
+ *
+ * @param salt     - Domain-specific salt (prevents cross-experiment correlation)
+ * @param identity - Client identity (API key or IP address)
+ * @param modulus  - Number of buckets; defaults to CANARY_BUCKET_COUNT (100)
+ * @returns        - Integer in [0, modulus)
+ */
+export function computeCanaryBucket(
+  salt: string,
+  identity: string,
+  modulus: number = CANARY_BUCKET_COUNT,
+): number {
+  const digest = createHash('sha256')
+    .update(`${salt}:${identity}`)
+    .digest('hex');
+
+  // Use the first 8 hex characters (32 bits) to avoid BigInt overhead while
+  // still giving a uniform distribution over 2^32 values.
+  const uint32 = parseInt(digest.slice(0, 8), 16);
+  return uint32 % modulus;
+}
+
+/**
+ * Resolve the stable client identity for canary bucketing.
+ *
+ * Preference order:
+ *   1. `X-API-Key` request header (authenticated callers always map to the
+ *      same bucket regardless of IP — important for proxy/CDN deployments).
+ *   2. `req.ip` — Express-resolved client IP (respects `trust proxy`).
+ *
+ * Returns `undefined` when no identity can be determined (e.g. tests that
+ * do not set an IP and send no API key).
+ */
+export function resolveClientIdentity(req: Request): string | undefined {
+  // Prefer API key: provides a stable identity across NAT/proxy topologies.
+  const apiKey = req.headers['x-api-key'];
+  if (typeof apiKey === 'string' && apiKey.trim().length > 0) {
+    return apiKey.trim();
+  }
+
+  // Fall back to client IP.
+  if (req.ip && req.ip.length > 0) {
+    return req.ip;
+  }
+
+  return undefined;
+}
+
+// ---------------------------------------------------------------------------
+// Middleware factory (accepts explicit config for testability)
+// ---------------------------------------------------------------------------
+
+/**
+ * Options accepted by `createCanaryRoutingMiddleware`.
+ *
+ * All fields are optional; production callers should rely on environment
+ * variables. Tests may pass explicit values to avoid polluting process.env.
+ */
+export interface CanaryRoutingOptions {
+  /**
+   * Percentage of requests to tag as canary [0, 100].
+   * Reads CANARY_TRAFFIC_PERCENT from the environment when omitted.
+   * Defaults to 0 (no canary traffic).
+   */
+  trafficPercent?: number;
+
+  /**
+   * Salt used to isolate this hash from other rollout hashes.
+   * Reads CANARY_SALT from the environment when omitted.
+   * Defaults to DEFAULT_CANARY_SALT.
+   */
+  salt?: string;
+}
+
+/**
+ * Returns an Express middleware that performs a stable canary traffic split.
+ *
+ * Mount this **after** `correlationIdMiddleware` so that `req.correlationId`
+ * is available for structured logging of the canary decision.
+ *
+ * @example
+ * ```typescript
+ * app.use(correlationIdMiddleware);
+ * app.use(createCanaryRoutingMiddleware());
+ * ```
+ */
+export function createCanaryRoutingMiddleware(options: CanaryRoutingOptions = {}) {
+  return function canaryRoutingMiddleware(
+    req: Request,
+    res: Response,
+    next: NextFunction,
+  ): void {
+    // ── Resolve configuration ─────────────────────────────────────────────
+
+    const trafficPercent =
+      options.trafficPercent ??
+      (() => {
+        const raw = process.env['CANARY_TRAFFIC_PERCENT'];
+        if (raw === undefined || raw === '') return 0;
+        const parsed = parseInt(raw, 10);
+        return Number.isFinite(parsed) && parsed >= 0 && parsed <= 100 ? parsed : 0;
+      })();
+
+    const salt =
+      options.salt ?? (process.env['CANARY_SALT'] ?? DEFAULT_CANARY_SALT);
+
+    // ── Fast path: canary disabled ────────────────────────────────────────
+
+    if (trafficPercent === 0) {
+      req.isCanary = false;
+      next();
+      return;
+    }
+
+    // ── Resolve client identity ───────────────────────────────────────────
+
+    const identity = resolveClientIdentity(req);
+
+    if (identity === undefined) {
+      // Cannot determine client identity; skip tagging to avoid false
+      // positives. Log at debug level so test harnesses can diagnose
+      // unexpected misses without polluting production logs.
+      logger.debug(
+        'Canary routing: unable to determine client identity; request not tagged',
+        req.correlationId,
+        { component: 'canary-routing' },
+      );
+      req.isCanary = false;
+      next();
+      return;
+    }
+
+    // ── Compute bucket and apply decision ─────────────────────────────────
+
+    const bucket = computeCanaryBucket(salt, identity);
+    const isCanary = bucket < trafficPercent;
+
+    req.isCanary = isCanary;
+
+    if (isCanary) {
+      res.setHeader(CANARY_HEADER, 'true');
+
+      logger.debug(
+        'Canary routing: request tagged as canary',
+        req.correlationId,
+        {
+          component: 'canary-routing',
+          bucket,
+          trafficPercent,
+        },
+      );
+    }
+
+    next();
+  };
+}
+
+/**
+ * Default export: a pre-built middleware instance that reads configuration
+ * from environment variables at request time. Suitable for use in
+ * `app.use(canaryRoutingMiddleware)`.
+ */
+export const canaryRoutingMiddleware = createCanaryRoutingMiddleware();

--- a/src/types/express.d.ts
+++ b/src/types/express.d.ts
@@ -16,6 +16,13 @@ declare global {
       apiVersion?: string;
       /** Attached by enforceStreamScope middleware; the normalized caller address. */
       callerAddress?: string;
+      /**
+       * Attached by canaryRoutingMiddleware.
+       * `true`  — this request falls within the canary traffic slice.
+       * `false` — this request is on the stable traffic slice.
+       * `undefined` — middleware has not yet run (e.g. very early in the stack).
+       */
+      isCanary?: boolean;
     }
   }
 }

--- a/tests/middleware/canaryRouting.test.ts
+++ b/tests/middleware/canaryRouting.test.ts
@@ -1,0 +1,554 @@
+/**
+ * canaryRouting middleware — comprehensive test suite
+ *
+ * Coverage targets
+ * ─────────────────
+ * - computeCanaryBucket: determinism, distribution, salt isolation
+ * - resolveClientIdentity: API key preference, IP fallback, edge cases
+ * - createCanaryRoutingMiddleware: disabled path, header echo, req.isCanary,
+ *   identity-not-found, correlation-ID integration, env-variable reading,
+ *   boundary values (0 %, 100 %), distribution smoke-test
+ * - Integration via createApp(): header visible on real HTTP responses
+ * - Security: raw identity never logged, salt never logged
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import express from 'express';
+import request from 'supertest';
+import { createHash } from 'crypto';
+
+import {
+  computeCanaryBucket,
+  resolveClientIdentity,
+  createCanaryRoutingMiddleware,
+  canaryRoutingMiddleware,
+  CANARY_HEADER,
+  DEFAULT_CANARY_SALT,
+  CANARY_BUCKET_COUNT,
+} from '../../src/middleware/canaryRouting.js';
+import { correlationIdMiddleware } from '../../src/middleware/correlationId.js';
+import { createApp } from '../../src/app.js';
+
+// ---------------------------------------------------------------------------
+// Helper: build a minimal Express app with the canary middleware
+// ---------------------------------------------------------------------------
+function buildApp(trafficPercent: number, salt = DEFAULT_CANARY_SALT) {
+  const app = express();
+  app.use(correlationIdMiddleware);
+  app.use(createCanaryRoutingMiddleware({ trafficPercent, salt }));
+  app.get('/ping', (req, res) => {
+    res.json({ isCanary: (req as express.Request & { isCanary?: boolean }).isCanary ?? null });
+  });
+  return app;
+}
+
+// ---------------------------------------------------------------------------
+// computeCanaryBucket
+// ---------------------------------------------------------------------------
+describe('computeCanaryBucket()', () => {
+  it('returns a number in [0, 100) for arbitrary inputs', () => {
+    for (const id of ['1.2.3.4', 'abc-key', 'user@example.com', '::1', '']) {
+      const b = computeCanaryBucket(DEFAULT_CANARY_SALT, id);
+      expect(b).toBeGreaterThanOrEqual(0);
+      expect(b).toBeLessThan(100);
+    }
+  });
+
+  it('is deterministic — same inputs always yield the same bucket', () => {
+    const salt = 'test-salt';
+    const id = 'stable-client';
+    expect(computeCanaryBucket(salt, id)).toBe(computeCanaryBucket(salt, id));
+    expect(computeCanaryBucket(salt, id)).toBe(computeCanaryBucket(salt, id));
+  });
+
+  it('produces different buckets for different identities (with overwhelmingly high probability)', () => {
+    const buckets = new Set(
+      Array.from({ length: 20 }, (_, i) => computeCanaryBucket(DEFAULT_CANARY_SALT, `client-${i}`)),
+    );
+    // With 20 distinct inputs and 100 buckets the chance of all landing in the
+    // same bucket is negligible — we assert at least 3 distinct values.
+    expect(buckets.size).toBeGreaterThan(3);
+  });
+
+  it('changes when the salt changes (cross-experiment independence)', () => {
+    const id = 'shared-client';
+    const b1 = computeCanaryBucket('salt-A', id);
+    const b2 = computeCanaryBucket('salt-B', id);
+    // Different salts must produce different hash inputs; with very high
+    // probability they land in different buckets.
+    // (The two could collide mod 100 by chance — verify the raw digest differs)
+    const d1 = createHash('sha256').update(`salt-A:${id}`).digest('hex');
+    const d2 = createHash('sha256').update(`salt-B:${id}`).digest('hex');
+    expect(d1).not.toBe(d2);
+    // Buckets are independent of feature-flag salt
+    expect(typeof b1).toBe('number');
+    expect(typeof b2).toBe('number');
+  });
+
+  it('respects a custom modulus', () => {
+    for (let i = 0; i < 50; i++) {
+      const b = computeCanaryBucket(DEFAULT_CANARY_SALT, `client-${i}`, 10);
+      expect(b).toBeGreaterThanOrEqual(0);
+      expect(b).toBeLessThan(10);
+    }
+  });
+
+  it('matches the reference formula: parseInt(sha256(salt:id).slice(0,8), 16) % 100', () => {
+    const salt = DEFAULT_CANARY_SALT;
+    const id = '192.168.1.1';
+    const digest = createHash('sha256').update(`${salt}:${id}`).digest('hex');
+    const expected = parseInt(digest.slice(0, 8), 16) % 100;
+    expect(computeCanaryBucket(salt, id)).toBe(expected);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resolveClientIdentity
+// ---------------------------------------------------------------------------
+describe('resolveClientIdentity()', () => {
+  function makeReq(overrides: Partial<{ ip: string; headers: Record<string, string> }>): express.Request {
+    return {
+      ip: overrides.ip ?? '',
+      headers: overrides.headers ?? {},
+    } as unknown as express.Request;
+  }
+
+  it('returns the X-API-Key header value when present', () => {
+    const req = makeReq({ headers: { 'x-api-key': 'my-key-123' }, ip: '1.2.3.4' });
+    expect(resolveClientIdentity(req)).toBe('my-key-123');
+  });
+
+  it('trims whitespace from the API key', () => {
+    const req = makeReq({ headers: { 'x-api-key': '  trimmed-key  ' }, ip: '1.2.3.4' });
+    expect(resolveClientIdentity(req)).toBe('trimmed-key');
+  });
+
+  it('falls back to req.ip when X-API-Key is absent', () => {
+    const req = makeReq({ ip: '10.0.0.1' });
+    expect(resolveClientIdentity(req)).toBe('10.0.0.1');
+  });
+
+  it('falls back to req.ip when X-API-Key is empty string', () => {
+    const req = makeReq({ headers: { 'x-api-key': '' }, ip: '10.0.0.2' });
+    expect(resolveClientIdentity(req)).toBe('10.0.0.2');
+  });
+
+  it('falls back to req.ip when X-API-Key is whitespace only', () => {
+    const req = makeReq({ headers: { 'x-api-key': '   ' }, ip: '10.0.0.3' });
+    expect(resolveClientIdentity(req)).toBe('10.0.0.3');
+  });
+
+  it('returns undefined when both API key and IP are absent', () => {
+    const req = makeReq({ ip: '', headers: {} });
+    expect(resolveClientIdentity(req)).toBeUndefined();
+  });
+
+  it('prefers API key over IP address', () => {
+    const req = makeReq({ headers: { 'x-api-key': 'api-key' }, ip: '5.5.5.5' });
+    // Must return the API key, not the IP
+    expect(resolveClientIdentity(req)).toBe('api-key');
+    expect(resolveClientIdentity(req)).not.toBe('5.5.5.5');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// createCanaryRoutingMiddleware — unit tests using express()
+// ---------------------------------------------------------------------------
+describe('createCanaryRoutingMiddleware()', () => {
+  describe('disabled path (trafficPercent = 0)', () => {
+    it('sets req.isCanary = false and calls next()', async () => {
+      const app = buildApp(0);
+      const res = await request(app).get('/ping').set('X-API-Key', 'any-key');
+      expect(res.status).toBe(200);
+      expect(res.body.isCanary).toBe(false);
+    });
+
+    it('does not emit X-Fluxora-Canary header', async () => {
+      const app = buildApp(0);
+      const res = await request(app).get('/ping').set('X-API-Key', 'any-key');
+      expect(res.headers[CANARY_HEADER.toLowerCase()]).toBeUndefined();
+    });
+  });
+
+  describe('fully enabled path (trafficPercent = 100)', () => {
+    it('sets req.isCanary = true for every request', async () => {
+      const app = buildApp(100);
+      // Test with multiple different identities
+      for (const key of ['key-a', 'key-b', 'key-c', '192.168.0.1']) {
+        const res = await request(app).get('/ping').set('X-API-Key', key);
+        expect(res.body.isCanary).toBe(true);
+      }
+    });
+
+    it('echoes X-Fluxora-Canary: true response header', async () => {
+      const app = buildApp(100);
+      const res = await request(app).get('/ping').set('X-API-Key', 'any');
+      expect(res.headers[CANARY_HEADER.toLowerCase()]).toBe('true');
+    });
+  });
+
+  describe('partial traffic split', () => {
+    it('is deterministic — same client always gets the same decision', async () => {
+      const app = buildApp(50);
+      const key = 'stable-client-key';
+      const results: boolean[] = [];
+      for (let i = 0; i < 5; i++) {
+        const res = await request(app).get('/ping').set('X-API-Key', key);
+        results.push(res.body.isCanary);
+      }
+      // All 5 calls must agree
+      expect(new Set(results).size).toBe(1);
+    });
+
+    it('bucket threshold is respected — client lands in canary iff bucket < percent', async () => {
+      const salt = DEFAULT_CANARY_SALT;
+      const key = 'threshold-test-key';
+      const bucket = computeCanaryBucket(salt, key);
+
+      // At trafficPercent = bucket, the client is NOT canary (bucket < bucket is false)
+      const appAtBucket = buildApp(bucket, salt);
+      const resAtBucket = await request(appAtBucket).get('/ping').set('X-API-Key', key);
+      expect(resAtBucket.body.isCanary).toBe(false);
+
+      // At trafficPercent = bucket + 1, the client IS canary
+      const appAboveBucket = buildApp(bucket + 1, salt);
+      const resAboveBucket = await request(appAboveBucket).get('/ping').set('X-API-Key', key);
+      expect(resAboveBucket.body.isCanary).toBe(true);
+    });
+
+    it('X-Fluxora-Canary header is absent for non-canary requests', async () => {
+      const salt = DEFAULT_CANARY_SALT;
+      const key = 'stable-key-not-canary';
+      const bucket = computeCanaryBucket(salt, key);
+      // Set percent = bucket so this client is NOT canary
+      const app = buildApp(bucket, salt);
+      const res = await request(app).get('/ping').set('X-API-Key', key);
+      expect(res.body.isCanary).toBe(false);
+      expect(res.headers[CANARY_HEADER.toLowerCase()]).toBeUndefined();
+    });
+
+    it('roughly 50% of diverse clients are canary at trafficPercent=50', () => {
+      // Pure unit test — no HTTP overhead, just hash math
+      const salt = DEFAULT_CANARY_SALT;
+      let canaryCount = 0;
+      const total = 1000;
+      for (let i = 0; i < total; i++) {
+        const bucket = computeCanaryBucket(salt, `client-${i}`);
+        if (bucket < 50) canaryCount++;
+      }
+      const ratio = canaryCount / total;
+      // Allow ±10 pp tolerance for a 1000-sample run
+      expect(ratio).toBeGreaterThan(0.40);
+      expect(ratio).toBeLessThan(0.60);
+    });
+  });
+
+  describe('client identity resolution in HTTP context', () => {
+    it('uses X-API-Key over IP when both are present', async () => {
+      const salt = DEFAULT_CANARY_SALT;
+      const key = 'api-key-identity';
+      const bucketByKey = computeCanaryBucket(salt, key);
+
+      // trafficPercent just above key's bucket → canary
+      const app = buildApp(bucketByKey + 1, salt);
+      const res = await request(app).get('/ping').set('X-API-Key', key);
+      expect(res.body.isCanary).toBe(true);
+    });
+
+    it('falls back to IP identity when no X-API-Key is sent', async () => {
+      // Build app with 100% canary — every IP should be tagged
+      const app = buildApp(100);
+      const res = await request(app).get('/ping');
+      // supertest uses 127.0.0.1 — req.ip will resolve to something
+      expect(res.body.isCanary).toBe(true);
+    });
+
+    it('sets req.isCanary = false and does not emit header when identity is unknown', async () => {
+      // Test by calling the exported resolveClientIdentity directly with no IP and no key.
+      // In HTTP context supertest always provides a loopback IP, so we verify via unit test.
+      const app = express();
+      app.use(correlationIdMiddleware);
+      // Use the factory directly with a custom identityResolver override is not possible,
+      // so test the behaviour via the exported helper instead.
+      app.use(createCanaryRoutingMiddleware({ trafficPercent: 100 }));
+      app.get('/ping', (req, res) => {
+        const val = (req as express.Request & { isCanary?: boolean }).isCanary;
+        res.json({ isCanary: val === undefined ? null : val });
+      });
+
+      // With no X-API-Key and a supertest loopback IP, isCanary will be true (100%)
+      // or false (0%) based on bucket — just verify req.isCanary is a boolean and
+      // the header is set consistently.
+      const res = await request(app).get('/ping');
+      expect(typeof res.body.isCanary).toBe('boolean');
+
+      // Verify the unit behaviour directly: undefined identity → isCanary = false
+      const { resolveClientIdentity: rci } = await import('../../src/middleware/canaryRouting.js');
+      const fakeReq = { ip: '', headers: {} } as express.Request;
+      expect(rci(fakeReq)).toBeUndefined();
+    });
+  });
+
+  describe('environment variable reading', () => {
+    afterEach(() => {
+      delete process.env['CANARY_TRAFFIC_PERCENT'];
+      delete process.env['CANARY_SALT'];
+    });
+
+    it('reads CANARY_TRAFFIC_PERCENT from process.env when no options passed', async () => {
+      const salt = DEFAULT_CANARY_SALT;
+      const key = 'env-test-key';
+      const bucket = computeCanaryBucket(salt, key);
+
+      process.env['CANARY_TRAFFIC_PERCENT'] = String(bucket + 1);
+
+      const app = express();
+      app.use(correlationIdMiddleware);
+      // Use the default export which reads env at request time
+      app.use(createCanaryRoutingMiddleware()); // no options → reads env
+      app.get('/ping', (req, res) => {
+        res.json({ isCanary: (req as express.Request & { isCanary?: boolean }).isCanary });
+      });
+
+      const res = await request(app).get('/ping').set('X-API-Key', key);
+      expect(res.body.isCanary).toBe(true);
+    });
+
+    it('reads CANARY_SALT from process.env when no options passed', async () => {
+      const customSalt = 'my-custom-salt';
+      const key = 'salt-env-test';
+      const bucket = computeCanaryBucket(customSalt, key);
+
+      process.env['CANARY_TRAFFIC_PERCENT'] = String(bucket + 1);
+      process.env['CANARY_SALT'] = customSalt;
+
+      const app = express();
+      app.use(correlationIdMiddleware);
+      app.use(createCanaryRoutingMiddleware());
+      app.get('/ping', (req, res) => {
+        res.json({ isCanary: (req as express.Request & { isCanary?: boolean }).isCanary });
+      });
+
+      const res = await request(app).get('/ping').set('X-API-Key', key);
+      expect(res.body.isCanary).toBe(true);
+    });
+
+    it('defaults to trafficPercent=0 when CANARY_TRAFFIC_PERCENT is missing', async () => {
+      delete process.env['CANARY_TRAFFIC_PERCENT'];
+      const app = express();
+      app.use(correlationIdMiddleware);
+      app.use(createCanaryRoutingMiddleware());
+      app.get('/ping', (req, res) => {
+        res.json({ isCanary: (req as express.Request & { isCanary?: boolean }).isCanary });
+      });
+      const res = await request(app).get('/ping').set('X-API-Key', 'key');
+      expect(res.body.isCanary).toBe(false);
+    });
+
+    it('ignores an out-of-range CANARY_TRAFFIC_PERCENT and defaults to 0', async () => {
+      process.env['CANARY_TRAFFIC_PERCENT'] = '999';
+      const app = express();
+      app.use(correlationIdMiddleware);
+      app.use(createCanaryRoutingMiddleware());
+      app.get('/ping', (req, res) => {
+        res.json({ isCanary: (req as express.Request & { isCanary?: boolean }).isCanary });
+      });
+      const res = await request(app).get('/ping').set('X-API-Key', 'key');
+      // 999 is out of range; middleware clamps to 0
+      expect(res.body.isCanary).toBe(false);
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Correlation-ID integration
+// ---------------------------------------------------------------------------
+describe('correlationId integration', () => {
+  it('req.correlationId is available inside the middleware (correlationId runs first)', async () => {
+    let capturedCorrelationId: string | undefined;
+
+    const app = express();
+    app.use(correlationIdMiddleware);
+    // Spy middleware to capture correlationId before canary runs
+    app.use((req, _res, next) => {
+      capturedCorrelationId = req.correlationId;
+      next();
+    });
+    app.use(createCanaryRoutingMiddleware({ trafficPercent: 100 }));
+    app.get('/ping', (_req, res) => res.json({ ok: true }));
+
+    const cid = '123e4567-e89b-12d3-a456-426614174000';
+    await request(app).get('/ping').set('x-correlation-id', cid);
+    expect(capturedCorrelationId).toBe(cid);
+  });
+
+  it('canary decision log calls include the correlation ID', async () => {
+    const logSpy = vi.spyOn(
+      (await import('../../src/lib/logger.js')).logger,
+      'debug',
+    );
+
+    const salt = DEFAULT_CANARY_SALT;
+    const key = 'log-test-key';
+    const bucket = computeCanaryBucket(salt, key);
+    // Use a valid UUID v4 (version digit must be 1-5; use '4' = v4)
+    const cid = 'aaaabbbb-cccc-4234-8678-000000000000';
+
+    const app = buildApp(bucket + 1, salt);
+    await request(app)
+      .get('/ping')
+      .set('X-API-Key', key)
+      .set('x-correlation-id', cid);
+
+    // At least one debug call should include the correlationId
+    const canaryCall = logSpy.mock.calls.find(
+      ([msg, callCid]) =>
+        typeof msg === 'string' &&
+        msg.includes('canary') &&
+        callCid === cid,
+    );
+    expect(canaryCall).toBeDefined();
+    expect(canaryCall![1]).toBe(cid);
+
+    logSpy.mockRestore();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Security tests
+// ---------------------------------------------------------------------------
+describe('security', () => {
+  it('does not log the raw API key in any log call', async () => {
+    const logSpy = vi.spyOn(
+      (await import('../../src/lib/logger.js')).logger,
+      'debug',
+    );
+
+    const sensitiveKey = 'super-secret-api-key-do-not-log';
+    const app = buildApp(100);
+    await request(app).get('/ping').set('X-API-Key', sensitiveKey);
+
+    for (const [, , meta] of logSpy.mock.calls) {
+      expect(JSON.stringify(meta ?? {})).not.toContain(sensitiveKey);
+    }
+
+    logSpy.mockRestore();
+  });
+
+  it('does not log the raw client IP in any log call', async () => {
+    const logSpy = vi.spyOn(
+      (await import('../../src/lib/logger.js')).logger,
+      'debug',
+    );
+
+    // supertest resolves to 127.0.0.1
+    const app = buildApp(100);
+    await request(app).get('/ping');
+
+    for (const [, , meta] of logSpy.mock.calls) {
+      expect(JSON.stringify(meta ?? {})).not.toContain('127.0.0.1');
+    }
+
+    logSpy.mockRestore();
+  });
+
+  it('does not include the salt value in any log message or meta', async () => {
+    const customSalt = 'ultra-secret-salt-xyz-987';
+    const logSpy = vi.spyOn(
+      (await import('../../src/lib/logger.js')).logger,
+      'debug',
+    );
+
+    const app = buildApp(100, customSalt);
+    await request(app).get('/ping').set('X-API-Key', 'any');
+
+    for (const args of logSpy.mock.calls) {
+      expect(JSON.stringify(args)).not.toContain(customSalt);
+    }
+
+    logSpy.mockRestore();
+  });
+
+  it('different salts produce independent bucketing (cross-experiment isolation)', () => {
+    const id = 'same-client-everywhere';
+    const saltA = 'feature-flags-salt';
+    const saltB = DEFAULT_CANARY_SALT;
+
+    const bucketA = computeCanaryBucket(saltA, id);
+    const bucketB = computeCanaryBucket(saltB, id);
+
+    // The raw hash inputs are different — hashes must differ
+    const hashA = createHash('sha256').update(`${saltA}:${id}`).digest('hex');
+    const hashB = createHash('sha256').update(`${saltB}:${id}`).digest('hex');
+    expect(hashA).not.toBe(hashB);
+    // Buckets are independently computed
+    expect(typeof bucketA).toBe('number');
+    expect(typeof bucketB).toBe('number');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Exported constants
+// ---------------------------------------------------------------------------
+describe('exported constants', () => {
+  it('CANARY_HEADER is X-Fluxora-Canary', () => {
+    expect(CANARY_HEADER).toBe('X-Fluxora-Canary');
+  });
+
+  it('DEFAULT_CANARY_SALT is a non-empty string', () => {
+    expect(typeof DEFAULT_CANARY_SALT).toBe('string');
+    expect(DEFAULT_CANARY_SALT.length).toBeGreaterThan(0);
+  });
+
+  it('CANARY_BUCKET_COUNT is 100', () => {
+    expect(CANARY_BUCKET_COUNT).toBe(100);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Integration test via createApp()
+// ---------------------------------------------------------------------------
+describe('integration via createApp()', () => {
+  afterEach(() => {
+    delete process.env['CANARY_TRAFFIC_PERCENT'];
+    delete process.env['CANARY_SALT'];
+  });
+
+  it('X-Fluxora-Canary header is absent when CANARY_TRAFFIC_PERCENT=0 (default)', async () => {
+    delete process.env['CANARY_TRAFFIC_PERCENT'];
+    const app = createApp();
+    const res = await request(app).get('/health');
+    expect(res.headers[CANARY_HEADER.toLowerCase()]).toBeUndefined();
+  });
+
+  it('X-Fluxora-Canary: true is present when client bucket is within traffic percent', async () => {
+    const salt = DEFAULT_CANARY_SALT;
+    const key = 'integration-canary-key';
+    const bucket = computeCanaryBucket(salt, key);
+
+    process.env['CANARY_TRAFFIC_PERCENT'] = String(bucket + 1);
+
+    const app = createApp();
+    const res = await request(app)
+      .get('/health')
+      .set('X-API-Key', key);
+
+    expect(res.headers[CANARY_HEADER.toLowerCase()]).toBe('true');
+  });
+
+  it('header is absent on non-canary client even with partial traffic percent', async () => {
+    const salt = DEFAULT_CANARY_SALT;
+    const key = 'stable-client-key';
+    const bucket = computeCanaryBucket(salt, key);
+
+    // Set percent = bucket so this exact client is NOT canary
+    process.env['CANARY_TRAFFIC_PERCENT'] = String(bucket);
+
+    const app = createApp();
+    const res = await request(app)
+      .get('/health')
+      .set('X-API-Key', key);
+
+    expect(res.headers[CANARY_HEADER.toLowerCase()]).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

Implements a deterministic, header-based canary traffic split middleware that tags a configurable percentage of requests as canary using a stable SHA-256 hash of the client identity.

Closes #920

---

## Changes

### `src/middleware/canaryRouting.ts` (new)
- **`computeCanaryBucket(salt, identity, modulus?)`** — pure function: `SHA-256(salt:identity)`, first 8 hex chars as `uint32 % 100`
- **`resolveClientIdentity(req)`** — prefers `X-API-Key` header, falls back to `req.ip`
- **`createCanaryRoutingMiddleware(options?)`** — factory with explicit config or env-var-driven `trafficPercent` / `salt`
- **`canaryRoutingMiddleware`** — default export for `app.use()`
- Sets `req.isCanary: boolean`, echoes `X-Fluxora-Canary: true` response header, logs at `debug` with `correlationId` and bucket number

### `src/types/express.d.ts`
- Added `isCanary?: boolean` to `Express.Request` augmentation

### `src/config/env.ts`
- Added `CANARY_TRAFFIC_PERCENT` (integer 0–100, default `0`) to `EnvSchema`, `Config` type, and `toConfig()`

### `src/app.ts`
- Mounts `canaryRoutingMiddleware` immediately after `correlationIdMiddleware` so every canary-tagged request carries a traceable correlation ID

### `tests/middleware/canaryRouting.test.ts` (new — 40 tests, all passing)
- `computeCanaryBucket`: determinism, distribution, salt independence, custom modulus, reference formula
- `resolveClientIdentity`: API key priority, IP fallback, edge cases
- Middleware: disabled / 100% / partial split, threshold boundary, env var reading
- Correlation-ID integration: `req.correlationId` available inside middleware
- Security: raw API key, IP address, and salt are never present in any log call
- Integration via `createApp()`: header visible on real HTTP responses

### `docs/deployment.md`
- New **Canary Routing** section: algorithm, config table, observability (header + structured logs + Prometheus labelling hint), security notes, and operator runbook (enable / ramp / disable / rollback)

---

## Design decisions

| Decision | Rationale |
|---|---|
| **SHA-256 with dedicated `CANARY_SALT`** | Prevents correlated bucketing with feature-flag rollout hashes that share the same client identity — correlated hashes confound A/B measurement |
| **API key preferred over IP** | Stable across NAT/proxy/CDN topologies; same client always lands in the same bucket regardless of egress path |
| **`uint32 % 100`** | Simple, uniform, and avoids `BigInt` overhead while giving 2³² distinct hash inputs |
| **Reads env vars at request time** | Allows live traffic-percent changes without restart (e.g. in containers with a hot-reload sidecar) |
| **Mounted after correlationIdMiddleware** | Ensures every canary log line carries a correlation ID for end-to-end traceability |

---

## Security

- Raw client identity (API key or IP) is hashed before any use and **never logged**
- The salt (`CANARY_SALT`) is read from the environment and **never reflected** in logs or response headers
- The `X-Fluxora-Canary` header reveals only the binary decision (`true`), not the bucket value or identity
- `CANARY_TRAFFIC_PERCENT` is validated by the Zod schema to be an integer in `[0, 100]`; out-of-range values throw a `ConfigError` at startup

---

## Testing

```
pnpm test tests/middleware/canaryRouting.test.ts

 ✓ tests/middleware/canaryRouting.test.ts (40 tests) 205ms

 Test Files  1 passed (1)
       Tests  40 passed (40)
```