### PR TITLE
Fix memory leak in webhook deduplication by replacing Set with DedupC…

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -8,7 +8,7 @@ import { auditRouter } from './routes/audit.js';
 import { adminRouter } from './routes/admin.js';
 import { dlqRouter } from './routes/dlq.js';
 import { authRouter } from './routes/auth.js';
-import { webhooksRouter } from './routes/webhooks.js';
+import { webhooksRouter, setInboundWebhookDedupCache } from './routes/webhooks.js';
 import { privacyRouter } from './routes/privacy.js';
 import { privacyHeaders } from './middleware/pii.js';
 import type { Config } from './config/env.js';
@@ -183,6 +183,46 @@ async function wireStreamEventDedupCache(config: Config): Promise<void> {
       },
     );
     setDedupCache(new InMemoryDedupCache());
+  }
+}
+
+async function wireInboundWebhookDedupCache(config: Config): Promise<void> {
+  if (!config.redisEnabled) {
+    logger.info('Redis disabled — inbound webhook dedup will use in-memory cache');
+    setInboundWebhookDedupCache(new InMemoryDedupCache());
+    return;
+  }
+
+  try {
+    const redisClient = await createRedisClient({
+      url: config.redisUrl,
+      enabled: config.redisEnabled,
+      mode: config.redisMode,
+      sentinelHosts: config.redisSentinelHosts,
+      sentinelName: config.redisSentinelName,
+      clusterNodes: config.redisClusterNodes,
+    });
+
+    const primary = new RedisDedupCache(redisClient);
+    const fallback = new InMemoryDedupCache();
+    const hybrid = new HybridDedupCache(primary, fallback, true);
+
+    setInboundWebhookDedupCache(hybrid);
+    addShutdownHook(() => hybrid.close());
+
+    logger.info('Redis inbound webhook dedup cache wired', undefined, {
+      component: 'inbound-webhook-dedup',
+    });
+  } catch (err) {
+    logger.warn(
+      'Redis connection failed for inbound webhook dedup — falling back to in-memory cache',
+      undefined,
+      {
+        component: 'inbound-webhook-dedup',
+        error: err instanceof Error ? err.message : String(err),
+      },
+    );
+    setInboundWebhookDedupCache(new InMemoryDedupCache());
   }
 }
 
@@ -386,6 +426,7 @@ export function createApp(options: AppOptions = {}): Express {
   const appConfig = options.config ?? loadConfig();
   void wireIdempotencyStore(appConfig);
   void wireStreamEventDedupCache(appConfig);
+  void wireInboundWebhookDedupCache(appConfig);
   void wireWebhookCircuitBreakerStore(appConfig);
   void wireAdminStateLock(appConfig);
   void wireIndexerLeaderElection(appConfig);

--- a/src/routes/webhooks.test.ts
+++ b/src/routes/webhooks.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import express from 'express';
+import request from 'supertest';
+import { webhooksRouter, setInboundWebhookDedupCache, getInboundWebhookDedupCache } from './webhooks.js';
+import { InMemoryDedupCache } from '../redis/dedup.js';
+import { computeWebhookSignature } from '../webhooks/signature.js';
+
+function makeApp() {
+  const app = express();
+  app.use('/internal/webhooks', webhooksRouter);
+  return app;
+}
+
+describe('POST /internal/webhooks/receive dedup', () => {
+  beforeEach(() => {
+    process.env.FLUXORA_WEBHOOK_SECRET = 'test-secret';
+    setInboundWebhookDedupCache(new InMemoryDedupCache());
+  });
+
+  it('bounds memory footprint under sustained unique-delivery-id traffic', async () => {
+    const app = makeApp();
+    const cache = getInboundWebhookDedupCache() as InMemoryDedupCache;
+    
+    // InMemoryDedupCache caps at 10,000. We insert 10,005 to test eviction.
+    
+    // To speed up the test without supertest overhead for 10,000 requests, 
+    // we populate 9,998 directly, and then send 7 via the endpoint.
+    for (let i = 0; i < 9998; i++) {
+        await cache.add('webhook', `deliv_pre_${i}`);
+    }
+
+    for (let i = 0; i < 7; i++) {
+      const deliveryId = `deliv_${i}`;
+      const payload = '{}';
+      const timestamp = Math.floor(Date.now() / 1000).toString();
+      const signature = computeWebhookSignature('test-secret', timestamp, payload);
+      
+      const res = await request(app)
+        .post('/internal/webhooks/receive')
+        .set('x-fluxora-delivery-id', deliveryId)
+        .set('x-fluxora-timestamp', timestamp)
+        .set('x-fluxora-signature', signature)
+        .set('x-fluxora-event', 'test.event')
+        .set('Content-Type', 'application/json')
+        .send(payload);
+        
+      expect(res.status).toBe(200);
+    }
+    
+    // Check that the cache hasn't grown beyond 10,000
+    const internalMap = (cache as any).seen as Map<string, true>;
+    expect(internalMap.size).toBeLessThanOrEqual(10000);
+    expect(internalMap.size).toBe(10000); // It should be exactly 10000
+    
+    // Verify duplicate returns 409
+    const payload = '{}';
+    const timestamp = Math.floor(Date.now() / 1000).toString();
+    const signature = computeWebhookSignature('test-secret', timestamp, payload);
+    const resDup = await request(app)
+        .post('/internal/webhooks/receive')
+        .set('x-fluxora-delivery-id', 'deliv_0')
+        .set('x-fluxora-timestamp', timestamp)
+        .set('x-fluxora-signature', signature)
+        .set('x-fluxora-event', 'test.event')
+        .set('Content-Type', 'application/json')
+        .send(payload);
+    
+    expect(resDup.status).toBe(409);
+    expect(resDup.body.error).toBe('duplicate_delivery');
+  });
+});

--- a/src/routes/webhooks.ts
+++ b/src/routes/webhooks.ts
@@ -17,6 +17,18 @@ import { requireAdminAuth } from '../middleware/adminAuth.js';
 import { logger } from '../lib/logger.js';
 import { successResponse, errorResponse } from '../utils/response.js';
 import { OffsetPaginationSchema } from '../validation/paginationSchema.js';
+import { InMemoryDedupCache } from '../redis/dedup.js';
+import type { DedupCache } from '../redis/dedup.js';
+
+let inboundWebhookDedupCache: DedupCache = new InMemoryDedupCache();
+
+export function setInboundWebhookDedupCache(cache: DedupCache): void {
+  inboundWebhookDedupCache = cache;
+}
+
+export function getInboundWebhookDedupCache(): DedupCache {
+  return inboundWebhookDedupCache;
+}
 
 export const webhooksRouter = express.Router();
 
@@ -29,22 +41,21 @@ export const webhooksRouter = express.Router();
  * POST /internal/webhooks/receive
  *
  * Verifies an incoming Fluxora webhook delivery against the shared secret.
+ * Deduplicates using `inboundWebhookDedupCache` (24h TTL, max 10,000 entries per instance).
  * Returns a flat envelope (not the standard successResponse / errorResponse
  * shape) so callers can rely on stable HTTP status codes and the
  * `error` string match the documented `WebhookVerificationCode` values.
  */
-const seenDeliveries = new Set<string>();
 webhooksRouter.post(
   '/receive',
   express.raw({ type: '*/*', limit: '1mb' }),
-  (req, res): void => {
+  async (req, res): Promise<void> => {
     const rawBody = req.body as Buffer;
     const headers = req.headers as Record<string, string | undefined>;
     // `verifyWebhookSignature` uses exact-optional types — only forward
     // properties when they are actually set.
     const verifyInput: Parameters<typeof verifyWebhookSignature>[0] = {
       rawBody,
-      isDuplicateDelivery: (id: string) => seenDeliveries.has(id),
     };
     if (process.env.FLUXORA_WEBHOOK_SECRET !== undefined) {
       verifyInput.secret = process.env.FLUXORA_WEBHOOK_SECRET;
@@ -66,7 +77,12 @@ webhooksRouter.post(
     }
 
     const deliveryId = headers['x-fluxora-delivery-id']!;
-    seenDeliveries.add(deliveryId);
+    
+    const isNew = await inboundWebhookDedupCache.add('webhook', deliveryId);
+    if (!isNew) {
+      res.status(409).json({ error: 'duplicate_delivery', message: 'Duplicate delivery id' });
+      return;
+    }
 
     let parsed: unknown;
     try {

--- a/src/tracing/hooks.ts
+++ b/src/tracing/hooks.ts
@@ -323,9 +323,8 @@ export class Tracer {
                 resolve();
               }
             });
-          }
-          this.activeSpans.delete(span.context.spanId);
           });
+          this.activeSpans.delete(span.context.spanId);
         }
       }
     }


### PR DESCRIPTION
Closes #840 
Resolves an unbounded memory growth issue in the POST /internal/webhooks/receive route caused by the seenDeliveries Set<string>. Previously, the Set kept every unique x-fluxora-delivery-id in memory forever and did not survive restarts.

This PR replaces the bespoke Set with a HybridDedupCache (reusing the cache from src/redis/dedup.ts), bringing the inbound deduplication in line with the rest of the application.

Changes

Replaced seenDeliveries in src/routes/webhooks.ts with inboundWebhookDedupCache (24h TTL, max 10,000 entries limit fallback).
Refactored the POST /receive handler to be asynchronous, executing the duplicate check directly after signature validation.
Added dependency wiring in src/app.ts (wireInboundWebhookDedupCache) to provision the HybridDedupCache backed by Redis with in-memory fallback.
Added src/routes/webhooks.test.ts to assert that memory grows bounded by 10,000 entries under sustained, unique inbound requests, and successfully rejects duplicate deliveries with HTTP 409.
Fixed a pre-existing syntax error in src/tracing/hooks.ts that broke the test runner.
Acceptance Criteria Met

Bounded memory footprint under sustained load tested.
Dedup guarantees are consistent and Redis-backed for multi-instance deployments.
Route documentation added, explicitly stating deduplication constraints.