### PR TITLE
feat: add grpc.health.v1 health-check service for k8s probes

### DIFF
--- a/src/tracing/hooks.ts
+++ b/src/tracing/hooks.ts
@@ -323,9 +323,8 @@ export class Tracer {
                 resolve();
               }
             });
-          }
-          this.activeSpans.delete(span.context.spanId);
           });
+          this.activeSpans.delete(span.context.spanId);
         }
       }
     }

--- a/tests/health/grpcHealth.test.ts
+++ b/tests/health/grpcHealth.test.ts
@@ -243,12 +243,10 @@ describe('grpcHealth', () => {
 
       // Open a Watch stream and never close it client-side.
       const call = client.watch({ service: '' });
-      // Expected once we call cancel() (or the server force-closes the
-      // stream) — without a listener, grpc-js surfaces it as an unhandled
-      // 'error' event on the EventEmitter, failing the test run.
       call.on('error', () => {});
-      call.on('data',() => {});
-      await new Promise((r) => setTimeout(r, 15));
+      await new Promise<void>((resolve) => {
+        call.once('data', () => resolve());
+      });
 
       const start = Date.now();
       await stopGrpcHealthServer(server, 100);


### PR DESCRIPTION
## Summary
Adds support for the standard `grpc.health.v1.Health` service alongside the existing HTTP `/health` routes to support Kubernetes-native gRPC probes (`grpc-health-probe`).

Closes #922 

## Changes
- **gRPC Health Check Service** (`src/health/grpcHealth.ts`):
  - Implements standard `Check` and `Watch` RPCs.
  - Reuses the existing `HealthCheckManager` dependency checks to prevent status drift.
  - Maps `healthy`/`degraded` to `SERVING` and `unhealthy`/errors to `NOT_SERVING`.
  - Configurable and optional via `GRPC_HEALTH_ENABLED` and `GRPC_HEALTH_PORT`.
- **Bug Fixes**:
  - **Syntax Error Fix** (`src/tracing/hooks.ts`): Resolved a compiler error in `flush()` where a Promise was not closed correctly.
  - **Test Flakiness Fix** (`tests/health/grpcHealth.test.ts`): Updated the grace period force-shutdown test to wait dynamically for a `'data'` event on the watch stream instead of relying on a flaky 15ms hard timeout.

## Testing & Verification
- Unit and integration tests passed successfully:
  - `tests/health/grpcHealth.test.ts`
  - `tests/health/grpcHealthWatch.test.ts`
- Verified that all edge cases (graceful shutdown, cancellation, throwing health managers, and custom config ports) are handled robustly.
