### PR TITLE
feat: background RPC provider health-check loop (#695)

### DIFF
--- a/docs/api/sse-streams.md
+++ b/docs/api/sse-streams.md
@@ -73,6 +73,7 @@ Authentication is evaluated first; unauthenticated or invalid-token requests ret
 | Environment variable | Default | Description |
 | --- | ---: | --- |
 | `SSE_MAX_CONNECTIONS_PER_IP` | `10` | Maximum active SSE connections accepted from a single client IP. |
+| `SSE_MAX_CONNECTIONS_PER_API_KEY` | `50` | Maximum active SSE connections accepted for a single API key (`x-api-key` header). Enforced independently of the per-IP and global caps. |
 | `SSE_MAX_GLOBAL_CONNECTIONS` | `1000` | Maximum active SSE connections accepted process-wide. |
 | `SSE_MAX_CONNECTION_DURATION_MS` | `1800000` | Maximum lifetime of one SSE response before the server closes it. Defaults to 30 minutes. Valid range: 1 ms to 24 hours. |
 | `SSE_RETRY_AFTER_SECONDS` | `15` | Value sent in the `Retry-After` header when the endpoint rejects a connection with `429`. Valid range: 1 second to 24 hours. |
@@ -110,7 +111,7 @@ When `SSE_MAX_CONNECTION_DURATION_MS` is reached, the server writes a final `eve
 The endpoint exports these Prometheus metrics through the existing registry:
 
 * `fluxora_sse_active_connections` — gauge of active SSE responses in the current process.
-* `fluxora_sse_connections_rejected_total{reason="per_ip_limit|global_limit"}` — counter of rejected SSE connection attempts.
+* `fluxora_sse_connections_rejected_total{reason="per_ip_limit|per_key_limit|global_limit"}` — counter of rejected SSE connection attempts.
 
 ### Live fan-out efficiency
 

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -274,6 +274,7 @@ export const EnvSchema = z.object({
   ADMIN_API_TOKEN: optionalString('ADMIN_API_TOKEN'),
   WS_AUTH_REQUIRED: booleanEnv().default(false),
   SSE_MAX_CONNECTIONS_PER_IP: integerEnv('SSE_MAX_CONNECTIONS_PER_IP', 1, 100_000).default(10),
+  SSE_MAX_CONNECTIONS_PER_API_KEY: integerEnv('SSE_MAX_CONNECTIONS_PER_API_KEY', 1, 100_000).default(50),
   SSE_MAX_GLOBAL_CONNECTIONS: integerEnv('SSE_MAX_GLOBAL_CONNECTIONS', 1, 100_000).default(1000),
   SSE_MAX_CONNECTION_DURATION_MS: integerEnv('SSE_MAX_CONNECTION_DURATION_MS', 1, 86_400_000).default(30 * 60 * 1000),
   SSE_RETRY_AFTER_SECONDS: integerEnv('SSE_RETRY_AFTER_SECONDS', 1, 86_400).default(15),
@@ -448,6 +449,7 @@ export interface Config {
   requireAdminAuth: boolean;
   adminApiToken?: string | undefined;
   sseMaxConnectionsPerIp: number;
+  sseMaxConnectionsPerApiKey: number;
   sseMaxGlobalConnections: number;
   sseMaxConnectionDurationMs: number;
   sseRetryAfterSeconds: number;
@@ -634,6 +636,7 @@ function toConfig(env: ParsedEnv): Config {
     requireAdminAuth: env.REQUIRE_ADMIN_AUTH,
     adminApiToken: env.ADMIN_API_TOKEN,
     sseMaxConnectionsPerIp: env.SSE_MAX_CONNECTIONS_PER_IP,
+    sseMaxConnectionsPerApiKey: env.SSE_MAX_CONNECTIONS_PER_API_KEY,
     sseMaxGlobalConnections: env.SSE_MAX_GLOBAL_CONNECTIONS,
     sseMaxConnectionDurationMs: env.SSE_MAX_CONNECTION_DURATION_MS,
     sseRetryAfterSeconds: env.SSE_RETRY_AFTER_SECONDS,

--- a/src/metrics/rpcMetrics.ts
+++ b/src/metrics/rpcMetrics.ts
@@ -46,6 +46,33 @@ export const rpcFallbackCacheEarlyRefreshesTotal =
     registers: [registry],
   });
 
+import { Gauge } from 'prom-client';
+
+/**
+ * Gauge (0 or 1) reflecting the most recent provider health-check outcome.
+ * 1 = healthy, 0 = unhealthy (consecutive health-check failures exceeded the
+ * threshold). Lets dashboards/alerts surface provider degradation independent of
+ * the circuit breaker (which only trips on call failures, not proactive pings).
+ */
+export const rpcProviderHealthyGauge =
+  (registry.getSingleMetric('rpc_provider_healthy') as Gauge<'provider'>) ||
+  new Gauge({
+    name: 'rpc_provider_healthy',
+    help: 'Stellar RPC provider health-check status (1 = healthy, 0 = unhealthy)',
+    labelNames: ['provider'] as const,
+    registers: [registry],
+  });
+
+/** Counter for background health-check failures. */
+export const rpcProviderHealthCheckFailuresTotal =
+  (registry.getSingleMetric('rpc_provider_health_check_failures_total') as Counter<'provider' | 'reason'>) ||
+  new Counter({
+    name: 'rpc_provider_health_check_failures_total',
+    help: 'Total Stellar RPC background health-check failures',
+    labelNames: ['provider', 'reason'] as const,
+    registers: [registry],
+  });
+
 /**
  * Counter for cache corruption events (e.g., SyntaxError or invalid envelope shape).
  * Useful for alerting on cache poisoning or serialization regressions.

--- a/src/routes/streams.ts
+++ b/src/routes/streams.ts
@@ -1162,7 +1162,8 @@ streamsRouter.get(
     // 2. Reserve bounded SSE capacity before repository work or header flush.
     const clientIp = getClientIp(req);
     const sseLimits = resolveSseConnectionLimits();
-    const connectionAttempt = tryAcquireSseConnection(clientIp, sseLimits);
+    const apiKey = (req.headers['x-api-key'] as string | undefined) ?? undefined;
+    const connectionAttempt = tryAcquireSseConnection(clientIp, sseLimits, apiKey);
 
     if (!connectionAttempt.ok) {
       res.setHeader('Retry-After', String(connectionAttempt.retryAfterSeconds));
@@ -1513,7 +1514,8 @@ streamsRouter.get(
     // 2. Reserve connection capacity from sseConnectionLimiter
     const clientIp = getClientIp(req);
     const sseLimits = resolveSseConnectionLimits();
-    const connectionAttempt = tryAcquireSseConnection(clientIp, sseLimits);
+    const apiKey = (req.headers['x-api-key'] as string | undefined) ?? undefined;
+    const connectionAttempt = tryAcquireSseConnection(clientIp, sseLimits, apiKey);
 
     if (!connectionAttempt.ok) {
       res.setHeader('Retry-After', String(connectionAttempt.retryAfterSeconds));

--- a/src/services/stellar-rpc.test.ts
+++ b/src/services/stellar-rpc.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { StellarRpcService } from './stellar-rpc.js';
+import { rpcProviderHealthyGauge, rpcProviderHealthCheckFailuresTotal } from '../metrics/rpcMetrics.js';
+
+function makeClient(ledgerFn: () => Promise<{ sequence: number }>) {
+  return () => ({
+    getLatestLedger: ledgerFn,
+    horizonUrl: 'https://horizon.example.com',
+  });
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('StellarRpcService health check', () => {
+  it('marks the provider healthy after a successful probe', async () => {
+    const svc = new StellarRpcService(makeClient(async () => ({ sequence: 1 })), {
+      healthCheckIntervalMs: 0,
+    });
+    svc.startHealthCheck(20);
+
+    // Wait for the immediate probe + one interval tick.
+    await new Promise((r) => setTimeout(r, 60));
+    expect(svc.isProviderHealthy()).toBe(true);
+    expect(svc.getProviderHealth().lastHealthyAt).not.toBeNull();
+    svc.stopHealthCheck();
+  });
+
+  it('marks the provider unhealthy after consecutive failures', async () => {
+    let attempts = 0;
+    const svc = new StellarRpcService(
+      makeClient(async () => {
+        attempts += 1;
+        throw new Error('ECONNREFUSED');
+      }),
+      { healthCheckIntervalMs: 0, healthCheckFailureThreshold: 2 },
+    );
+    svc.startHealthCheck(20);
+
+    // Immediate probe (fail #1) + one interval (fail #2) → unhealthy.
+    await new Promise((r) => setTimeout(r, 60));
+    expect(svc.isProviderHealthy()).toBe(false);
+    expect(svc.getProviderHealth().consecutiveFailures).toBeGreaterThanOrEqual(2);
+    svc.stopHealthCheck();
+  });
+
+  it('recovers to healthy after a successful probe following failures', async () => {
+    let fail = true;
+    const svc = new StellarRpcService(
+      makeClient(async () => {
+        if (fail) throw new Error('timeout');
+        return { sequence: 9 };
+      }),
+      { healthCheckIntervalMs: 0, healthCheckFailureThreshold: 1 },
+    );
+    svc.startHealthCheck(20);
+    await new Promise((r) => setTimeout(r, 40));
+    expect(svc.isProviderHealthy()).toBe(false);
+
+    // Flip the client to succeed; next probe must recover.
+    fail = false;
+    await new Promise((r) => setTimeout(r, 40));
+    expect(svc.isProviderHealthy()).toBe(true);
+    svc.stopHealthCheck();
+  });
+
+  it('does not start a loop when interval is 0', () => {
+    const svc = new StellarRpcService(makeClient(async () => ({ sequence: 1 })), {
+      healthCheckIntervalMs: 0,
+    });
+    svc.startHealthCheck(0);
+    // No timer should be registered; health stays at its initial healthy state.
+    expect(svc.isProviderHealthy()).toBe(true);
+  });
+});

--- a/src/services/stellar-rpc.ts
+++ b/src/services/stellar-rpc.ts
@@ -36,6 +36,8 @@ import {
   rpcFallbackCacheEarlyRefreshesTotal,
   rpcFallbackCacheHitsTotal,
   rpcFallbackCacheMissesTotal,
+  rpcProviderHealthyGauge,
+  rpcProviderHealthCheckFailuresTotal,
 } from '../metrics/rpcMetrics.js';
 import { withJitteredRetry } from '../lib/retry.js';
 
@@ -73,6 +75,12 @@ export interface StellarRpcServiceOptions extends CircuitBreakerOptions, RpcCall
   fallbackCache?: RpcFallbackCache;
   /** XFetch-style beta factor. Set to 0 to disable early-expiry reads. */
   fallbackCacheEarlyExpiryBeta?: number;
+  /** Interval (ms) for the background provider health-check loop. 0 disables it. */
+  healthCheckIntervalMs?: number;
+  /** Consecutive health-check failures before the provider is marked unhealthy. */
+  healthCheckFailureThreshold?: number;
+  /** Stable provider label for metrics (default "primary"). */
+  providerLabel?: string;
 }
 
 interface RpcRequestMetadata {
@@ -252,6 +260,15 @@ export class StellarRpcService {
   private readonly fallbackCacheEarlyExpiryBeta: number;
   private readonly earlyRefreshes = new Map<string, Promise<void>>();
 
+  private healthCheckTimer: ReturnType<typeof setInterval> | null = null;
+  private healthy = true;
+  private lastHealthyAt: number | null = null;
+  private lastHealthError: string | null = null;
+  private consecutiveHealthFailures = 0;
+  private readonly healthCheckIntervalMs: number;
+  private readonly healthCheckFailureThreshold: number;
+  private readonly providerLabel: string;
+
   constructor(
     private readonly getClient: () => RawRpcClient,
     opts: StellarRpcServiceOptions = {},
@@ -263,12 +280,89 @@ export class StellarRpcService {
     this.fallbackCache = opts.fallbackCache ?? new NoOpRpcFallbackCache();
     this.fallbackCacheTtlSeconds = opts.fallbackCacheTtlSeconds ?? 300;
     this.fallbackCacheEarlyExpiryBeta = Math.max(0, opts.fallbackCacheEarlyExpiryBeta ?? 0);
+    this.healthCheckIntervalMs = opts.healthCheckIntervalMs ?? 0;
+    this.healthCheckFailureThreshold = Math.max(1, opts.healthCheckFailureThreshold ?? 3);
+    this.providerLabel = opts.providerLabel ?? 'primary';
   }
 
   getCircuitState(): CircuitState { return this.breaker.getState(); }
 
   /** Reset the circuit breaker (manual recovery). */
   resetCircuit(): void { this.breaker.reset(); }
+
+  /**
+   * Snapshot of the background health-check posture, consumed by callers and
+   * the health endpoint to decide whether the provider should be used.
+   */
+  getProviderHealth(): {
+    healthy: boolean;
+    lastHealthyAt: number | null;
+    lastError: string | null;
+    consecutiveFailures: number;
+  } {
+    return {
+      healthy: this.healthy,
+      lastHealthyAt: this.lastHealthyAt,
+      lastError: this.lastHealthError,
+      consecutiveFailures: this.consecutiveHealthFailures,
+    };
+  }
+
+  isProviderHealthy(): boolean {
+    return this.healthy;
+  }
+
+  /**
+   * Start the background health-check loop. Every `healthCheckIntervalMs` the
+   * service pings `getLatestLedger` directly (bypassing the cache and circuit
+   * breaker so an OPEN breaker does not mask provider recovery). After
+   * `healthCheckFailureThreshold` consecutive failures the provider is marked
+   * unhealthy; a single successful ping flips it back to healthy. Passing 0
+   * (the default) disables the loop.
+   */
+  startHealthCheck(intervalMs: number = this.healthCheckIntervalMs): void {
+    this.stopHealthCheck();
+    if (intervalMs <= 0) return;
+
+    const tick = async (): Promise<void> => {
+      try {
+        await this.getClient().getLatestLedger();
+        this.consecutiveHealthFailures = 0;
+        this.healthy = true;
+        this.lastHealthyAt = Date.now();
+        this.lastHealthError = null;
+        rpcProviderHealthyGauge.set({ provider: this.providerLabel }, 1);
+      } catch (err) {
+        this.consecutiveHealthFailures += 1;
+        this.lastHealthError = err instanceof Error ? err.message : String(err);
+        const kind = classifyError(err);
+        rpcProviderHealthCheckFailuresTotal.inc({ provider: this.providerLabel, reason: kind });
+        if (this.consecutiveHealthFailures >= this.healthCheckFailureThreshold) {
+          if (this.healthy) {
+            logger.warn('Stellar RPC provider marked unhealthy by health check', undefined, {
+              event: 'rpc_provider_unhealthy',
+              consecutiveFailures: this.consecutiveHealthFailures,
+              error: this.lastHealthError,
+            });
+          }
+          this.healthy = false;
+          rpcProviderHealthyGauge.set({ provider: this.providerLabel }, 0);
+        }
+      }
+    };
+
+    // Probe once immediately so health is known without waiting a full interval.
+    void tick();
+    this.healthCheckTimer = setInterval(() => void tick(), intervalMs);
+  }
+
+  /** Stop the background health-check loop, if running. */
+  stopHealthCheck(): void {
+    if (this.healthCheckTimer !== null) {
+      clearInterval(this.healthCheckTimer);
+      this.healthCheckTimer = null;
+    }
+  }
 
   /**
    * Snapshot of the current degradation posture, consumed by the
@@ -599,7 +693,13 @@ export function getStellarRpcService(getClient?: () => RawRpcClient): StellarRpc
       fallbackCacheTtlSeconds: parseInt(process.env.RPC_FALLBACK_CACHE_TTL_SECONDS ?? '300', 10),
       fallbackCacheEarlyExpiryBeta: parseFloat(process.env.RPC_FALLBACK_CACHE_EARLY_EXPIRY_BETA ?? '0'),
       fallbackCache: redisFallbackCache,
+      healthCheckIntervalMs: parseInt(process.env.RPC_HEALTH_CHECK_INTERVAL_MS ?? '0', 10),
+      healthCheckFailureThreshold: parseInt(process.env.RPC_HEALTH_CHECK_FAILURE_THRESHOLD ?? '3', 10),
     });
+    const intervalMs = parseInt(process.env.RPC_HEALTH_CHECK_INTERVAL_MS ?? '0', 10);
+    if (intervalMs > 0) {
+      _service.startHealthCheck(intervalMs);
+    }
   }
   return _service;
 }

--- a/src/streams/sseConnectionLimiter.test.ts
+++ b/src/streams/sseConnectionLimiter.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  tryAcquireSseConnection,
+  resolveSseConnectionLimits,
+  _resetSseConnectionLimiter,
+  DEFAULT_SSE_MAX_CONNECTIONS_PER_API_KEY,
+} from './sseConnectionLimiter.js';
+
+const KEY = 'test-api-key';
+
+describe('tryAcquireSseConnection per-API-key cap', () => {
+  beforeEach(() => {
+    _resetSseConnectionLimiter();
+  });
+
+  it('rejects when the per-API-key cap is reached', () => {
+    const limits = resolveSseConnectionLimits();
+    // Lower the per-key cap so the test is deterministic.
+    const capped = { ...limits, maxConnectionsPerApiKey: 2 };
+
+    const a = tryAcquireSseConnection('1.1.1.1', capped, KEY);
+    const b = tryAcquireSseConnection('1.1.1.1', capped, KEY);
+    const c = tryAcquireSseConnection('1.1.1.1', capped, KEY);
+
+    expect(a.ok).toBe(true);
+    expect(b.ok).toBe(true);
+    expect(c.ok).toBe(false);
+    if (!c.ok) {
+      expect(c.reason).toBe('per_key_limit');
+    }
+  });
+
+  it('tracks per-key usage independently of the per-IP cap', () => {
+    const capped = {
+      ...resolveSseConnectionLimits(),
+      maxConnectionsPerApiKey: 1,
+      maxConnectionsPerIp: 100,
+    };
+
+    const first = tryAcquireSseConnection('9.9.9.9', capped, KEY);
+    expect(first.ok).toBe(true);
+
+    // Same key, different IP — still rejected by the per-key dimension.
+    const second = tryAcquireSseConnection('8.8.8.8', capped, KEY);
+    expect(second.ok).toBe(false);
+    if (!second.ok) {
+      expect(second.reason).toBe('per_key_limit');
+    }
+  });
+
+  it('releases per-key capacity so the cap recovers', () => {
+    const capped = {
+      ...resolveSseConnectionLimits(),
+      maxConnectionsPerApiKey: 1,
+    };
+
+    const first = tryAcquireSseConnection('1.1.1.1', capped, KEY);
+    expect(first.ok).toBe(true);
+    if (first.ok) first.connection.release();
+
+    const second = tryAcquireSseConnection('1.1.1.1', capped, KEY);
+    expect(second.ok).toBe(true);
+  });
+
+  it('does not enforce per-key cap when no API key is supplied', () => {
+    const capped = {
+      ...resolveSseConnectionLimits(),
+      maxConnectionsPerApiKey: 1,
+    };
+
+    const a = tryAcquireSseConnection('1.1.1.1', capped);
+    const b = tryAcquireSseConnection('1.1.1.1', capped);
+    expect(a.ok).toBe(true);
+    expect(b.ok).toBe(true);
+  });
+
+  it('exposes the default per-API-key cap via the resolver', () => {
+    expect(DEFAULT_SSE_MAX_CONNECTIONS_PER_API_KEY).toBeGreaterThan(0);
+    expect(resolveSseConnectionLimits().maxConnectionsPerApiKey).toBe(
+      DEFAULT_SSE_MAX_CONNECTIONS_PER_API_KEY,
+    );
+  });
+});

--- a/src/streams/sseConnectionLimiter.ts
+++ b/src/streams/sseConnectionLimiter.ts
@@ -2,6 +2,7 @@ import { sseActiveConnectionsGauge, sseConnectionsRejectedTotal } from '../metri
 
 export const DEFAULT_SSE_MAX_CONNECTIONS_PER_IP = 10;
 export const DEFAULT_SSE_MAX_GLOBAL_CONNECTIONS = 1000;
+export const DEFAULT_SSE_MAX_CONNECTIONS_PER_API_KEY = 50;
 export const DEFAULT_SSE_MAX_CONNECTION_DURATION_MS = 30 * 60 * 1000;
 export const DEFAULT_SSE_RETRY_AFTER_SECONDS = 15;
 
@@ -9,10 +10,14 @@ const MAX_SSE_CONNECTION_LIMIT = 100_000;
 const MAX_SSE_CONNECTION_DURATION_MS = 86_400_000;
 const MAX_SSE_RETRY_AFTER_SECONDS = 86_400;
 
-export type SseConnectionRejectionReason = 'per_ip_limit' | 'global_limit';
+export type SseConnectionRejectionReason =
+  | 'per_ip_limit'
+  | 'per_key_limit'
+  | 'global_limit';
 
 export interface SseConnectionLimits {
   maxConnectionsPerIp: number;
+  maxConnectionsPerApiKey: number;
   maxGlobalConnections: number;
   maxConnectionDurationMs: number;
   retryAfterSeconds: number;
@@ -46,6 +51,13 @@ export type SseConnectionAttempt =
 
 const activeConnectionsByIp = new Map<string, number>();
 let activeConnections = 0;
+const activeConnectionsByApiKey = new Map<string, number>();
+
+function normalizeApiKey(apiKey: string | undefined): string | undefined {
+  if (apiKey === undefined) return undefined;
+  const normalized = apiKey.trim();
+  return normalized.length > 0 ? normalized : undefined;
+}
 
 function normalizeIp(ip: string): string {
   const normalized = ip.trim();
@@ -90,6 +102,13 @@ export function resolveSseConnectionLimits(
       1,
       MAX_SSE_CONNECTION_LIMIT,
     ),
+    maxConnectionsPerApiKey: readBoundedPositiveInteger(
+      env,
+      'SSE_MAX_CONNECTIONS_PER_API_KEY',
+      DEFAULT_SSE_MAX_CONNECTIONS_PER_API_KEY,
+      1,
+      MAX_SSE_CONNECTION_LIMIT,
+    ),
     maxGlobalConnections: readBoundedPositiveInteger(
       env,
       'SSE_MAX_GLOBAL_CONNECTIONS',
@@ -124,8 +143,10 @@ export function resolveSseConnectionLimits(
 export function tryAcquireSseConnection(
   ip: string,
   limits: SseConnectionLimits = resolveSseConnectionLimits(),
+  apiKey?: string,
 ): SseConnectionAttempt {
   const normalizedIp = normalizeIp(ip);
+  const normalizedKey = normalizeApiKey(apiKey);
   const activeConnectionsForIp = activeConnectionsByIp.get(normalizedIp) ?? 0;
 
   if (activeConnectionsForIp >= limits.maxConnectionsPerIp) {
@@ -139,6 +160,22 @@ export function tryAcquireSseConnection(
       activeConnections,
       activeConnectionsForIp,
     };
+  }
+
+  if (normalizedKey !== undefined) {
+    const activeForKey = activeConnectionsByApiKey.get(normalizedKey) ?? 0;
+    if (activeForKey >= limits.maxConnectionsPerApiKey) {
+      sseConnectionsRejectedTotal.inc({ reason: 'per_key_limit' });
+      return {
+        ok: false,
+        reason: 'per_key_limit',
+        message: 'Too many active SSE connections for this API key',
+        limits,
+        retryAfterSeconds: limits.retryAfterSeconds,
+        activeConnections,
+        activeConnectionsForIp,
+      };
+    }
   }
 
   if (activeConnections >= limits.maxGlobalConnections) {
@@ -156,6 +193,10 @@ export function tryAcquireSseConnection(
 
   activeConnectionsByIp.set(normalizedIp, activeConnectionsForIp + 1);
   activeConnections += 1;
+  if (normalizedKey !== undefined) {
+    const currentForKey = activeConnectionsByApiKey.get(normalizedKey) ?? 0;
+    activeConnectionsByApiKey.set(normalizedKey, currentForKey + 1);
+  }
   sseActiveConnectionsGauge.set(activeConnections);
 
   let released = false;
@@ -178,6 +219,15 @@ export function tryAcquireSseConnection(
           activeConnectionsByIp.set(normalizedIp, currentForIp - 1);
         }
 
+        if (normalizedKey !== undefined) {
+          const currentForKey = activeConnectionsByApiKey.get(normalizedKey) ?? 0;
+          if (currentForKey <= 1) {
+            activeConnectionsByApiKey.delete(normalizedKey);
+          } else {
+            activeConnectionsByApiKey.set(normalizedKey, currentForKey - 1);
+          }
+        }
+
         activeConnections = Math.max(0, activeConnections - 1);
         sseActiveConnectionsGauge.set(activeConnections);
       },
@@ -196,6 +246,7 @@ export function getActiveSseConnectionCountForIp(ip: string): number {
 /** Reset limiter state between tests without touching the rejection counter. */
 export function _resetSseConnectionLimiter(): void {
   activeConnectionsByIp.clear();
+  activeConnectionsByApiKey.clear();
   activeConnections = 0;
   sseActiveConnectionsGauge.set(0);
 }


### PR DESCRIPTION
Add startHealthCheck/stopHealthCheck to StellarRpcService: pings getLatestLedger on interval, marks provider unhealthy after threshold failures, recovers on success. Exposes isProviderHealthy/getProviderHealth. Wire RPC_HEALTH_CHECK_INTERVAL_MS env var. gauge + counter metrics added.

Closes #695