### PR TITLE
feat: per-API-key SSE connection cap (#701)

### DIFF
--- a/docs/api/sse-streams.md
+++ b/docs/api/sse-streams.md
@@ -73,6 +73,7 @@ Authentication is evaluated first; unauthenticated or invalid-token requests ret
 | Environment variable | Default | Description |
 | --- | ---: | --- |
 | `SSE_MAX_CONNECTIONS_PER_IP` | `10` | Maximum active SSE connections accepted from a single client IP. |
+| `SSE_MAX_CONNECTIONS_PER_API_KEY` | `50` | Maximum active SSE connections accepted for a single API key (`x-api-key` header). Enforced independently of the per-IP and global caps. |
 | `SSE_MAX_GLOBAL_CONNECTIONS` | `1000` | Maximum active SSE connections accepted process-wide. |
 | `SSE_MAX_CONNECTION_DURATION_MS` | `1800000` | Maximum lifetime of one SSE response before the server closes it. Defaults to 30 minutes. Valid range: 1 ms to 24 hours. |
 | `SSE_RETRY_AFTER_SECONDS` | `15` | Value sent in the `Retry-After` header when the endpoint rejects a connection with `429`. Valid range: 1 second to 24 hours. |
@@ -110,7 +111,7 @@ When `SSE_MAX_CONNECTION_DURATION_MS` is reached, the server writes a final `eve
 The endpoint exports these Prometheus metrics through the existing registry:
 
 * `fluxora_sse_active_connections` — gauge of active SSE responses in the current process.
-* `fluxora_sse_connections_rejected_total{reason="per_ip_limit|global_limit"}` — counter of rejected SSE connection attempts.
+* `fluxora_sse_connections_rejected_total{reason="per_ip_limit|per_key_limit|global_limit"}` — counter of rejected SSE connection attempts.
 
 ### Live fan-out efficiency
 

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -274,6 +274,7 @@ export const EnvSchema = z.object({
   ADMIN_API_TOKEN: optionalString('ADMIN_API_TOKEN'),
   WS_AUTH_REQUIRED: booleanEnv().default(false),
   SSE_MAX_CONNECTIONS_PER_IP: integerEnv('SSE_MAX_CONNECTIONS_PER_IP', 1, 100_000).default(10),
+  SSE_MAX_CONNECTIONS_PER_API_KEY: integerEnv('SSE_MAX_CONNECTIONS_PER_API_KEY', 1, 100_000).default(50),
   SSE_MAX_GLOBAL_CONNECTIONS: integerEnv('SSE_MAX_GLOBAL_CONNECTIONS', 1, 100_000).default(1000),
   SSE_MAX_CONNECTION_DURATION_MS: integerEnv('SSE_MAX_CONNECTION_DURATION_MS', 1, 86_400_000).default(30 * 60 * 1000),
   SSE_RETRY_AFTER_SECONDS: integerEnv('SSE_RETRY_AFTER_SECONDS', 1, 86_400).default(15),
@@ -448,6 +449,7 @@ export interface Config {
   requireAdminAuth: boolean;
   adminApiToken?: string | undefined;
   sseMaxConnectionsPerIp: number;
+  sseMaxConnectionsPerApiKey: number;
   sseMaxGlobalConnections: number;
   sseMaxConnectionDurationMs: number;
   sseRetryAfterSeconds: number;
@@ -634,6 +636,7 @@ function toConfig(env: ParsedEnv): Config {
     requireAdminAuth: env.REQUIRE_ADMIN_AUTH,
     adminApiToken: env.ADMIN_API_TOKEN,
     sseMaxConnectionsPerIp: env.SSE_MAX_CONNECTIONS_PER_IP,
+    sseMaxConnectionsPerApiKey: env.SSE_MAX_CONNECTIONS_PER_API_KEY,
     sseMaxGlobalConnections: env.SSE_MAX_GLOBAL_CONNECTIONS,
     sseMaxConnectionDurationMs: env.SSE_MAX_CONNECTION_DURATION_MS,
     sseRetryAfterSeconds: env.SSE_RETRY_AFTER_SECONDS,

--- a/src/routes/streams.ts
+++ b/src/routes/streams.ts
@@ -1162,7 +1162,8 @@ streamsRouter.get(
     // 2. Reserve bounded SSE capacity before repository work or header flush.
     const clientIp = getClientIp(req);
     const sseLimits = resolveSseConnectionLimits();
-    const connectionAttempt = tryAcquireSseConnection(clientIp, sseLimits);
+    const apiKey = (req.headers['x-api-key'] as string | undefined) ?? undefined;
+    const connectionAttempt = tryAcquireSseConnection(clientIp, sseLimits, apiKey);
 
     if (!connectionAttempt.ok) {
       res.setHeader('Retry-After', String(connectionAttempt.retryAfterSeconds));
@@ -1513,7 +1514,8 @@ streamsRouter.get(
     // 2. Reserve connection capacity from sseConnectionLimiter
     const clientIp = getClientIp(req);
     const sseLimits = resolveSseConnectionLimits();
-    const connectionAttempt = tryAcquireSseConnection(clientIp, sseLimits);
+    const apiKey = (req.headers['x-api-key'] as string | undefined) ?? undefined;
+    const connectionAttempt = tryAcquireSseConnection(clientIp, sseLimits, apiKey);
 
     if (!connectionAttempt.ok) {
       res.setHeader('Retry-After', String(connectionAttempt.retryAfterSeconds));

--- a/src/streams/sseConnectionLimiter.test.ts
+++ b/src/streams/sseConnectionLimiter.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  tryAcquireSseConnection,
+  resolveSseConnectionLimits,
+  _resetSseConnectionLimiter,
+  DEFAULT_SSE_MAX_CONNECTIONS_PER_API_KEY,
+} from './sseConnectionLimiter.js';
+
+const KEY = 'test-api-key';
+
+describe('tryAcquireSseConnection per-API-key cap', () => {
+  beforeEach(() => {
+    _resetSseConnectionLimiter();
+  });
+
+  it('rejects when the per-API-key cap is reached', () => {
+    const limits = resolveSseConnectionLimits();
+    // Lower the per-key cap so the test is deterministic.
+    const capped = { ...limits, maxConnectionsPerApiKey: 2 };
+
+    const a = tryAcquireSseConnection('1.1.1.1', capped, KEY);
+    const b = tryAcquireSseConnection('1.1.1.1', capped, KEY);
+    const c = tryAcquireSseConnection('1.1.1.1', capped, KEY);
+
+    expect(a.ok).toBe(true);
+    expect(b.ok).toBe(true);
+    expect(c.ok).toBe(false);
+    if (!c.ok) {
+      expect(c.reason).toBe('per_key_limit');
+    }
+  });
+
+  it('tracks per-key usage independently of the per-IP cap', () => {
+    const capped = {
+      ...resolveSseConnectionLimits(),
+      maxConnectionsPerApiKey: 1,
+      maxConnectionsPerIp: 100,
+    };
+
+    const first = tryAcquireSseConnection('9.9.9.9', capped, KEY);
+    expect(first.ok).toBe(true);
+
+    // Same key, different IP — still rejected by the per-key dimension.
+    const second = tryAcquireSseConnection('8.8.8.8', capped, KEY);
+    expect(second.ok).toBe(false);
+    if (!second.ok) {
+      expect(second.reason).toBe('per_key_limit');
+    }
+  });
+
+  it('releases per-key capacity so the cap recovers', () => {
+    const capped = {
+      ...resolveSseConnectionLimits(),
+      maxConnectionsPerApiKey: 1,
+    };
+
+    const first = tryAcquireSseConnection('1.1.1.1', capped, KEY);
+    expect(first.ok).toBe(true);
+    if (first.ok) first.connection.release();
+
+    const second = tryAcquireSseConnection('1.1.1.1', capped, KEY);
+    expect(second.ok).toBe(true);
+  });
+
+  it('does not enforce per-key cap when no API key is supplied', () => {
+    const capped = {
+      ...resolveSseConnectionLimits(),
+      maxConnectionsPerApiKey: 1,
+    };
+
+    const a = tryAcquireSseConnection('1.1.1.1', capped);
+    const b = tryAcquireSseConnection('1.1.1.1', capped);
+    expect(a.ok).toBe(true);
+    expect(b.ok).toBe(true);
+  });
+
+  it('exposes the default per-API-key cap via the resolver', () => {
+    expect(DEFAULT_SSE_MAX_CONNECTIONS_PER_API_KEY).toBeGreaterThan(0);
+    expect(resolveSseConnectionLimits().maxConnectionsPerApiKey).toBe(
+      DEFAULT_SSE_MAX_CONNECTIONS_PER_API_KEY,
+    );
+  });
+});

--- a/src/streams/sseConnectionLimiter.ts
+++ b/src/streams/sseConnectionLimiter.ts
@@ -2,6 +2,7 @@ import { sseActiveConnectionsGauge, sseConnectionsRejectedTotal } from '../metri
 
 export const DEFAULT_SSE_MAX_CONNECTIONS_PER_IP = 10;
 export const DEFAULT_SSE_MAX_GLOBAL_CONNECTIONS = 1000;
+export const DEFAULT_SSE_MAX_CONNECTIONS_PER_API_KEY = 50;
 export const DEFAULT_SSE_MAX_CONNECTION_DURATION_MS = 30 * 60 * 1000;
 export const DEFAULT_SSE_RETRY_AFTER_SECONDS = 15;
 
@@ -9,10 +10,14 @@ const MAX_SSE_CONNECTION_LIMIT = 100_000;
 const MAX_SSE_CONNECTION_DURATION_MS = 86_400_000;
 const MAX_SSE_RETRY_AFTER_SECONDS = 86_400;
 
-export type SseConnectionRejectionReason = 'per_ip_limit' | 'global_limit';
+export type SseConnectionRejectionReason =
+  | 'per_ip_limit'
+  | 'per_key_limit'
+  | 'global_limit';
 
 export interface SseConnectionLimits {
   maxConnectionsPerIp: number;
+  maxConnectionsPerApiKey: number;
   maxGlobalConnections: number;
   maxConnectionDurationMs: number;
   retryAfterSeconds: number;
@@ -46,6 +51,13 @@ export type SseConnectionAttempt =
 
 const activeConnectionsByIp = new Map<string, number>();
 let activeConnections = 0;
+const activeConnectionsByApiKey = new Map<string, number>();
+
+function normalizeApiKey(apiKey: string | undefined): string | undefined {
+  if (apiKey === undefined) return undefined;
+  const normalized = apiKey.trim();
+  return normalized.length > 0 ? normalized : undefined;
+}
 
 function normalizeIp(ip: string): string {
   const normalized = ip.trim();
@@ -90,6 +102,13 @@ export function resolveSseConnectionLimits(
       1,
       MAX_SSE_CONNECTION_LIMIT,
     ),
+    maxConnectionsPerApiKey: readBoundedPositiveInteger(
+      env,
+      'SSE_MAX_CONNECTIONS_PER_API_KEY',
+      DEFAULT_SSE_MAX_CONNECTIONS_PER_API_KEY,
+      1,
+      MAX_SSE_CONNECTION_LIMIT,
+    ),
     maxGlobalConnections: readBoundedPositiveInteger(
       env,
       'SSE_MAX_GLOBAL_CONNECTIONS',
@@ -124,8 +143,10 @@ export function resolveSseConnectionLimits(
 export function tryAcquireSseConnection(
   ip: string,
   limits: SseConnectionLimits = resolveSseConnectionLimits(),
+  apiKey?: string,
 ): SseConnectionAttempt {
   const normalizedIp = normalizeIp(ip);
+  const normalizedKey = normalizeApiKey(apiKey);
   const activeConnectionsForIp = activeConnectionsByIp.get(normalizedIp) ?? 0;
 
   if (activeConnectionsForIp >= limits.maxConnectionsPerIp) {
@@ -139,6 +160,22 @@ export function tryAcquireSseConnection(
       activeConnections,
       activeConnectionsForIp,
     };
+  }
+
+  if (normalizedKey !== undefined) {
+    const activeForKey = activeConnectionsByApiKey.get(normalizedKey) ?? 0;
+    if (activeForKey >= limits.maxConnectionsPerApiKey) {
+      sseConnectionsRejectedTotal.inc({ reason: 'per_key_limit' });
+      return {
+        ok: false,
+        reason: 'per_key_limit',
+        message: 'Too many active SSE connections for this API key',
+        limits,
+        retryAfterSeconds: limits.retryAfterSeconds,
+        activeConnections,
+        activeConnectionsForIp,
+      };
+    }
   }
 
   if (activeConnections >= limits.maxGlobalConnections) {
@@ -156,6 +193,10 @@ export function tryAcquireSseConnection(
 
   activeConnectionsByIp.set(normalizedIp, activeConnectionsForIp + 1);
   activeConnections += 1;
+  if (normalizedKey !== undefined) {
+    const currentForKey = activeConnectionsByApiKey.get(normalizedKey) ?? 0;
+    activeConnectionsByApiKey.set(normalizedKey, currentForKey + 1);
+  }
   sseActiveConnectionsGauge.set(activeConnections);
 
   let released = false;
@@ -178,6 +219,15 @@ export function tryAcquireSseConnection(
           activeConnectionsByIp.set(normalizedIp, currentForIp - 1);
         }
 
+        if (normalizedKey !== undefined) {
+          const currentForKey = activeConnectionsByApiKey.get(normalizedKey) ?? 0;
+          if (currentForKey <= 1) {
+            activeConnectionsByApiKey.delete(normalizedKey);
+          } else {
+            activeConnectionsByApiKey.set(normalizedKey, currentForKey - 1);
+          }
+        }
+
         activeConnections = Math.max(0, activeConnections - 1);
         sseActiveConnectionsGauge.set(activeConnections);
       },
@@ -196,6 +246,7 @@ export function getActiveSseConnectionCountForIp(ip: string): number {
 /** Reset limiter state between tests without touching the rejection counter. */
 export function _resetSseConnectionLimiter(): void {
   activeConnectionsByIp.clear();
+  activeConnectionsByApiKey.clear();
   activeConnections = 0;
   sseActiveConnectionsGauge.set(0);
 }


### PR DESCRIPTION
Add SSE_MAX_CONNECTIONS_PER_API_KEY limit to sseConnectionLimiter.ts with normalizedApiKey helper, per-key tryAcquire/release, and test coverage. Config interface updated in env.ts; routes pass req.apiKey.

Closes #701