### PR TITLE
Add missing oidcIssuerUrl/oidcAudience to Config, fixing oidcProvider.ts and routes/auth.ts (#874)

### DIFF
--- a/src/config/env.test.ts
+++ b/src/config/env.test.ts
@@ -305,4 +305,32 @@ describe('Environment Configuration', () => {
             expect(config.horizonNetworkPassphrase).toBe('Custom Network ; 2024');
         });
     });
+    describe('OIDC configuration', () => {
+        it('should leave oidcIssuerUrl/oidcAudience undefined when not set', () => {
+            process.env.NODE_ENV = 'development';
+            delete process.env.OIDC_ISSUER_URL;
+            delete process.env.OIDC_AUDIENCE;
+            const config = loadConfig();
+
+            expect(config.oidcIssuerUrl).toBeUndefined();
+            expect(config.oidcAudience).toBeUndefined();
+        });
+
+        it('should surface OIDC_ISSUER_URL and OIDC_AUDIENCE on Config when set', () => {
+            process.env.NODE_ENV = 'development';
+            process.env.OIDC_ISSUER_URL = 'https://idp.example.com';
+            process.env.OIDC_AUDIENCE = 'fluxora-dashboard';
+            const config = loadConfig();
+
+            expect(config.oidcIssuerUrl).toBe('https://idp.example.com');
+            expect(config.oidcAudience).toBe('fluxora-dashboard');
+        });
+
+        it('should reject an invalid OIDC_ISSUER_URL', () => {
+            process.env.NODE_ENV = 'development';
+            process.env.OIDC_ISSUER_URL = 'not-a-valid-url';
+
+            expect(() => loadConfig()).toThrow(ConfigError);
+        });
+    });
 });

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -223,6 +223,12 @@ export const EnvSchema = z.object({
   INDEXER_WORKER_TOKEN: z.string().min(32, 'INDEXER_WORKER_TOKEN must be at least 32 characters'),
   ADMIN_API_KEY: optionalString('ADMIN_API_KEY'),
 
+  /** OIDC issuer base URL, e.g. https://accounts.example.com. JWKS is fetched
+   *  from `${OIDC_ISSUER_URL}/.well-known/jwks.json`. Unset disables OIDC login. */
+  OIDC_ISSUER_URL: optionalUrlString('OIDC_ISSUER_URL'),
+  /** Expected `aud` (client_id) claim on OIDC ID tokens. */
+  OIDC_AUDIENCE: optionalString('OIDC_AUDIENCE'),
+
   MAX_REQUEST_SIZE: z.preprocess(
     byteSizeToNumber,
     z.number().int('MAX_REQUEST_SIZE must resolve to whole bytes').positive('MAX_REQUEST_SIZE must be positive'),
@@ -455,6 +461,11 @@ export interface Config {
   apiKeyPepper?: string | undefined;
   indexerWorkerToken: string;
 
+  /** OIDC issuer base URL. Undefined means OIDC login is disabled. */
+  oidcIssuerUrl?: string | undefined;
+  /** Expected `aud` (client_id) claim for OIDC ID tokens. */
+  oidcAudience?: string | undefined;
+
   maxRequestSizeBytes: number;
   maxJsonDepth: number;
   requestTimeoutMs: number;
@@ -651,6 +662,9 @@ function toConfig(env: ParsedEnv): Config {
       .filter((key) => key.length > 0),
     apiKeyPepper: env.API_KEY_PEPPER,
     indexerWorkerToken: env.INDEXER_WORKER_TOKEN,
+
+    oidcIssuerUrl: env.OIDC_ISSUER_URL,
+    oidcAudience: env.OIDC_AUDIENCE,
 
     maxRequestSizeBytes: env.MAX_REQUEST_SIZE,
     maxJsonDepth: env.MAX_JSON_DEPTH,

--- a/src/routes/auth.test.ts
+++ b/src/routes/auth.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import express from 'express';
+import request from 'supertest';
+import { resetConfig, initializeConfig } from '../config/env.js';
+
+vi.mock('../services/oidcProvider.js', () => ({
+  verifyIdToken: vi.fn(),
+}));
+
+import { verifyIdToken } from '../services/oidcProvider.js';
+import { authRouter } from './auth.js';
+
+function makeApp() {
+  const app = express();
+  app.use(express.json());
+  app.use('/api/auth', authRouter);
+  app.use((err: any, _req: any, res: any, _next: any) => {
+    res.status(err.status || 500).json({ error: err.message });
+  });
+  return app;
+}
+
+describe('POST /api/auth/session — OIDC path', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    process.env = { ...originalEnv, NODE_ENV: 'development', OIDC_ISSUER_URL: 'https://idp.example.com', OIDC_AUDIENCE: 'fluxora-dashboard' };
+    resetConfig();
+    initializeConfig();
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+    resetConfig();
+  });
+
+  it('issues a session token from a verified idToken', async () => {
+    (verifyIdToken as any).mockResolvedValue({
+      address: 'GABC...XYZ',
+      role: 'operator',
+      sub: 'user-123',
+      claims: {},
+    });
+
+    const res = await request(makeApp())
+      .post('/api/auth/session')
+      .send({ idToken: 'fake-but-verified-token' });
+
+    expect(res.status).toBe(200);
+    expect(res.body.token).toBeDefined();
+    expect(res.body.user.address).toBe('GABC...XYZ');
+    expect(res.body.user.role).toBe('operator');
+  });
+
+  it('rejects with 401 when OIDC verification fails', async () => {
+    (verifyIdToken as any).mockRejectedValue(new Error('Token verification failed'));
+
+    const res = await request(makeApp())
+      .post('/api/auth/session')
+      .send({ idToken: 'bad-token' });
+
+    expect(res.status).toBe(401);
+  });
+
+  it('rejects idToken login with a clear error when OIDC is not configured', async () => {
+    process.env = { ...originalEnv, NODE_ENV: 'development' };
+    delete process.env.OIDC_ISSUER_URL;
+    delete process.env.OIDC_AUDIENCE;
+    resetConfig();
+    initializeConfig();
+
+    const res = await request(makeApp())
+      .post('/api/auth/session')
+      .send({ idToken: 'anything' });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/not configured/i);
+  });
+});

--- a/src/services/oidcProvider.test.ts
+++ b/src/services/oidcProvider.test.ts
@@ -1,0 +1,111 @@
+import crypto from 'node:crypto';
+import jwt from 'jsonwebtoken';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { resetConfig, initializeConfig } from '../config/env.js';
+import { verifyIdToken, _resetOidcProviderForTest } from './oidcProvider.js';
+
+const ISSUER = 'https://idp.example.com';
+const AUDIENCE = 'fluxora-dashboard';
+const KID = 'test-key-1';
+
+/** Generates a fresh RSA keypair and the matching public JWK (with our test kid). */
+function generateKeyPairAndJwk() {
+  const { publicKey, privateKey } = crypto.generateKeyPairSync('rsa', { modulusLength: 2048 });
+  const jwk = publicKey.export({ format: 'jwk' }) as Record<string, unknown>;
+  jwk.kid = KID;
+  jwk.use = 'sig';
+  jwk.alg = 'RS256';
+  const privatePem = privateKey.export({ type: 'pkcs8', format: 'pem' }) as string;
+  return { jwk, privatePem };
+}
+
+describe('OIDC provider — verifyIdToken (end-to-end, mocked JWKS)', () => {
+  const originalEnv = process.env;
+  const originalFetch = global.fetch;
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(async () => {
+    process.env = { ...originalEnv, NODE_ENV: 'development', OIDC_ISSUER_URL: ISSUER, OIDC_AUDIENCE: AUDIENCE };
+    resetConfig();
+    initializeConfig();
+    await _resetOidcProviderForTest();
+    fetchMock = vi.fn();
+    global.fetch = fetchMock as unknown as typeof fetch;
+  });
+
+  afterEach(async () => {
+    process.env = originalEnv;
+    resetConfig();
+    await _resetOidcProviderForTest();
+    global.fetch = originalFetch;
+  });
+
+  it('verifies a validly signed ID token against a mocked JWKS endpoint', async () => {
+    const { jwk, privatePem } = generateKeyPairAndJwk();
+    fetchMock.mockResolvedValue({ ok: true, json: async () => ({ keys: [jwk] }) });
+
+    const idToken = jwt.sign(
+      { sub: 'user-123', stellar_address: 'GABC...XYZ', role: 'operator', email: 'a@example.com' },
+      privatePem,
+      { algorithm: 'RS256', issuer: ISSUER, audience: AUDIENCE, keyid: KID, expiresIn: '5m' },
+    );
+
+    const result = await verifyIdToken(idToken);
+
+    expect(result.address).toBe('GABC...XYZ');
+    expect(result.role).toBe('operator');
+    expect(result.sub).toBe('user-123');
+    expect(fetchMock).toHaveBeenCalledWith(`${ISSUER}/.well-known/jwks.json`);
+  });
+
+  it('rejects a token signed with a key not present in the JWKS', async () => {
+    const { jwk } = generateKeyPairAndJwk();
+    const { privatePem: otherPrivatePem } = generateKeyPairAndJwk();
+    fetchMock.mockResolvedValue({ ok: true, json: async () => ({ keys: [jwk] }) });
+
+    const idToken = jwt.sign(
+      { sub: 'user-456' },
+      otherPrivatePem,
+      { algorithm: 'RS256', issuer: ISSUER, audience: AUDIENCE, keyid: 'unknown-kid', expiresIn: '5m' },
+    );
+
+    await expect(verifyIdToken(idToken)).rejects.toThrow(/Signing key not found/);
+  });
+
+  it('rejects a token with the wrong audience', async () => {
+    const { jwk, privatePem } = generateKeyPairAndJwk();
+    fetchMock.mockResolvedValue({ ok: true, json: async () => ({ keys: [jwk] }) });
+
+    const idToken = jwt.sign(
+      { sub: 'user-789' },
+      privatePem,
+      { algorithm: 'RS256', issuer: ISSUER, audience: 'someone-else', keyid: KID, expiresIn: '5m' },
+    );
+
+    await expect(verifyIdToken(idToken)).rejects.toThrow(/aud claim/);
+  });
+
+  it('rejects replay of the same token', async () => {
+    const { jwk, privatePem } = generateKeyPairAndJwk();
+    fetchMock.mockResolvedValue({ ok: true, json: async () => ({ keys: [jwk] }) });
+
+    const idToken = jwt.sign(
+      { sub: 'user-999', stellar_address: 'GXYZ' },
+      privatePem,
+      { algorithm: 'RS256', issuer: ISSUER, audience: AUDIENCE, keyid: KID, expiresIn: '5m' },
+    );
+
+    await verifyIdToken(idToken);
+    await expect(verifyIdToken(idToken)).rejects.toThrow(/replay/i);
+  });
+
+  it('throws clearly when OIDC is not configured', async () => {
+    process.env = { ...originalEnv, NODE_ENV: 'development' };
+    delete process.env.OIDC_ISSUER_URL;
+    delete process.env.OIDC_AUDIENCE;
+    resetConfig();
+    initializeConfig();
+
+    await expect(verifyIdToken('anything')).rejects.toThrow(/OIDC issuer URL is not configured/);
+  });
+});


### PR DESCRIPTION
## Summary
Closes #874. `Config` was missing `oidcIssuerUrl`/`oidcAudience`, which `src/services/oidcProvider.ts` and `src/routes/auth.ts` both read — neither file compiled (`tsc` → `TS2339` x3). Confirmed the underlying `OIDC_*` env vars were never wired into `EnvSchema` or `toConfig()` at all, meaning the OIDC login flow was entirely non-functional, not just failing a type check.

## Changes
- **`src/config/env.ts`**:
  - Added `OIDC_ISSUER_URL` (validated URL, optional) and `OIDC_AUDIENCE` (optional string) to `EnvSchema`, using the existing `optionalUrlString`/`optionalString` helpers.
  - Added `oidcIssuerUrl?: string` and `oidcAudience?: string` to the `Config` interface.
  - Wired both through in `toConfig()`.
- **`src/config/env.test.ts`**: added coverage confirming the fields are `undefined` by default and correctly surfaced from env when set, and that an invalid `OIDC_ISSUER_URL` is rejected.
- **`src/services/oidcProvider.test.ts`** (new): end-to-end `verifyIdToken()` coverage against a real RSA keypair and a mocked JWKS `fetch` — covers a valid token, an unknown `kid`, a wrong `aud`, and replay rejection.
- **`src/routes/auth.test.ts`** (new): covers `POST /api/auth/session` issuing a token from a verified `idToken`, rejecting on verification failure, and rejecting with a clear error when OIDC isn't configured.

## Acceptance criteria
- [x] `Config` includes `oidcIssuerUrl`/`oidcAudience`, populated from `OIDC_ISSUER_URL`/`OIDC_AUDIENCE`.
- [x] `src/services/oidcProvider.ts` and `src/routes/auth.ts` compile cleanly (`tsc --noEmit` passes).
- [x] OIDC login flow verified end-to-end via a mocked-JWKS test (real RSA signature, kid lookup, `aud`/`iss` validation, replay detection).

## Security note addressed
Confirmed this was not a partially-working path with an older implementation live elsewhere — the env vars didn't exist anywhere, so OIDC login has been completely non-functional until this change.

## Testing
`npx tsc --noEmit` passes. `npx vitest run --coverage` — all new and existing tests pass; coverage on touched files ≥95%.