### PR TITLE
feat: generate TypeScript client SDK from openapi.yaml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,11 @@ jobs:
       - name: SDK drift check (Python)
         run: node scripts/generate-sdk-python.mjs --check
 
+      # Drift check: fail CI if sdk/typescript/ diverges from openapi.yaml.
+      # Re-run `pnpm generate:sdk:ts` locally and commit the result to fix.
+      - name: SDK drift check (TypeScript)
+        run: node scripts/generate-sdk-ts.mjs --check
+
       # continue-on-error keeps this visible without blocking the pipeline while
       # a large pre-existing backlog (~467 failing tests / 59 files, unrelated
       # to CI restoration) gets triaged in a dedicated follow-up.

--- a/package.json
+++ b/package.json
@@ -25,7 +25,9 @@
     "docker:seed": "docker-compose exec indexer pnpm run seed",
     "docker:test": "docker-compose exec indexer pnpm test",
     "generate:sdk:python": "node scripts/generate-sdk-python.mjs",
-    "check:sdk:python": "node scripts/generate-sdk-python.mjs --check"
+    "check:sdk:python": "node scripts/generate-sdk-python.mjs --check",
+    "generate:sdk:ts": "node scripts/generate-sdk-ts.mjs",
+    "check:sdk:ts": "node scripts/generate-sdk-ts.mjs --check"
   },
   "keywords": [
     "indexer",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -142,6 +142,8 @@ importers:
         specifier: ^1.6.0
         version: 1.6.1(@types/node@20.19.43)
 
+  sdk/typescript: {}
+
 packages:
 
   '@ampproject/remapping@2.3.0':

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+packages:
+  - 'sdk/*'

--- a/scripts/generate-sdk-ts.mjs
+++ b/scripts/generate-sdk-ts.mjs
@@ -1,52 +1,74 @@
 #!/usr/bin/env node
 /**
- * TypeScript Client SDK generator script for Fluxora Backend.
- * Generates a typed TypeScript client SDK under `sdk/typescript/` from `openapi.yaml`.
+ * TypeScript Client SDK generator for Fluxora Backend.
+ *
+ * Reads `openapi.yaml` (the authoritative spec) and emits a fully-typed
+ * TypeScript client under `sdk/typescript/`.
  *
  * Usage:
  *   node scripts/generate-sdk-ts.mjs [--check] [--out-dir <path>] [--spec <path>]
  *
  * Options:
- *   --check       Drift check mode: compares generated output against existing files.
- *                 Exits 0 if identical, exits 1 if files differ or are missing.
- *   --out-dir     Output directory for the TypeScript SDK (default: sdk/typescript).
- *   --spec        Path to openapi.yaml spec file (default: openapi.yaml).
+ *   --check     Drift-check mode. Compares generated output against disk.
+ *               Exits 0 when identical; exits 1 on any mismatch or missing file.
+ *               Used by CI to catch spec/SDK divergence automatically.
+ *   --out-dir   Output directory (default: sdk/typescript).
+ *   --spec      Path to openapi.yaml (default: openapi.yaml).
+ *
+ * @security Generated files contain no credentials or secrets. Bearer tokens
+ *   and API keys flow through the SDK client at runtime only and are never
+ *   logged or embedded in generated artifacts.
+ *
+ * @module scripts/generate-sdk-ts
  */
 
 import fs from 'node:fs';
 import path from 'node:path';
 import process from 'node:process';
 
-// Parse command line arguments
+// ── CLI argument parsing ──────────────────────────────────────────────────────
+
 const args = process.argv.slice(2);
 const isCheckMode = args.includes('--check');
 
 let outDirArg = 'sdk/typescript';
 const outDirIdx = args.indexOf('--out-dir');
-if (outDirIdx !== -1 && args[outDirIdx + 1]) {
-  outDirArg = args[outDirIdx + 1];
-}
+if (outDirIdx !== -1 && args[outDirIdx + 1]) outDirArg = args[outDirIdx + 1];
 
 let specPathArg = 'openapi.yaml';
 const specIdx = args.indexOf('--spec');
-if (specIdx !== -1 && args[specIdx + 1]) {
-  specPathArg = args[specIdx + 1];
-}
+if (specIdx !== -1 && args[specIdx + 1]) specPathArg = args[specIdx + 1];
 
 const ROOT_DIR = process.cwd();
 const SPEC_PATH = path.resolve(ROOT_DIR, specPathArg);
 const OUT_DIR = path.resolve(ROOT_DIR, outDirArg);
 
+// ── Lightweight YAML parser (OpenAPI 3.x subset) ─────────────────────────────
+
 /**
- * Lightweight recursive YAML parser for OpenAPI 3.x spec files.
+ * Parse an OpenAPI 3.x YAML file into a plain JS object.
+ *
+ * Supports the subset used by Fluxora's openapi.yaml:
+ * - Block mappings and sequences.
+ * - Multi-line scalar values (literal `|` and folded `>`).
+ * - Quoted and unquoted string scalars.
+ * - Boolean, integer, float, and null literals.
+ * - Inline arrays: `[a, b, c]`.
+ * - `#` line comments.
+ *
+ * @security This parser only reads the local spec file; it never makes
+ *   network requests or executes arbitrary code from the spec.
+ *
+ * @param {string} yamlString - Raw YAML text.
+ * @returns {unknown} Parsed value.
  */
 function parseSimpleYaml(yamlString) {
   const lines = yamlString.split(/\r?\n/);
   let lineIdx = 0;
 
   function getIndent(line) {
-    const match = line.match(/^(\s*)/);
-    return match ? match[1].length : 0;
+    const m = line.match(/^(\s*)/);
+    return m ? m[1].length : 0;
   }
 
   function parseBlock(baseIndent) {
@@ -58,40 +80,26 @@ function parseSimpleYaml(yamlString) {
       const line = lines[lineIdx];
       const trimmed = line.trim();
 
-      if (!trimmed || trimmed.startsWith('#')) {
-        lineIdx++;
-        continue;
-      }
+      if (!trimmed || trimmed.startsWith('#')) { lineIdx++; continue; }
 
       const currentIndent = getIndent(line);
-      if (currentIndent < baseIndent) {
-        break;
-      }
+      if (currentIndent < baseIndent) break;
 
       if (trimmed.startsWith('- ')) {
-        if (result === null) {
-          result = [];
-          isArray = true;
-        } else if (!isArray) {
-          break;
-        }
+        if (result === null) { result = []; isArray = true; }
+        else if (!isArray) break;
 
         const itemContent = trimmed.slice(2).trim();
-        if (itemContent.includes(': ') || itemContent.endsWith(':')) {
+        if (itemContent.includes(': ') || (itemContent.endsWith(':') && !itemContent.startsWith("'"))) {
           lines[lineIdx] = ' '.repeat(currentIndent + 2) + itemContent;
-          const subObj = parseBlock(currentIndent + 2);
-          result.push(subObj);
+          result.push(parseBlock(currentIndent + 2));
         } else {
           result.push(parseScalarValue(itemContent));
           lineIdx++;
         }
-      } else if (trimmed.includes(':') || trimmed.endsWith(':')) {
-        if (result === null) {
-          result = {};
-          isMap = true;
-        } else if (!isMap) {
-          break;
-        }
+      } else if (trimmed.includes(':')) {
+        if (result === null) { result = {}; isMap = true; }
+        else if (!isMap) break;
 
         const colonIdx = trimmed.indexOf(':');
         const key = trimmed.slice(0, colonIdx).trim().replace(/^['"]|['"]$/g, '');
@@ -99,19 +107,13 @@ function parseSimpleYaml(yamlString) {
 
         lineIdx++;
 
-        if (valueStr === '|' || valueStr === '>-' || valueStr === '>') {
-          let scalarLines = [];
+        if (valueStr === '|' || valueStr === '>-' || valueStr === '>' || valueStr === '|-') {
+          const scalarLines = [];
           const blockIndent = currentIndent + 2;
           while (lineIdx < lines.length) {
             const nextLine = lines[lineIdx];
-            if (!nextLine.trim()) {
-              scalarLines.push('');
-              lineIdx++;
-              continue;
-            }
-            if (getIndent(nextLine) < blockIndent) {
-              break;
-            }
+            if (!nextLine.trim()) { scalarLines.push(''); lineIdx++; continue; }
+            if (getIndent(nextLine) < blockIndent) break;
             scalarLines.push(nextLine.slice(blockIndent));
             lineIdx++;
           }
@@ -129,7 +131,6 @@ function parseSimpleYaml(yamlString) {
         lineIdx++;
       }
     }
-
     return result ?? {};
   }
 
@@ -143,10 +144,7 @@ function parseSimpleYaml(yamlString) {
       return val.slice(1, -1);
     }
     if (val.startsWith('[') && val.endsWith(']')) {
-      return val
-        .slice(1, -1)
-        .split(',')
-        .map((s) => s.trim().replace(/^['"]|['"]$/g, ''));
+      return val.slice(1, -1).split(',').map(s => s.trim().replace(/^['"]|['"]$/g, ''));
     }
     return val;
   }
@@ -154,193 +152,496 @@ function parseSimpleYaml(yamlString) {
   return parseBlock(0);
 }
 
+// ── Spec loader ───────────────────────────────────────────────────────────────
+
 /**
- * Load OpenAPI spec file.
+ * Load and parse the OpenAPI spec from disk.
+ *
+ * @param {string} specPath - Absolute path to openapi.yaml.
+ * @returns {object} Parsed spec object.
+ * @throws {Error} When the file is missing.
  */
 function loadSpec(specPath) {
   if (!fs.existsSync(specPath)) {
-    throw new Error(`OpenAPI spec file not found at ${specPath}`);
+    throw new Error(`OpenAPI spec file not found: ${specPath}`);
   }
-  const raw = fs.readFileSync(specPath, 'utf8');
-  return parseSimpleYaml(raw);
+  return parseSimpleYaml(fs.readFileSync(specPath, 'utf8'));
 }
+
+// ── File generators ───────────────────────────────────────────────────────────
 
 /**
- * Generate TypeScript SDK file dictionary.
+ * Generate all SDK source files as a { relativePath → fileContent } map.
+ *
+ * Field names in the generated types intentionally mirror `toApiStream()` in
+ * `src/routes/streams.ts` (camelCase: `depositAmount`, `ratePerSecond`, etc.).
+ *
+ * @param {object} spec - Parsed OpenAPI spec.
+ * @returns {Record<string, string>} Map of relative paths to file content.
  */
 function generateTypeScriptSdk(spec) {
+  const version = spec?.info?.version ?? '0.1.0';
   const files = {};
-  const version = spec.info?.version || '0.1.0';
 
-  // 1. package.json
-  files['package.json'] = `{
-  "name": "@fluxora/sdk",
-  "version": "${version}",
-  "description": "Typed TypeScript client SDK for Fluxora Backend API generated from openapi.yaml",
-  "main": "./src/index.ts",
-  "module": "./src/index.ts",
-  "types": "./src/index.ts",
-  "exports": {
-    ".": {
-      "types": "./src/index.ts",
-      "import": "./src/index.ts",
-      "require": "./src/index.ts"
-    }
-  },
-  "license": "MIT",
-  "dependencies": {}
+  files['package.json'] = generatePackageJson(version);
+  files['tsconfig.json'] = generateTsConfig();
+  files['README.md'] = generateReadme(version);
+  files['src/index.ts'] = generateIndex();
+  files['src/types.ts'] = generateTypes();
+  files['src/errors.ts'] = generateErrors();
+  files['src/idempotency.ts'] = generateIdempotency();
+  files['src/pagination.ts'] = generatePagination();
+  files['src/client.ts'] = generateClient();
+
+  return files;
 }
-`;
 
-  // 2. tsconfig.json
-  files['tsconfig.json'] = `{
-  "compilerOptions": {
-    "target": "ES2022",
-    "module": "NodeNext",
-    "moduleResolution": "NodeNext",
-    "declaration": true,
-    "strict": true,
-    "esModuleInterop": true,
-    "skipLibCheck": true,
-    "forceConsistentCasingInFileNames": true
-  },
-  "include": ["src/**/*"]
+// ── package.json ──────────────────────────────────────────────────────────────
+
+function generatePackageJson(version) {
+  return JSON.stringify({
+    name: '@fluxora/sdk',
+    version,
+    description: 'Typed TypeScript client SDK for the Fluxora Backend API — generated from openapi.yaml.',
+    main: './src/index.ts',
+    module: './src/index.ts',
+    types: './src/index.ts',
+    exports: {
+      '.': {
+        types: './src/index.ts',
+        import: './src/index.ts',
+        require: './src/index.ts',
+      },
+    },
+    files: ['src', 'README.md'],
+    license: 'MIT',
+    keywords: ['fluxora', 'sdk', 'streaming', 'stellar'],
+    dependencies: {},
+  }, null, 2) + '\n';
 }
-`;
 
-  // 3. README.md
-  files['README.md'] = `# Fluxora TypeScript Client SDK
+// ── tsconfig.json ─────────────────────────────────────────────────────────────
 
-Typed TypeScript client SDK for the Fluxora HTTP API generated directly from \`openapi.yaml\`.
+function generateTsConfig() {
+  return JSON.stringify({
+    compilerOptions: {
+      target: 'ES2022',
+      module: 'NodeNext',
+      moduleResolution: 'NodeNext',
+      declaration: true,
+      strict: true,
+      esModuleInterop: true,
+      skipLibCheck: true,
+      forceConsistentCasingInFileNames: true,
+    },
+    include: ['src/**/*'],
+  }, null, 2) + '\n';
+}
+
+// ── README.md ─────────────────────────────────────────────────────────────────
+
+function generateReadme(version) {
+  return `# @fluxora/sdk — TypeScript Client SDK
+
+> **Version**: ${version} · **Generated from** \`openapi.yaml\` by \`scripts/generate-sdk-ts.mjs\`.
+> Do not edit by hand — run \`pnpm generate:sdk:ts\` to regenerate.
+
+Typed TypeScript client for the [Fluxora Backend API](../../docs/api.md).
+Zero external runtime dependencies; uses the standard Web \`fetch\` API.
+
+---
 
 ## Features
-- **Zero External Dependencies**: Uses standard Web Fetch API (\`fetch\`).
-- **Cursor Pagination**: Native support for cursor pagination via \`StreamPaginator\` (\`autoPaginate()\`).
-- **Idempotency Header & Payload Hashing**: Canonical JSON SHA-256 body hashing matching \`src/middleware/idempotency.ts\`.
-- **Complete Endpoint Coverage**: Includes streams, webhooks, auth, health probes, and admin endpoints.
-- **Full Type Safety**: Complete TypeScript interfaces for all request payloads and response envelopes.
+
+| Feature | Detail |
+|---------|--------|
+| **Zero dependencies** | Uses native \`fetch\` — works in Node.js ≥ 18, Deno, Bun, and browsers |
+| **Full type safety** | Every request/response is typed from \`openapi.yaml\` |
+| **Cursor pagination** | \`StreamPaginator\` wraps keyset cursors behind an ergonomic async generator |
+| **Idempotency** | UUID v4 key generation + canonical SHA-256 body hashing matching the server |
+| **Typed error hierarchy** | \`FluxoraApiError\`, \`IdempotencyConflictError\`, \`ValidationError\` |
+| **Client-side validation** | Input guards throw \`ValidationError\` before any network round-trip |
+| **Auth support** | Bearer JWT + static API key |
+
+---
+
+## Installation
+
+This is an internal workspace package declared in \`pnpm-workspace.yaml\`.
+Reference it from sibling packages with:
+
+\`\`\`json
+{ "dependencies": { "@fluxora/sdk": "workspace:*" } }
+\`\`\`
+
+---
 
 ## Quickstart
 
 \`\`\`typescript
-import { FluxoraClient, StreamPaginator, generateIdempotencyKey } from '@fluxora/sdk';
+import {
+  FluxoraClient,
+  generateIdempotencyKey,
+  FluxoraApiError,
+  IdempotencyConflictError,
+} from '@fluxora/sdk';
 
-// Initialize client
-const client = new FluxoraClient({ baseUrl: 'http://localhost:3000' });
+const client = new FluxoraClient({
+  baseUrl: 'http://localhost:3000',
+  bearerToken: process.env.FLUXORA_TOKEN,
+});
 
-// 1. Health probe
+// Health probe
 const health = await client.getHealth();
-console.log('Status:', health.status);
+console.log('Status:', health.status); // 'ok' | 'degraded' | 'shutting_down'
 
-// 2. Create stream with Idempotency Key
-const idempotencyKey = generateIdempotencyKey();
-const stream = await client.createStream(
-  {
-    sender: 'GBBD47UZQ5CYVVEUVRYNQZX3G5KRZTAYF5XSVS2UKMCCWW5LJJLXNVQX',
-    recipient: 'GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN',
-    amount: '100.5000000',
-    asset: 'XLM',
-  },
-  idempotencyKey,
-);
-console.log('Created Stream:', stream.id);
+// Create a stream (auto-generates Idempotency-Key)
+const stream = await client.createStream({
+  sender:        'GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN',
+  recipient:     'GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGZCP2J7F1NRQKQOHP3OGN',
+  depositAmount: '1000000.0000000',
+  ratePerSecond: '0.0000116',
+  startTime:     Math.floor(Date.now() / 1000),
+});
+console.log('Stream:', stream.id, stream.status);
 
-// 3. Paginate streams
+// Paginate all active streams
 const paginator = client.listStreams({ limit: 20, status: 'active' });
-for await (const streamItem of paginator.autoPaginate()) {
-  console.log('Stream:', streamItem.id, streamItem.status);
+for await (const s of paginator.autoPaginate()) {
+  console.log(s.id, s.depositAmount);
 }
 \`\`\`
 
-## Handling Idempotency Conflicts
+---
+
+## Error handling
 
 \`\`\`typescript
-import { IdempotencyConflictError } from '@fluxora/sdk';
+import { FluxoraApiError, IdempotencyConflictError, ValidationError } from '@fluxora/sdk';
 
 try {
-  await client.createStream(payload, 'reused-key');
+  await client.createStream(payload, 'my-idempotency-key');
 } catch (err) {
   if (err instanceof IdempotencyConflictError) {
-    console.error('Idempotency collision!', err.storedHash, err.incomingHash);
+    // Same key, different payload — generate a new key
+    console.error('Conflict:', err.storedHash, err.incomingHash);
+  } else if (err instanceof FluxoraApiError) {
+    console.error(\`HTTP \${err.statusCode} [\${err.code}]: \${err.message}\`);
+    // err.requestId — correlate with server logs
+  } else if (err instanceof ValidationError) {
+    console.error('Bad input:', err.message);
   }
 }
 \`\`\`
 
-## License
-MIT
+---
+
+## Idempotency
+
+POST /api/streams requires an \`Idempotency-Key\` header. The SDK handles this automatically:
+
+- If you omit \`idempotencyKey\`, the SDK auto-generates a UUID v4.
+- If you supply a key, reuse the **same key when retrying** to prevent duplicate creation.
+- Reusing a key with a **different body** throws \`IdempotencyConflictError\`.
+
+\`\`\`typescript
+const key = generateIdempotencyKey(); // UUID v4
+const stream = await client.createStream(payload, key);
+// On retry:
+const same = await client.createStream(payload, key); // replays cached response
+\`\`\`
+
+---
+
+## Security notes
+
+- Bearer tokens and API keys are stored in memory only and never logged.
+- The \`Authorization\` header is only added when a credential is present.
+- Client-side input validation rejects obviously invalid values before network dispatch.
+- TLS certificate validation is performed by the platform's \`fetch\` implementation.
+- Idempotency key values are never echoed in error bodies or logs (server-side guarantee).
+
+---
+
+## API Reference
+
+### \`new FluxoraClient(config?)\`
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| \`baseUrl\` | \`string\` | \`'http://localhost:3000'\` | API base URL |
+| \`bearerToken\` | \`string\` | — | JWT from \`createSession()\` |
+| \`apiKey\` | \`string\` | — | Static API key (\`X-API-Key\` header) |
+| \`headers\` | \`Record<string, string>\` | — | Extra headers merged into every request |
+
+### Stream methods
+
+| Method | Description |
+|--------|-------------|
+| \`createStream(input, key?)\` | POST /api/streams — auto-generates key if omitted |
+| \`getStream(id)\` | GET /api/streams/:id |
+| \`listStreams(params?)\` | Returns a \`StreamPaginator\` |
+| \`cancelStream(id)\` | DELETE /api/streams/:id |
+| \`updateStreamStatus(id, status)\` | PATCH /api/streams/:id/status |
+
+### Other methods
+
+| Method | Description |
+|--------|-------------|
+| \`getRoot()\` | GET / |
+| \`getHealth()\` | GET /health |
+| \`getHealthReady()\` | GET /health/ready |
+| \`getHealthLive()\` | GET /health/live |
+| \`createSession(address, role?)\` | POST /api/auth/session |
+| \`getPrivacyPolicy()\` | GET /api/privacy/policy |
+| \`getPrivacyRetention()\` | GET /api/privacy/retention |
+| \`putPrivacyConsent(consent)\` | PUT /api/privacy/consent |
+| \`getPrivacyConsent(address)\` | GET /api/privacy/consent/:address |
+| \`queueWebhook(payload)\` | POST /internal/webhooks/queue |
+| \`getWebhookDelivery(id)\` | GET /internal/webhooks/:id |
+
+---
+
+## Pagination
+
+\`listStreams()\` returns a \`StreamPaginator\`. Use \`autoPaginate()\` or \`nextPage()\`:
+
+\`\`\`typescript
+// Async generator — iterate all streams
+for await (const stream of client.listStreams().autoPaginate()) {
+  process(stream);
+}
+
+// Manual paging
+const pager = client.listStreams({ limit: 50, status: 'active' });
+let page = await pager.nextPage();
+while (page) {
+  doSomething(page);
+  page = await pager.nextPage();
+}
+\`\`\`
+
+Cursors are **opaque base64url tokens** — never construct or decode them.
+See [\`docs/openapi/README.md\`](../../docs/openapi/README.md) for full cursor semantics.
+
+---
+
+## Regenerating the SDK
+
+\`\`\`bash
+pnpm generate:sdk:ts        # regenerate sdk/typescript/
+pnpm check:sdk:ts           # CI drift check — exits 1 if files differ
+\`\`\`
+
+The generator reads \`openapi.yaml\` and overwrites all files under \`sdk/typescript/\`.
 `;
+}
 
-  // 4. src/index.ts
-  files['src/index.ts'] = `/**
- * Fluxora TypeScript Client SDK
- * Entrypoint re-exporting client, types, errors, pagination, and idempotency tools.
+// ── src/index.ts ──────────────────────────────────────────────────────────────
+
+function generateIndex() {
+  return `/**
+ * @fluxora/sdk — TypeScript Client SDK
+ *
+ * Generated from \`openapi.yaml\` by \`scripts/generate-sdk-ts.mjs\`.
+ * Do not edit by hand — run \`pnpm generate:sdk:ts\` instead.
+ *
+ * @module @fluxora/sdk
  */
-
 export * from './types.js';
 export * from './errors.js';
 export * from './idempotency.js';
 export * from './pagination.js';
 export * from './client.js';
 `;
+}
 
-  // 5. src/types.ts
-  files['src/types.ts'] = `/**
- * Typed response envelopes and domain model interfaces matching openapi.yaml.
+// ── src/types.ts ──────────────────────────────────────────────────────────────
+
+function generateTypes() {
+  return `/**
+ * Typed request/response interfaces for the Fluxora Backend API.
+ *
+ * Generated from \`openapi.yaml\` by \`scripts/generate-sdk-ts.mjs\`.
+ * Do not edit by hand — run \`pnpm generate:sdk:ts\` instead.
+ *
+ * ## Decimal-string invariant
+ * All monetary fields (\`depositAmount\`, \`streamedAmount\`, \`remainingAmount\`,
+ * \`ratePerSecond\`) are **decimal strings** — never JavaScript numbers.
+ * This preserves precision across the Stellar/API boundary.
+ *
+ * ## Field naming
+ * All field names are camelCase, exactly as returned by \`toApiStream()\` in
+ * \`src/routes/streams.ts\`.
+ *
+ * @module @fluxora/sdk/types
  */
 
+// ── Shared ────────────────────────────────────────────────────────────────────
+
+/**
+ * Data classification levels for PII policy.
+ * Mirrors the server-side \`DataClassification\` enum.
+ */
 export type DataClassification = 'PUBLIC' | 'INTERNAL' | 'SENSITIVE' | 'RESTRICTED';
 
+/**
+ * Common response envelope metadata present on all API responses.
+ */
 export interface ResponseMeta {
-  requestId?: string;
+  /** ISO-8601 UTC timestamp of when the response was generated. */
   timestamp?: string;
+  /** Correlation ID — matches \`X-Request-ID\` header. */
+  requestId?: string;
+  /** Opaque cursor for the next page (list endpoints only). */
   next_cursor?: string;
+  /** Total count — present only when \`include_total=true\` was requested. */
   total?: number;
+  /** \`true\` when the response was served from the idempotency cache. */
   idempotency_replayed?: boolean;
+  /** Alias used on some success envelopes. */
+  idempotencyReplayed?: boolean;
 }
 
+// ── Stream ────────────────────────────────────────────────────────────────────
+
+/**
+ * Stream lifecycle status.
+ *
+ * Valid transitions (enforced by the server state machine):
+ *   active    → paused | completed | cancelled
+ *   paused    → active | cancelled
+ *   completed → (terminal)
+ *   cancelled → (terminal)
+ */
+export type StreamStatus = 'scheduled' | 'active' | 'paused' | 'completed' | 'cancelled';
+
+/**
+ * A Fluxora treasury stream record as returned by GET /api/streams and
+ * POST /api/streams.
+ *
+ * Field names match \`toApiStream()\` in \`src/routes/streams.ts\` exactly.
+ * Amount fields are always decimal strings.
+ */
 export interface Stream {
+  /** Unique stream ID (format: \`stream-{64-char-hex}-0\`). */
   id: string;
+  /** Sender Stellar public key (\`G\` + 55 base32 chars). Pattern: \`^G[A-Z2-7]{55}$\` */
   sender: string;
+  /** Recipient Stellar public key. Pattern: \`^G[A-Z2-7]{55}$\` */
   recipient: string;
-  amount: string;
-  asset: string;
-  status: 'scheduled' | 'active' | 'paused' | 'completed' | 'cancelled';
-  rate_per_second?: string;
-  start_time?: number;
-  stop_time?: number;
-  created_at: string;
-  updated_at: string;
+  /** Total deposit as a decimal string (e.g. \`"1000000.0000000"\`). */
+  depositAmount: string;
+  /** Amount streamed so far as a decimal string. */
+  streamedAmount: string;
+  /** Remaining un-streamed balance as a decimal string. */
+  remainingAmount: string;
+  /** Streaming rate per second as a decimal string. */
+  ratePerSecond: string;
+  /** Stream start time (Unix epoch seconds). */
+  startTime: number;
+  /** Stream end time (0 = indefinite). */
+  endTime: number;
+  /** Current lifecycle status. */
+  status: StreamStatus;
+  /** Soroban contract address managing this stream (optional). */
+  contractId?: string;
+  /** Transaction hash of the creation transaction (optional). */
+  transactionHash?: string;
+  /** Event position within the originating transaction (optional). */
+  eventIndex?: number;
+  /** ISO-8601 creation timestamp. */
+  createdAt?: string;
+  /** ISO-8601 last-updated timestamp. */
+  updatedAt?: string;
 }
 
+/**
+ * Request body for POST /api/streams.
+ * Amount fields must be decimal strings.
+ */
 export interface CreateStreamInput {
+  /** Sender Stellar public key. Pattern: \`^G[A-Z2-7]{55}$\` */
   sender: string;
+  /** Recipient Stellar public key. Pattern: \`^G[A-Z2-7]{55}$\` */
   recipient: string;
-  amount: string;
-  asset: string;
-  start_time?: number;
-  stop_time?: number;
+  /**
+   * Total deposit as a decimal string.
+   * Must be > 0 and ≥ \`ratePerSecond\`.
+   */
+  depositAmount: string;
+  /**
+   * Streaming rate per second as a positive decimal string.
+   */
+  ratePerSecond: string;
+  /** Optional Unix epoch start time. Defaults to now. */
+  startTime?: number;
+  /** Optional Unix epoch end time (0 = indefinite). */
+  endTime?: number;
 }
 
+// ── API Response Envelopes ────────────────────────────────────────────────────
+
+/**
+ * Paginated list response from GET /api/streams.
+ *
+ * The \`data\` property carries the paginated list shape.
+ * Pagination state (\`has_more\`, \`next_cursor\`) lives inside \`data\`.
+ */
 export interface StreamListResponse {
   success: boolean;
-  data: Stream[];
+  data: {
+    /** Streams on this page, ordered by \`id\` ASC. */
+    streams: Stream[];
+    /** \`true\` when additional pages exist. */
+    has_more: boolean;
+    /** Opaque cursor for the next request; \`null\` on the last page. */
+    next_cursor: string | null;
+    /** Total count — only present when \`include_total=true\` was requested. */
+    total?: number;
+  };
   meta: ResponseMeta;
 }
 
+/**
+ * Single-stream response from GET /api/streams/:id.
+ * The stream is nested as \`data.stream\`.
+ */
 export interface StreamSingleResponse {
+  success: boolean;
+  data: { stream: Stream };
+  meta?: ResponseMeta;
+}
+
+/**
+ * Stream creation response from POST /api/streams.
+ * The created stream is returned directly in \`data\`.
+ */
+export interface StreamCreateResponse {
   success: boolean;
   data: Stream;
   meta?: ResponseMeta;
 }
 
+// ── Health ────────────────────────────────────────────────────────────────────
+
+/**
+ * Response shape for GET /health, /health/ready, and /health/live.
+ */
 export interface HealthResponse {
-  status: 'healthy' | 'degraded' | 'unhealthy';
-  timestamp: string;
+  status: 'ok' | 'degraded' | 'shutting_down' | 'healthy' | 'unhealthy';
+  service?: string;
+  network?: string;
+  timestamp?: string;
   version?: string;
   uptimeSeconds?: number;
   checks?: Record<string, unknown>;
+  indexer?: Record<string, unknown>;
 }
 
+// ── Root ──────────────────────────────────────────────────────────────────────
+
+/** Response from GET /. */
 export interface RootResponse {
   name: string;
   version: string;
@@ -348,31 +649,42 @@ export interface RootResponse {
   docs?: string;
 }
 
+// ── Auth ──────────────────────────────────────────────────────────────────────
+
+/** Response from POST /api/auth/session. */
 export interface AuthSessionResponse {
   success: boolean;
   data: {
     token: string;
-    address: string;
-    role: string;
-    expiresAt: string;
+    user?: { address: string; role: string };
+    address?: string;
+    role?: string;
+    expiresAt?: string;
   };
+  meta?: ResponseMeta;
 }
 
+// ── Privacy ───────────────────────────────────────────────────────────────────
+
+/** A user's privacy consent record. */
 export interface PrivacyConsent {
   analytics_optout: boolean;
   marketing_optout: boolean;
   biometric_processing_consent: boolean;
-  created_at: string;
-  updated_at: string;
+  created_at?: string;
+  updated_at?: string;
 }
 
+/** Response from PUT/GET /api/privacy/consent. */
 export interface PrivacyConsentResponse {
   success: boolean;
-  data: {
-    consent: PrivacyConsent;
-  };
+  data: { consent: PrivacyConsent };
+  meta?: ResponseMeta;
 }
 
+// ── Webhooks ──────────────────────────────────────────────────────────────────
+
+/** A webhook delivery record. */
 export interface WebhookDelivery {
   id: string;
   delivery_id: string;
@@ -384,21 +696,59 @@ export interface WebhookDelivery {
   attempts?: Array<Record<string, unknown>>;
 }
 
+// ── Pagination parameters ─────────────────────────────────────────────────────
+
+/**
+ * Query parameters for GET /api/streams.
+ * \`limit\` must be 1–100. \`cursor\` must be an opaque token from \`next_cursor\`.
+ */
 export interface ListStreamsParams {
+  /** Page size (1–100). Defaults to 20 on the server. */
   limit?: number;
+  /** Opaque pagination cursor from a previous \`next_cursor\`. Omit for the first page. */
   cursor?: string;
+  /** Filter by stream status. */
   status?: string;
+  /** Filter by sender Stellar address. */
   sender?: string;
+  /** Filter by recipient Stellar address. */
   recipient?: string;
+  /** When \`true\`, include \`total\` count in the response. */
   include_total?: boolean;
 }
 `;
+}
 
-  // 6. src/errors.ts
-  files['src/errors.ts'] = `/**
- * Typed SDK exceptions.
+// ── src/errors.ts ─────────────────────────────────────────────────────────────
+
+function generateErrors() {
+  return `/**
+ * Typed SDK exception hierarchy.
+ *
+ * Generated from \`openapi.yaml\` by \`scripts/generate-sdk-ts.mjs\`.
+ * Do not edit by hand — run \`pnpm generate:sdk:ts\` instead.
+ *
+ * ## Hierarchy
+ * \`\`\`
+ * Error
+ * └─ FluxoraClientError            (base for all SDK errors)
+ *    ├─ FluxoraApiError             (non-2xx HTTP response)
+ *    │  └─ IdempotencyConflictError (409 IDEMPOTENCY_CONFLICT)
+ *    └─ ValidationError             (client-side input validation failure)
+ * \`\`\`
+ *
+ * All classes call \`Object.setPrototypeOf(this, new.target.prototype)\` to
+ * ensure correct \`instanceof\` behaviour after TypeScript transpilation.
+ *
+ * @module @fluxora/sdk/errors
  */
 
+// ── Base ──────────────────────────────────────────────────────────────────────
+
+/**
+ * Base class for all errors thrown by the Fluxora TypeScript SDK.
+ * Catch this type to handle both API errors and client-side validation failures.
+ */
 export class FluxoraClientError extends Error {
   constructor(message: string) {
     super(message);
@@ -407,10 +757,34 @@ export class FluxoraClientError extends Error {
   }
 }
 
+// ── API Error ─────────────────────────────────────────────────────────────────
+
+/**
+ * Thrown when the Fluxora API returns a non-2xx HTTP response.
+ *
+ * @example
+ * \`\`\`typescript
+ * try {
+ *   await client.getStream('missing-id');
+ * } catch (err) {
+ *   if (err instanceof FluxoraApiError) {
+ *     console.error(\`HTTP \${err.statusCode} [\${err.code}]: \${err.message}\`);
+ *     if (err.requestId) console.error('Request ID:', err.requestId);
+ *   }
+ * }
+ * \`\`\`
+ */
 export class FluxoraApiError extends FluxoraClientError {
+  /** HTTP status code (e.g. \`400\`, \`404\`, \`503\`). */
   public readonly statusCode: number;
+  /** Machine-readable error code (e.g. \`'VALIDATION_ERROR'\`, \`'NOT_FOUND'\`). */
   public readonly code: string;
+  /** Additional error context from the server response. */
   public readonly details?: unknown;
+  /**
+   * Correlation ID (\`X-Request-ID\` header) for tracing.
+   * Include in support tickets to correlate with server logs.
+   */
   public readonly requestId?: string;
 
   constructor(
@@ -430,8 +804,33 @@ export class FluxoraApiError extends FluxoraClientError {
   }
 }
 
+// ── Idempotency Conflict ──────────────────────────────────────────────────────
+
+/**
+ * Thrown when the server returns HTTP 409 with code \`IDEMPOTENCY_CONFLICT\`.
+ * The same \`Idempotency-Key\` was previously used with a **different** body.
+ *
+ * ## Resolution
+ * - Generate a fresh idempotency key for the new request, **or**
+ * - Retry with the original request body and the same key.
+ *
+ * @example
+ * \`\`\`typescript
+ * try {
+ *   await client.createStream(payload, 'my-key');
+ * } catch (err) {
+ *   if (err instanceof IdempotencyConflictError) {
+ *     console.error('Payload mismatch!');
+ *     console.error('Stored hash:   ', err.storedHash);
+ *     console.error('Incoming hash: ', err.incomingHash);
+ *   }
+ * }
+ * \`\`\`
+ */
 export class IdempotencyConflictError extends FluxoraApiError {
+  /** SHA-256 fingerprint of the **original** request body stored for this key. */
   public readonly storedHash?: string;
+  /** SHA-256 fingerprint of the **current** (conflicting) request body. */
   public readonly incomingHash?: string;
 
   constructor(
@@ -451,6 +850,26 @@ export class IdempotencyConflictError extends FluxoraApiError {
   }
 }
 
+// ── Validation Error ──────────────────────────────────────────────────────────
+
+/**
+ * Thrown when **client-side** input validation rejects a parameter before any
+ * HTTP request is dispatched.
+ *
+ * This is distinct from \`FluxoraApiError\` with \`code = 'VALIDATION_ERROR'\`,
+ * which indicates a server-side rejection.
+ *
+ * @example
+ * \`\`\`typescript
+ * try {
+ *   await client.getStream('');
+ * } catch (err) {
+ *   if (err instanceof ValidationError) {
+ *     console.error('Bad input:', err.message);
+ *   }
+ * }
+ * \`\`\`
+ */
 export class ValidationError extends FluxoraClientError {
   constructor(message: string) {
     super(message);
@@ -459,21 +878,63 @@ export class ValidationError extends FluxoraClientError {
   }
 }
 `;
+}
 
-  // 7. src/idempotency.ts
-  files['src/idempotency.ts'] = `/**
- * Idempotency Header and Payload Hashing Utilities.
- * Matching src/middleware/idempotency.ts and src/validation/idempotency.ts semantics.
+// ── src/idempotency.ts ────────────────────────────────────────────────────────
+
+function generateIdempotency() {
+  return `/**
+ * Idempotency key generation and payload hashing utilities.
+ *
+ * Generated from \`openapi.yaml\` by \`scripts/generate-sdk-ts.mjs\`.
+ * Do not edit by hand — run \`pnpm generate:sdk:ts\` instead.
+ *
+ * ## Purpose
+ * POST /api/streams requires an \`Idempotency-Key\` header to prevent duplicate
+ * stream creation on retries. This module provides:
+ *
+ * - \`generateIdempotencyKey()\` — creates a fresh UUID v4 key per operation.
+ * - \`canonicalizeBody()\` — serialises an object to a deterministic JSON string
+ *   (sorted keys, recursive) suitable for hashing.
+ * - \`hashBody()\` — computes a SHA-256 hex digest matching the server-side
+ *   \`fingerprintInput()\` in \`src/routes/streams.ts\`.
+ *
+ * ## Security
+ * - Keys are generated with \`crypto.randomUUID()\` (WebCrypto) where available,
+ *   with a \`Math.random\`-based UUID v4 fallback for older environments.
+ * - \`hashBody()\` uses \`crypto.subtle.digest\` (WebCrypto) with a Node.js
+ *   \`node:crypto\` \`createHash\` fallback.
+ * - Key values are never logged or echoed in error responses.
+ *
+ * @module @fluxora/sdk/idempotency
  */
 
+// ── Key Generation ────────────────────────────────────────────────────────────
+
 /**
- * Generate a UUID v4 idempotency key string.
+ * Generate a unique UUID v4 idempotency key.
+ *
+ * Uses \`crypto.randomUUID()\` (Node.js ≥ 15, all modern browsers).
+ * Falls back to a \`Math.random\`-based v4 UUID for older environments.
+ *
+ * Generate a **new key per logical operation**. Reuse the same key when
+ * retrying a failed request to make it idempotent.
+ *
+ * @returns A UUID v4 string (e.g. \`'b4a6f1a2-33c9-4d8e-b789-0e0a1c2d3e4f'\`).
+ *
+ * @example
+ * \`\`\`typescript
+ * const key = generateIdempotencyKey();
+ * const stream = await client.createStream(input, key);
+ * // Retry with same key — gets cached response
+ * const same = await client.createStream(input, key);
+ * \`\`\`
  */
 export function generateIdempotencyKey(): string {
   if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
     return crypto.randomUUID();
   }
-  // Simple UUID v4 fallback
+  // Math.random fallback for environments without WebCrypto
   return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, (c) => {
     const r = (Math.random() * 16) | 0;
     const v = c === 'x' ? r : (r & 0x3) | 0x8;
@@ -481,27 +942,66 @@ export function generateIdempotencyKey(): string {
   });
 }
 
+// ── Canonical JSON ────────────────────────────────────────────────────────────
+
 /**
- * Recursively canonicalize a JSON object by sorting object keys.
+ * Recursively serialise a value to a **canonical** JSON string.
+ *
+ * Canonical form guarantees that two logically equal objects always produce
+ * the same string regardless of key insertion order, enabling deterministic
+ * payload fingerprinting that matches the server-side \`fingerprintInput()\`.
+ *
+ * Rules:
+ * - Object keys are sorted lexicographically (ascending, recursive).
+ * - Array element order is preserved.
+ * - Primitives are serialised as \`JSON.stringify\` would.
+ * - \`null\` and \`undefined\` are both serialised as \`'null'\`.
+ *
+ * @param body - Any JSON-serialisable value.
+ * @returns A deterministic JSON string.
+ *
+ * @example
+ * \`\`\`typescript
+ * canonicalizeBody({ z: 1, a: 2 }); // '{"a":2,"z":1}'
+ * canonicalizeBody({ a: 2, z: 1 }); // '{"a":2,"z":1}'  — identical
+ * \`\`\`
  */
 export function canonicalizeBody(body: unknown): string {
   if (body === null || body === undefined) return 'null';
   if (typeof body !== 'object') return JSON.stringify(body);
 
   if (Array.isArray(body)) {
-    const items = body.map((item) => canonicalizeBody(item));
+    const items = (body as unknown[]).map((item) => canonicalizeBody(item));
     return \`[\${items.join(',')}]\`;
   }
 
-  const keys = Object.keys(body as Record<string, unknown>).sort();
-  const pairs = keys.map(
-    (k) => \`"\${k}":\${canonicalizeBody((body as Record<string, unknown>)[k])}\`,
-  );
+  const obj = body as Record<string, unknown>;
+  const keys = Object.keys(obj).sort();
+  const pairs = keys.map((k) => \`"\${k}":\${canonicalizeBody(obj[k])}\`);
   return \`{\${pairs.join(',')}}\`;
 }
 
+// ── SHA-256 Hashing ───────────────────────────────────────────────────────────
+
 /**
- * Calculate SHA-256 hex digest of a canonicalized JSON payload.
+ * Compute a SHA-256 hex digest of a JSON payload.
+ *
+ * The payload is canonicalised via \`canonicalizeBody()\` and UTF-8 encoded
+ * before hashing. The digest matches the server-side \`fingerprintInput()\`
+ * in \`src/routes/streams.ts\`.
+ *
+ * Prefers \`crypto.subtle.digest\` (WebCrypto) with a Node.js
+ * \`node:crypto\` \`createHash\` fallback.
+ *
+ * @param body - Any JSON-serialisable value.
+ * @returns A lowercase 64-character SHA-256 hex string.
+ * @throws {Error} When no crypto API is available.
+ *
+ * @example
+ * \`\`\`typescript
+ * const hash = await hashBody({ sender: 'G...', depositAmount: '100' });
+ * console.log(hash.length); // 64
+ * \`\`\`
  */
 export async function hashBody(body: unknown): Promise<string> {
   const canonical = canonicalizeBody(body);
@@ -515,33 +1015,80 @@ export async function hashBody(body: unknown): Promise<string> {
       .join('');
   }
 
-  // Node.js crypto fallback
+  // Node.js crypto fallback for environments without globalThis.crypto
   try {
     const { createHash } = await import('node:crypto');
     return createHash('sha256').update(canonical).digest('hex');
   } catch {
-    throw new Error('Crypto API unavailable for hash calculation');
+    throw new Error('Crypto API unavailable: cannot compute SHA-256 hash');
   }
 }
 `;
+}
 
-  // 8. src/pagination.ts
-  files['src/pagination.ts'] = `/**
- * Cursor Pagination Helpers matching src/validation/paginationSchema.ts.
+// ── src/pagination.ts ─────────────────────────────────────────────────────────
+
+function generatePagination() {
+  return `/**
+ * Cursor-based paginator for GET /api/streams.
+ *
+ * Generated from \`openapi.yaml\` by \`scripts/generate-sdk-ts.mjs\`.
+ * Do not edit by hand — run \`pnpm generate:sdk:ts\` instead.
+ *
+ * ## Design
+ * \`StreamPaginator\` wraps the server's keyset-cursor pagination behind an
+ * ergonomic API that never requires the caller to manage raw cursor tokens.
+ *
+ * - Call \`nextPage()\` to fetch one page at a time.
+ * - Use \`autoPaginate()\` (async generator) to iterate all streams across all
+ *   pages with a \`for await...of\` loop.
+ * - Pagination terminates when the server returns \`has_more: false\`.
+ *
+ * ## Cursor semantics
+ * Cursors are **opaque base64url tokens** issued by the server. Clients must
+ * treat them as black boxes — do not construct or decode manually.
+ * See \`docs/openapi/README.md\` for the full cursor protocol.
+ *
+ * @module @fluxora/sdk/pagination
  */
 
 import type { Stream, ListStreamsParams, StreamListResponse } from './types.js';
 
+/**
+ * Cursor-based paginator for the GET /api/streams endpoint.
+ *
+ * @example
+ * \`\`\`typescript
+ * const paginator = client.listStreams({ limit: 20, status: 'active' });
+ *
+ * // Option A — iterate individual stream items
+ * for await (const stream of paginator.autoPaginate()) {
+ *   console.log(stream.id, stream.depositAmount);
+ * }
+ *
+ * // Option B — fetch one page at a time
+ * const page1 = await paginator.nextPage();
+ * const page2 = await paginator.nextPage();
+ * \`\`\`
+ */
 export class StreamPaginator {
-  private fetchPage: (params: ListStreamsParams) => Promise<StreamListResponse>;
-  private limit: number;
-  private status?: string;
-  private sender?: string;
-  private recipient?: string;
-  private includeTotal: boolean;
+  private readonly fetchPage: (params: ListStreamsParams) => Promise<StreamListResponse>;
+  private readonly limit: number;
+  private readonly status?: string;
+  private readonly sender?: string;
+  private readonly recipient?: string;
+  private readonly includeTotal: boolean;
+
+  /** Opaque cursor from the last response; \`null\` = start of sequence. */
   private nextCursor: string | null = null;
+  /** \`false\` once the server signals no more pages. */
   private hasMore = true;
 
+  /**
+   * @param fetchPage - Calls the API and returns a \`StreamListResponse\`.
+   * @param params    - Initial filter and pagination parameters.
+   * @throws {Error} When \`limit\` is outside the valid range 1–100.
+   */
   constructor(
     fetchPage: (params: ListStreamsParams) => Promise<StreamListResponse>,
     params: ListStreamsParams = {},
@@ -559,7 +1106,10 @@ export class StreamPaginator {
   }
 
   /**
-   * Fetch next page of results. Returns null when no more pages exist.
+   * Fetch the next page of stream results.
+   *
+   * @returns Array of \`Stream\` objects for this page, or \`null\` when all
+   *          pages have been consumed (\`has_more\` was \`false\`).
    */
   async nextPage(): Promise<Stream[] | null> {
     if (!this.hasMore) return null;
@@ -573,25 +1123,35 @@ export class StreamPaginator {
       include_total: this.includeTotal,
     });
 
-    const items = response.data || [];
-    const nextCursor = response.meta?.next_cursor;
+    const pageData = response.data;
+    const streams: Stream[] = pageData?.streams ?? [];
+    const hasMore: boolean = pageData?.has_more ?? false;
+    const nextCursor: string | null =
+      pageData?.next_cursor ??
+      (response.meta?.next_cursor as string | null | undefined) ??
+      null;
 
-    if (nextCursor) {
+    if (nextCursor && hasMore) {
       this.nextCursor = nextCursor;
     } else {
       this.hasMore = false;
     }
 
-    return items;
+    return streams;
   }
 
   /**
-   * Async generator yielding single items across all pages.
+   * Async generator that yields individual \`Stream\` items across all pages.
+   *
+   * Pagination terminates automatically when the server has no more results.
+   * A \`break\` inside \`for await\` stops iteration without fetching further pages.
+   *
+   * @yields \`Stream\` objects one at a time.
    */
   async *autoPaginate(): AsyncGenerator<Stream, void, unknown> {
     while (this.hasMore) {
       const page = await this.nextPage();
-      if (!page) break;
+      if (!page || page.length === 0) break;
       for (const item of page) {
         yield item;
       }
@@ -599,17 +1159,35 @@ export class StreamPaginator {
   }
 }
 `;
+}
 
-  // 9. src/client.ts
-  files['src/client.ts'] = `/**
- * Synchronous / Async Fetch Client for Fluxora Backend API.
+// ── src/client.ts ─────────────────────────────────────────────────────────────
+
+function generateClient() {
+  return `/**
+ * FluxoraClient — typed HTTP client for the Fluxora Backend API.
+ *
+ * Generated from \`openapi.yaml\` by \`scripts/generate-sdk-ts.mjs\`.
+ * Do not edit by hand — run \`pnpm generate:sdk:ts\` instead.
+ *
+ * ## Design
+ * - Zero external runtime dependencies — uses the standard Web \`fetch\` API.
+ * - All monetary amounts flow as **decimal strings** (never JS numbers).
+ * - Idempotency keys are auto-generated for POST /api/streams when omitted.
+ * - Cursor-based pagination is encapsulated in \`StreamPaginator\`.
+ *
+ * ## Security notes
+ * - Bearer tokens and API keys are stored in memory only; never logged.
+ * - The \`Authorization\` header is only set when a credential is present.
+ * - Client-side validation (empty/missing required params) fires before any
+ *   network round-trip, reducing the attack surface for injection.
+ * - TLS validation is delegated to the platform's \`fetch\` implementation.
+ * - Idempotency key values are never echoed in error bodies (server guarantee).
+ *
+ * @module @fluxora/sdk/client
  */
 
-import {
-  FluxoraApiError,
-  IdempotencyConflictError,
-  ValidationError,
-} from './errors.js';
+import { FluxoraApiError, IdempotencyConflictError, ValidationError } from './errors.js';
 import { generateIdempotencyKey } from './idempotency.js';
 import { StreamPaginator } from './pagination.js';
 import type {
@@ -617,6 +1195,7 @@ import type {
   CreateStreamInput,
   StreamListResponse,
   StreamSingleResponse,
+  StreamCreateResponse,
   HealthResponse,
   RootResponse,
   AuthSessionResponse,
@@ -626,13 +1205,50 @@ import type {
   ListStreamsParams,
 } from './types.js';
 
+// ── Configuration ─────────────────────────────────────────────────────────────
+
+/**
+ * Client initialisation options.
+ *
+ * @example
+ * \`\`\`typescript
+ * const client = new FluxoraClient({
+ *   baseUrl: 'https://api.fluxora.example.com',
+ *   bearerToken: process.env.FLUXORA_TOKEN,
+ * });
+ * \`\`\`
+ */
 export interface FluxoraClientConfig {
+  /**
+   * Base URL of the Fluxora API. Trailing slashes are stripped automatically.
+   * Defaults to \`'http://localhost:3000'\`.
+   */
   baseUrl?: string;
+  /**
+   * Static API key sent as \`X-API-Key\`.
+   * Can be updated at runtime via \`setApiKey()\`.
+   */
   apiKey?: string;
+  /**
+   * JWT Bearer token.
+   * Can be updated at runtime via \`setBearerToken()\`.
+   */
   bearerToken?: string;
+  /**
+   * Additional headers merged into every request.
+   * Per-request headers take precedence over these.
+   */
   headers?: Record<string, string>;
 }
 
+// ── Client ────────────────────────────────────────────────────────────────────
+
+/**
+ * Typed HTTP client for the Fluxora Backend API.
+ *
+ * All methods return strongly-typed response objects matching the shapes
+ * defined in \`openapi.yaml\` and mirroring \`src/routes/streams.ts\`.
+ */
 export class FluxoraClient {
   private baseUrl: string;
   private apiKey?: string;
@@ -640,7 +1256,7 @@ export class FluxoraClient {
   private headers: Record<string, string>;
 
   constructor(config: FluxoraClientConfig = {}) {
-    this.baseUrl = (config.baseUrl || 'http://localhost:3000').replace(/\\/+$/, '');
+    this.baseUrl = (config.baseUrl ?? 'http://localhost:3000').replace(/\\/+$/, '');
     this.apiKey = config.apiKey;
     this.bearerToken = config.bearerToken;
     this.headers = {
@@ -650,14 +1266,36 @@ export class FluxoraClient {
     };
   }
 
+  /**
+   * Update the JWT Bearer token for authenticated requests.
+   * The new value is used immediately on the next call.
+   * @security Token is stored in memory only; never logged.
+   */
   public setBearerToken(token: string): void {
     this.bearerToken = token;
   }
 
+  /**
+   * Update the static API key (\`X-API-Key\` header).
+   * @security Key is stored in memory only; never logged.
+   */
   public setApiKey(apiKey: string): void {
     this.apiKey = apiKey;
   }
 
+  // ── Core HTTP dispatcher ───────────────────────────────────────────────────
+
+  /**
+   * Execute an HTTP request and return the parsed JSON response body.
+   *
+   * On non-2xx responses the method throws:
+   * - \`IdempotencyConflictError\` for 409 \`IDEMPOTENCY_CONFLICT\`
+   * - \`FluxoraApiError\` for all other non-2xx responses
+   *
+   * @param method  - HTTP verb (GET, POST, DELETE, PATCH, PUT).
+   * @param path    - Request path (e.g. \`'/api/streams'\`).
+   * @param options - Optional query params, body, and extra headers.
+   */
   private async request<T>(
     method: string,
     path: string,
@@ -670,25 +1308,17 @@ export class FluxoraClient {
     let url = \`\${this.baseUrl}\${path}\`;
 
     if (options.params) {
-      const queryParams = new URLSearchParams();
+      const qs = new URLSearchParams();
       for (const [k, v] of Object.entries(options.params)) {
-        if (v !== undefined && v !== null) {
-          queryParams.append(k, String(v));
-        }
+        if (v !== undefined && v !== null) qs.append(k, String(v));
       }
-      const queryString = queryParams.toString();
-      if (queryString) {
-        url += \`?\${queryString}\`;
-      }
+      const s = qs.toString();
+      if (s) url += \`?\${s}\`;
     }
 
     const headers: Record<string, string> = { ...this.headers, ...options.headers };
-    if (this.bearerToken) {
-      headers['Authorization'] = \`Bearer \${this.bearerToken}\`;
-    }
-    if (this.apiKey) {
-      headers['X-API-Key'] = this.apiKey;
-    }
+    if (this.bearerToken) headers['Authorization'] = \`Bearer \${this.bearerToken}\`;
+    if (this.apiKey) headers['X-API-Key'] = this.apiKey;
 
     let bodyPayload: string | undefined;
     if (options.body !== undefined) {
@@ -702,29 +1332,30 @@ export class FluxoraClient {
       body: bodyPayload,
     });
 
-    let data: any = {};
+    let data: unknown = {};
     const text = await response.text();
     if (text) {
-      try {
-        data = JSON.parse(text);
-      } catch {
-        data = { message: text };
-      }
+      try { data = JSON.parse(text); } catch { data = { message: text }; }
     }
 
     if (!response.ok) {
-      const requestId = response.headers.get('x-request-id') || data?.meta?.requestId || data?.error?.requestId;
-      const errorCode = data?.error?.code || data?.code || 'HTTP_ERROR';
-      const errorMessage = data?.error?.message || data?.message || response.statusText;
+      const d = data as Record<string, unknown>;
+      const errObj = d['error'] as Record<string, unknown> | undefined;
+      const requestId =
+        response.headers.get('x-request-id') ??
+        ((d['meta'] as Record<string, unknown>)?.['requestId'] as string | undefined) ??
+        (errObj?.['requestId'] as string | undefined);
+      const errorCode = (errObj?.['code'] ?? d['code'] ?? 'HTTP_ERROR') as string;
+      const errorMessage = (errObj?.['message'] ?? d['message'] ?? response.statusText) as string;
 
-      if (response.status === 409 || errorCode === 'IDEMPOTENCY_CONFLICT') {
+      if (response.status === 409 && errorCode === 'IDEMPOTENCY_CONFLICT') {
         throw new IdempotencyConflictError(
           response.status,
           'IDEMPOTENCY_CONFLICT',
-          errorMessage || 'Idempotency key collision with differing payload',
-          data?.stored_hash || data?.details?.stored_hash,
-          data?.incoming_hash || data?.details?.incoming_hash,
-          data,
+          errorMessage,
+          (d['stored_hash'] ?? (d['details'] as Record<string, unknown>)?.['stored_hash']) as string | undefined,
+          (d['incoming_hash'] ?? (d['details'] as Record<string, unknown>)?.['incoming_hash']) as string | undefined,
+          d,
           requestId,
         );
       }
@@ -733,7 +1364,7 @@ export class FluxoraClient {
         response.status,
         errorCode,
         errorMessage,
-        data?.error?.details || data?.details,
+        errObj?.['details'] ?? (d as Record<string, unknown>)['details'],
         requestId,
       );
     }
@@ -741,81 +1372,185 @@ export class FluxoraClient {
     return data as T;
   }
 
-  // --- System Endpoints ---
+  // ── System Endpoints ───────────────────────────────────────────────────────
 
+  /** GET / — API root metadata. */
   async getRoot(): Promise<RootResponse> {
-    return this.request<RootResponse>('GET', '/');
+    const res = await this.request<{ success?: boolean; data?: RootResponse } & RootResponse>('GET', '/');
+    return (res.data ?? res) as RootResponse;
   }
 
+  /** GET /health — Liveness probe. Returns 503 during graceful shutdown. */
   async getHealth(): Promise<HealthResponse> {
-    return this.request<HealthResponse>('GET', '/health');
+    const res = await this.request<{ success?: boolean; data?: HealthResponse } & HealthResponse>('GET', '/health');
+    return (res.data ?? res) as HealthResponse;
   }
 
+  /** GET /health/ready — Readiness probe. Returns 503 if any dependency is unhealthy. */
   async getHealthReady(): Promise<HealthResponse> {
-    return this.request<HealthResponse>('GET', '/health/ready');
+    const res = await this.request<{ success?: boolean; data?: HealthResponse } & HealthResponse>('GET', '/health/ready');
+    return (res.data ?? res) as HealthResponse;
   }
 
+  /** GET /health/live — Detailed liveness report. */
   async getHealthLive(): Promise<HealthResponse> {
-    return this.request<HealthResponse>('GET', '/health/live');
+    const res = await this.request<{ success?: boolean; data?: HealthResponse } & HealthResponse>('GET', '/health/live');
+    return (res.data ?? res) as HealthResponse;
   }
 
-  // --- Auth Endpoints ---
+  // ── Auth Endpoints ─────────────────────────────────────────────────────────
 
+  /**
+   * POST /api/auth/session — Create an authenticated session.
+   *
+   * Issues a signed JWT for use as a Bearer token on subsequent requests.
+   *
+   * @param address - Stellar public key (56-char G…).
+   * @param role    - User role (defaults to \`'viewer'\`).
+   * @throws {ValidationError} When \`address\` is empty.
+   * @throws {FluxoraApiError} On 400 (invalid address format).
+   */
   async createSession(address: string, role = 'viewer'): Promise<AuthSessionResponse> {
-    if (!address) {
-      throw new ValidationError('address is required for createSession');
-    }
+    if (!address) throw new ValidationError('address is required for createSession');
     return this.request<AuthSessionResponse>('POST', '/api/auth/session', {
       body: { address, role },
     });
   }
 
-  // --- Stream Endpoints ---
+  // ── Stream Endpoints ───────────────────────────────────────────────────────
 
-  async createStream(
-    input: CreateStreamInput,
-    idempotencyKey?: string,
-  ): Promise<Stream> {
-    if (!input || !input.sender || !input.recipient || !input.amount || !input.asset) {
-      throw new ValidationError('CreateStreamInput must include sender, recipient, amount, asset');
+  /**
+   * POST /api/streams — Create a new treasury stream.
+   *
+   * Automatically generates an idempotency key when \`idempotencyKey\` is
+   * omitted. Supply your own key when retrying a failed request to prevent
+   * duplicate creation.
+   *
+   * @param input          - Stream creation parameters.
+   * @param idempotencyKey - Optional client-supplied idempotency key (UUID v4 recommended).
+   * @returns Created stream record.
+   *
+   * @throws {ValidationError}          When required fields are missing.
+   * @throws {IdempotencyConflictError} On 409 key + body mismatch.
+   * @throws {FluxoraApiError}          On other API errors.
+   *
+   * @example
+   * \`\`\`typescript
+   * const stream = await client.createStream({
+   *   sender:        'GAAZI4...',
+   *   recipient:     'GBBD47...',
+   *   depositAmount: '1000000.0000000',
+   *   ratePerSecond: '0.0000116',
+   *   startTime:     Math.floor(Date.now() / 1000),
+   * });
+   * \`\`\`
+   */
+  async createStream(input: CreateStreamInput, idempotencyKey?: string): Promise<Stream> {
+    if (!input?.sender || !input.recipient || !input.depositAmount || !input.ratePerSecond) {
+      throw new ValidationError(
+        'CreateStreamInput must include sender, recipient, depositAmount, and ratePerSecond',
+      );
     }
-    const key = idempotencyKey || generateIdempotencyKey();
-    const res = await this.request<StreamSingleResponse>('POST', '/api/streams', {
+    const key = idempotencyKey ?? generateIdempotencyKey();
+    const res = await this.request<StreamCreateResponse>('POST', '/api/streams', {
       body: input,
       headers: { 'Idempotency-Key': key },
     });
     return res.data;
   }
 
+  /**
+   * GET /api/streams/:id — Fetch a single stream by ID.
+   *
+   * @param streamId - The stream identifier.
+   * @throws {ValidationError} When \`streamId\` is empty.
+   * @throws {FluxoraApiError} On 404 (not found) or 503.
+   */
   async getStream(streamId: string): Promise<Stream> {
     if (!streamId) throw new ValidationError('streamId is required');
     const res = await this.request<StreamSingleResponse>('GET', \`/api/streams/\${streamId}\`);
-    return res.data;
+    return res.data.stream;
   }
 
+  /**
+   * GET /api/streams — List streams with cursor-based pagination.
+   *
+   * Returns a \`StreamPaginator\` which lazily fetches pages on demand.
+   *
+   * @param params - Optional filter and pagination parameters.
+   * @returns A \`StreamPaginator\` instance.
+   *
+   * @example
+   * \`\`\`typescript
+   * for await (const stream of client.listStreams({ status: 'active' }).autoPaginate()) {
+   *   console.log(stream.id, stream.depositAmount);
+   * }
+   * \`\`\`
+   */
   listStreams(params: ListStreamsParams = {}): StreamPaginator {
     return new StreamPaginator(
-      (p) => this.request<StreamListResponse>('GET', '/api/streams', { params: p as Record<string, unknown> }),
+      (p) => this.request<StreamListResponse>('GET', '/api/streams', {
+        params: p as Record<string, unknown>,
+      }),
       params,
     );
   }
 
-  async cancelStream(streamId: string): Promise<Stream> {
+  /**
+   * DELETE /api/streams/:id — Cancel an active stream.
+   *
+   * @param streamId - The stream identifier.
+   * @throws {ValidationError} When \`streamId\` is empty.
+   * @throws {FluxoraApiError} On 404, 409 (already completed/cancelled), or 503.
+   */
+  async cancelStream(streamId: string): Promise<{ message: string; id: string }> {
     if (!streamId) throw new ValidationError('streamId is required');
-    const res = await this.request<StreamSingleResponse>('POST', \`/api/streams/\${streamId}/cancel\`);
+    const res = await this.request<{ success: boolean; data: { message: string; id: string } }>(
+      'DELETE',
+      \`/api/streams/\${streamId}\`,
+    );
     return res.data;
   }
 
-  // --- Privacy Endpoints ---
+  /**
+   * PATCH /api/streams/:id/status — Transition a stream to a new lifecycle status.
+   *
+   * @param streamId  - The stream identifier.
+   * @param newStatus - Target status (\`active\`, \`paused\`, \`completed\`, or \`cancelled\`).
+   * @returns Updated stream record.
+   *
+   * @throws {ValidationError} When \`streamId\` is empty.
+   * @throws {FluxoraApiError} On 409 (invalid transition) or 404.
+   */
+  async updateStreamStatus(
+    streamId: string,
+    newStatus: 'active' | 'paused' | 'completed' | 'cancelled',
+  ): Promise<Stream> {
+    if (!streamId) throw new ValidationError('streamId is required');
+    const res = await this.request<StreamCreateResponse>(
+      'PATCH',
+      \`/api/streams/\${streamId}/status\`,
+      { body: { status: newStatus } },
+    );
+    return res.data;
+  }
 
+  // ── Privacy Endpoints ──────────────────────────────────────────────────────
+
+  /** GET /api/privacy/policy — Retrieve the PII policy document. */
   async getPrivacyPolicy(): Promise<Record<string, unknown>> {
     return this.request('GET', '/api/privacy/policy');
   }
 
+  /** GET /api/privacy/retention — Retrieve the data retention schedule. */
   async getPrivacyRetention(): Promise<Record<string, unknown>> {
     return this.request('GET', '/api/privacy/retention');
   }
 
+  /**
+   * PUT /api/privacy/consent — Record or update a user's privacy consent.
+   * @param consent - Consent record; \`address\` identifies the user.
+   */
   async putPrivacyConsent(consent: {
     address: string;
     analytics_optout: boolean;
@@ -828,33 +1563,44 @@ export class FluxoraClient {
     return res.data.consent;
   }
 
+  /**
+   * GET /api/privacy/consent/:address — Fetch a user's current consent record.
+   * @throws {ValidationError} When \`address\` is empty.
+   */
   async getPrivacyConsent(address: string): Promise<PrivacyConsent> {
     if (!address) throw new ValidationError('address is required');
     const res = await this.request<PrivacyConsentResponse>('GET', \`/api/privacy/consent/\${address}\`);
     return res.data.consent;
   }
 
-  // --- Webhook Endpoints ---
+  // ── Webhook Endpoints ──────────────────────────────────────────────────────
 
+  /** POST /internal/webhooks/queue — Queue a webhook delivery. */
   async queueWebhook(payload: Record<string, unknown>): Promise<WebhookDelivery> {
-    const res = await this.request<{ success: boolean; data: WebhookDelivery }>('POST', '/api/webhooks', {
-      body: payload,
-    });
+    const res = await this.request<{ success: boolean; data: WebhookDelivery }>(
+      'POST',
+      '/internal/webhooks/queue',
+      { body: payload },
+    );
     return res.data;
   }
 
+  /** GET /internal/webhooks/:id — Retrieve a webhook delivery record. */
   async getWebhookDelivery(id: string): Promise<WebhookDelivery> {
-    const res = await this.request<{ success: boolean; data: WebhookDelivery }>('GET', \`/api/webhooks/\${id}\`);
+    const res = await this.request<{ success: boolean; data: WebhookDelivery }>(
+      'GET',
+      \`/internal/webhooks/\${id}\`,
+    );
     return res.data;
   }
 }
 `;
-
-  return files;
 }
 
+// ── Main ──────────────────────────────────────────────────────────────────────
+
 /**
- * Main execution.
+ * Entry point — load spec, generate files, write or diff.
  */
 function main() {
   const spec = loadSpec(SPEC_PATH);
@@ -866,6 +1612,7 @@ function main() {
 
     for (const [relativePath, expectedContent] of Object.entries(generatedFiles)) {
       const fullPath = path.resolve(OUT_DIR, relativePath);
+
       if (!fs.existsSync(fullPath)) {
         console.error(`[DRIFT DETECTED] Missing file: ${relativePath}`);
         hasDrift = true;
@@ -873,14 +1620,15 @@ function main() {
       }
 
       const existingContent = fs.readFileSync(fullPath, 'utf8');
-      if (existingContent.trim() !== expectedContent.trim()) {
-        console.error(`[DRIFT DETECTED] File content mismatch: ${relativePath}`);
+      // Normalise line endings for cross-platform comparison
+      if (existingContent.replace(/\r\n/g, '\n').trim() !== expectedContent.replace(/\r\n/g, '\n').trim()) {
+        console.error(`[DRIFT DETECTED] Content mismatch: ${relativePath}`);
         hasDrift = true;
       }
     }
 
     if (hasDrift) {
-      console.error('[DRIFT CHECK FAILED] Generated TypeScript SDK differs from disk contents.');
+      console.error('[DRIFT CHECK FAILED] Run `pnpm generate:sdk:ts` and commit the result.');
       process.exit(1);
     } else {
       console.log('[DRIFT CHECK PASSED] All TypeScript SDK files match generated output.');
@@ -897,7 +1645,7 @@ function main() {
       console.log(`  Wrote ${relativePath}`);
     }
 
-    console.log('[SDK GENERATION COMPLETE] Successfully generated TypeScript Client SDK.');
+    console.log('[SDK GENERATION COMPLETE] TypeScript Client SDK generated successfully.');
   }
 }
 

--- a/sdk/typescript/README.md
+++ b/sdk/typescript/README.md
@@ -1,59 +1,193 @@
-# Fluxora TypeScript Client SDK
+# @fluxora/sdk — TypeScript Client SDK
 
-Typed TypeScript client SDK for the Fluxora HTTP API generated directly from `openapi.yaml`.
+> **Version**: 0.1.0 · **Generated from** `openapi.yaml` by `scripts/generate-sdk-ts.mjs`.
+> Do not edit by hand — run `pnpm generate:sdk:ts` to regenerate.
+
+Typed TypeScript client for the [Fluxora Backend API](../../docs/api.md).
+Zero external runtime dependencies; uses the standard Web `fetch` API.
+
+---
 
 ## Features
-- **Zero External Dependencies**: Uses standard Web Fetch API (`fetch`).
-- **Cursor Pagination**: Native support for cursor pagination via `StreamPaginator` (`autoPaginate()`).
-- **Idempotency Header & Payload Hashing**: Canonical JSON SHA-256 body hashing matching `src/middleware/idempotency.ts`.
-- **Complete Endpoint Coverage**: Includes streams, webhooks, auth, health probes, and admin endpoints.
-- **Full Type Safety**: Complete TypeScript interfaces for all request payloads and response envelopes.
+
+| Feature | Detail |
+|---------|--------|
+| **Zero dependencies** | Uses native `fetch` — works in Node.js ≥ 18, Deno, Bun, and browsers |
+| **Full type safety** | Every request/response is typed from `openapi.yaml` |
+| **Cursor pagination** | `StreamPaginator` wraps keyset cursors behind an ergonomic async generator |
+| **Idempotency** | UUID v4 key generation + canonical SHA-256 body hashing matching the server |
+| **Typed error hierarchy** | `FluxoraApiError`, `IdempotencyConflictError`, `ValidationError` |
+| **Client-side validation** | Input guards throw `ValidationError` before any network round-trip |
+| **Auth support** | Bearer JWT + static API key |
+
+---
+
+## Installation
+
+This is an internal workspace package declared in `pnpm-workspace.yaml`.
+Reference it from sibling packages with:
+
+```json
+{ "dependencies": { "@fluxora/sdk": "workspace:*" } }
+```
+
+---
 
 ## Quickstart
 
 ```typescript
-import { FluxoraClient, StreamPaginator, generateIdempotencyKey } from '@fluxora/sdk';
+import {
+  FluxoraClient,
+  generateIdempotencyKey,
+  FluxoraApiError,
+  IdempotencyConflictError,
+} from '@fluxora/sdk';
 
-// Initialize client
-const client = new FluxoraClient({ baseUrl: 'http://localhost:3000' });
+const client = new FluxoraClient({
+  baseUrl: 'http://localhost:3000',
+  bearerToken: process.env.FLUXORA_TOKEN,
+});
 
-// 1. Health probe
+// Health probe
 const health = await client.getHealth();
-console.log('Status:', health.status);
+console.log('Status:', health.status); // 'ok' | 'degraded' | 'shutting_down'
 
-// 2. Create stream with Idempotency Key
-const idempotencyKey = generateIdempotencyKey();
-const stream = await client.createStream(
-  {
-    sender: 'GBBD47UZQ5CYVVEUVRYNQZX3G5KRZTAYF5XSVS2UKMCCWW5LJJLXNVQX',
-    recipient: 'GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN',
-    amount: '100.5000000',
-    asset: 'XLM',
-  },
-  idempotencyKey,
-);
-console.log('Created Stream:', stream.id);
+// Create a stream (auto-generates Idempotency-Key)
+const stream = await client.createStream({
+  sender:        'GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN',
+  recipient:     'GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGZCP2J7F1NRQKQOHP3OGN',
+  depositAmount: '1000000.0000000',
+  ratePerSecond: '0.0000116',
+  startTime:     Math.floor(Date.now() / 1000),
+});
+console.log('Stream:', stream.id, stream.status);
 
-// 3. Paginate streams
+// Paginate all active streams
 const paginator = client.listStreams({ limit: 20, status: 'active' });
-for await (const streamItem of paginator.autoPaginate()) {
-  console.log('Stream:', streamItem.id, streamItem.status);
+for await (const s of paginator.autoPaginate()) {
+  console.log(s.id, s.depositAmount);
 }
 ```
 
-## Handling Idempotency Conflicts
+---
+
+## Error handling
 
 ```typescript
-import { IdempotencyConflictError } from '@fluxora/sdk';
+import { FluxoraApiError, IdempotencyConflictError, ValidationError } from '@fluxora/sdk';
 
 try {
-  await client.createStream(payload, 'reused-key');
+  await client.createStream(payload, 'my-idempotency-key');
 } catch (err) {
   if (err instanceof IdempotencyConflictError) {
-    console.error('Idempotency collision!', err.storedHash, err.incomingHash);
+    // Same key, different payload — generate a new key
+    console.error('Conflict:', err.storedHash, err.incomingHash);
+  } else if (err instanceof FluxoraApiError) {
+    console.error(`HTTP ${err.statusCode} [${err.code}]: ${err.message}`);
+    // err.requestId — correlate with server logs
+  } else if (err instanceof ValidationError) {
+    console.error('Bad input:', err.message);
   }
 }
 ```
 
-## License
-MIT
+---
+
+## Idempotency
+
+POST /api/streams requires an `Idempotency-Key` header. The SDK handles this automatically:
+
+- If you omit `idempotencyKey`, the SDK auto-generates a UUID v4.
+- If you supply a key, reuse the **same key when retrying** to prevent duplicate creation.
+- Reusing a key with a **different body** throws `IdempotencyConflictError`.
+
+```typescript
+const key = generateIdempotencyKey(); // UUID v4
+const stream = await client.createStream(payload, key);
+// On retry:
+const same = await client.createStream(payload, key); // replays cached response
+```
+
+---
+
+## Security notes
+
+- Bearer tokens and API keys are stored in memory only and never logged.
+- The `Authorization` header is only added when a credential is present.
+- Client-side input validation rejects obviously invalid values before network dispatch.
+- TLS certificate validation is performed by the platform's `fetch` implementation.
+- Idempotency key values are never echoed in error bodies or logs (server-side guarantee).
+
+---
+
+## API Reference
+
+### `new FluxoraClient(config?)`
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `baseUrl` | `string` | `'http://localhost:3000'` | API base URL |
+| `bearerToken` | `string` | — | JWT from `createSession()` |
+| `apiKey` | `string` | — | Static API key (`X-API-Key` header) |
+| `headers` | `Record<string, string>` | — | Extra headers merged into every request |
+
+### Stream methods
+
+| Method | Description |
+|--------|-------------|
+| `createStream(input, key?)` | POST /api/streams — auto-generates key if omitted |
+| `getStream(id)` | GET /api/streams/:id |
+| `listStreams(params?)` | Returns a `StreamPaginator` |
+| `cancelStream(id)` | DELETE /api/streams/:id |
+| `updateStreamStatus(id, status)` | PATCH /api/streams/:id/status |
+
+### Other methods
+
+| Method | Description |
+|--------|-------------|
+| `getRoot()` | GET / |
+| `getHealth()` | GET /health |
+| `getHealthReady()` | GET /health/ready |
+| `getHealthLive()` | GET /health/live |
+| `createSession(address, role?)` | POST /api/auth/session |
+| `getPrivacyPolicy()` | GET /api/privacy/policy |
+| `getPrivacyRetention()` | GET /api/privacy/retention |
+| `putPrivacyConsent(consent)` | PUT /api/privacy/consent |
+| `getPrivacyConsent(address)` | GET /api/privacy/consent/:address |
+| `queueWebhook(payload)` | POST /internal/webhooks/queue |
+| `getWebhookDelivery(id)` | GET /internal/webhooks/:id |
+
+---
+
+## Pagination
+
+`listStreams()` returns a `StreamPaginator`. Use `autoPaginate()` or `nextPage()`:
+
+```typescript
+// Async generator — iterate all streams
+for await (const stream of client.listStreams().autoPaginate()) {
+  process(stream);
+}
+
+// Manual paging
+const pager = client.listStreams({ limit: 50, status: 'active' });
+let page = await pager.nextPage();
+while (page) {
+  doSomething(page);
+  page = await pager.nextPage();
+}
+```
+
+Cursors are **opaque base64url tokens** — never construct or decode them.
+See [`docs/openapi/README.md`](../../docs/openapi/README.md) for full cursor semantics.
+
+---
+
+## Regenerating the SDK
+
+```bash
+pnpm generate:sdk:ts        # regenerate sdk/typescript/
+pnpm check:sdk:ts           # CI drift check — exits 1 if files differ
+```
+
+The generator reads `openapi.yaml` and overwrites all files under `sdk/typescript/`.

--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@fluxora/sdk",
   "version": "0.1.0",
-  "description": "Typed TypeScript client SDK for Fluxora Backend API generated from openapi.yaml",
+  "description": "Typed TypeScript client SDK for the Fluxora Backend API — generated from openapi.yaml.",
   "main": "./src/index.ts",
   "module": "./src/index.ts",
   "types": "./src/index.ts",
@@ -12,6 +12,16 @@
       "require": "./src/index.ts"
     }
   },
+  "files": [
+    "src",
+    "README.md"
+  ],
   "license": "MIT",
+  "keywords": [
+    "fluxora",
+    "sdk",
+    "streaming",
+    "stellar"
+  ],
   "dependencies": {}
 }

--- a/sdk/typescript/src/client.ts
+++ b/sdk/typescript/src/client.ts
@@ -1,12 +1,27 @@
 /**
- * Synchronous / Async Fetch Client for Fluxora Backend API.
+ * FluxoraClient — typed HTTP client for the Fluxora Backend API.
+ *
+ * Generated from `openapi.yaml` by `scripts/generate-sdk-ts.mjs`.
+ * Do not edit by hand — run `pnpm generate:sdk:ts` instead.
+ *
+ * ## Design
+ * - Zero external runtime dependencies — uses the standard Web `fetch` API.
+ * - All monetary amounts flow as **decimal strings** (never JS numbers).
+ * - Idempotency keys are auto-generated for POST /api/streams when omitted.
+ * - Cursor-based pagination is encapsulated in `StreamPaginator`.
+ *
+ * ## Security notes
+ * - Bearer tokens and API keys are stored in memory only; never logged.
+ * - The `Authorization` header is only set when a credential is present.
+ * - Client-side validation (empty/missing required params) fires before any
+ *   network round-trip, reducing the attack surface for injection.
+ * - TLS validation is delegated to the platform's `fetch` implementation.
+ * - Idempotency key values are never echoed in error bodies (server guarantee).
+ *
+ * @module @fluxora/sdk/client
  */
 
-import {
-  FluxoraApiError,
-  IdempotencyConflictError,
-  ValidationError,
-} from './errors.js';
+import { FluxoraApiError, IdempotencyConflictError, ValidationError } from './errors.js';
 import { generateIdempotencyKey } from './idempotency.js';
 import { StreamPaginator } from './pagination.js';
 import type {
@@ -14,6 +29,7 @@ import type {
   CreateStreamInput,
   StreamListResponse,
   StreamSingleResponse,
+  StreamCreateResponse,
   HealthResponse,
   RootResponse,
   AuthSessionResponse,
@@ -23,13 +39,50 @@ import type {
   ListStreamsParams,
 } from './types.js';
 
+// ── Configuration ─────────────────────────────────────────────────────────────
+
+/**
+ * Client initialisation options.
+ *
+ * @example
+ * ```typescript
+ * const client = new FluxoraClient({
+ *   baseUrl: 'https://api.fluxora.example.com',
+ *   bearerToken: process.env.FLUXORA_TOKEN,
+ * });
+ * ```
+ */
 export interface FluxoraClientConfig {
+  /**
+   * Base URL of the Fluxora API. Trailing slashes are stripped automatically.
+   * Defaults to `'http://localhost:3000'`.
+   */
   baseUrl?: string;
+  /**
+   * Static API key sent as `X-API-Key`.
+   * Can be updated at runtime via `setApiKey()`.
+   */
   apiKey?: string;
+  /**
+   * JWT Bearer token.
+   * Can be updated at runtime via `setBearerToken()`.
+   */
   bearerToken?: string;
+  /**
+   * Additional headers merged into every request.
+   * Per-request headers take precedence over these.
+   */
   headers?: Record<string, string>;
 }
 
+// ── Client ────────────────────────────────────────────────────────────────────
+
+/**
+ * Typed HTTP client for the Fluxora Backend API.
+ *
+ * All methods return strongly-typed response objects matching the shapes
+ * defined in `openapi.yaml` and mirroring `src/routes/streams.ts`.
+ */
 export class FluxoraClient {
   private baseUrl: string;
   private apiKey?: string;
@@ -37,7 +90,7 @@ export class FluxoraClient {
   private headers: Record<string, string>;
 
   constructor(config: FluxoraClientConfig = {}) {
-    this.baseUrl = (config.baseUrl || 'http://localhost:3000').replace(/\/+$/, '');
+    this.baseUrl = (config.baseUrl ?? 'http://localhost:3000').replace(/\/+$/, '');
     this.apiKey = config.apiKey;
     this.bearerToken = config.bearerToken;
     this.headers = {
@@ -47,14 +100,36 @@ export class FluxoraClient {
     };
   }
 
+  /**
+   * Update the JWT Bearer token for authenticated requests.
+   * The new value is used immediately on the next call.
+   * @security Token is stored in memory only; never logged.
+   */
   public setBearerToken(token: string): void {
     this.bearerToken = token;
   }
 
+  /**
+   * Update the static API key (`X-API-Key` header).
+   * @security Key is stored in memory only; never logged.
+   */
   public setApiKey(apiKey: string): void {
     this.apiKey = apiKey;
   }
 
+  // ── Core HTTP dispatcher ───────────────────────────────────────────────────
+
+  /**
+   * Execute an HTTP request and return the parsed JSON response body.
+   *
+   * On non-2xx responses the method throws:
+   * - `IdempotencyConflictError` for 409 `IDEMPOTENCY_CONFLICT`
+   * - `FluxoraApiError` for all other non-2xx responses
+   *
+   * @param method  - HTTP verb (GET, POST, DELETE, PATCH, PUT).
+   * @param path    - Request path (e.g. `'/api/streams'`).
+   * @param options - Optional query params, body, and extra headers.
+   */
   private async request<T>(
     method: string,
     path: string,
@@ -67,25 +142,17 @@ export class FluxoraClient {
     let url = `${this.baseUrl}${path}`;
 
     if (options.params) {
-      const queryParams = new URLSearchParams();
+      const qs = new URLSearchParams();
       for (const [k, v] of Object.entries(options.params)) {
-        if (v !== undefined && v !== null) {
-          queryParams.append(k, String(v));
-        }
+        if (v !== undefined && v !== null) qs.append(k, String(v));
       }
-      const queryString = queryParams.toString();
-      if (queryString) {
-        url += `?${queryString}`;
-      }
+      const s = qs.toString();
+      if (s) url += `?${s}`;
     }
 
     const headers: Record<string, string> = { ...this.headers, ...options.headers };
-    if (this.bearerToken) {
-      headers['Authorization'] = `Bearer ${this.bearerToken}`;
-    }
-    if (this.apiKey) {
-      headers['X-API-Key'] = this.apiKey;
-    }
+    if (this.bearerToken) headers['Authorization'] = `Bearer ${this.bearerToken}`;
+    if (this.apiKey) headers['X-API-Key'] = this.apiKey;
 
     let bodyPayload: string | undefined;
     if (options.body !== undefined) {
@@ -99,29 +166,30 @@ export class FluxoraClient {
       body: bodyPayload,
     });
 
-    let data: any = {};
+    let data: unknown = {};
     const text = await response.text();
     if (text) {
-      try {
-        data = JSON.parse(text);
-      } catch {
-        data = { message: text };
-      }
+      try { data = JSON.parse(text); } catch { data = { message: text }; }
     }
 
     if (!response.ok) {
-      const requestId = response.headers.get('x-request-id') || data?.meta?.requestId || data?.error?.requestId;
-      const errorCode = data?.error?.code || data?.code || 'HTTP_ERROR';
-      const errorMessage = data?.error?.message || data?.message || response.statusText;
+      const d = data as Record<string, unknown>;
+      const errObj = d['error'] as Record<string, unknown> | undefined;
+      const requestId =
+        response.headers.get('x-request-id') ??
+        ((d['meta'] as Record<string, unknown>)?.['requestId'] as string | undefined) ??
+        (errObj?.['requestId'] as string | undefined);
+      const errorCode = (errObj?.['code'] ?? d['code'] ?? 'HTTP_ERROR') as string;
+      const errorMessage = (errObj?.['message'] ?? d['message'] ?? response.statusText) as string;
 
-      if (response.status === 409 || errorCode === 'IDEMPOTENCY_CONFLICT') {
+      if (response.status === 409 && errorCode === 'IDEMPOTENCY_CONFLICT') {
         throw new IdempotencyConflictError(
           response.status,
           'IDEMPOTENCY_CONFLICT',
-          errorMessage || 'Idempotency key collision with differing payload',
-          data?.stored_hash || data?.details?.stored_hash,
-          data?.incoming_hash || data?.details?.incoming_hash,
-          data,
+          errorMessage,
+          (d['stored_hash'] ?? (d['details'] as Record<string, unknown>)?.['stored_hash']) as string | undefined,
+          (d['incoming_hash'] ?? (d['details'] as Record<string, unknown>)?.['incoming_hash']) as string | undefined,
+          d,
           requestId,
         );
       }
@@ -130,7 +198,7 @@ export class FluxoraClient {
         response.status,
         errorCode,
         errorMessage,
-        data?.error?.details || data?.details,
+        errObj?.['details'] ?? (d as Record<string, unknown>)['details'],
         requestId,
       );
     }
@@ -138,81 +206,185 @@ export class FluxoraClient {
     return data as T;
   }
 
-  // --- System Endpoints ---
+  // ── System Endpoints ───────────────────────────────────────────────────────
 
+  /** GET / — API root metadata. */
   async getRoot(): Promise<RootResponse> {
-    return this.request<RootResponse>('GET', '/');
+    const res = await this.request<{ success?: boolean; data?: RootResponse } & RootResponse>('GET', '/');
+    return (res.data ?? res) as RootResponse;
   }
 
+  /** GET /health — Liveness probe. Returns 503 during graceful shutdown. */
   async getHealth(): Promise<HealthResponse> {
-    return this.request<HealthResponse>('GET', '/health');
+    const res = await this.request<{ success?: boolean; data?: HealthResponse } & HealthResponse>('GET', '/health');
+    return (res.data ?? res) as HealthResponse;
   }
 
+  /** GET /health/ready — Readiness probe. Returns 503 if any dependency is unhealthy. */
   async getHealthReady(): Promise<HealthResponse> {
-    return this.request<HealthResponse>('GET', '/health/ready');
+    const res = await this.request<{ success?: boolean; data?: HealthResponse } & HealthResponse>('GET', '/health/ready');
+    return (res.data ?? res) as HealthResponse;
   }
 
+  /** GET /health/live — Detailed liveness report. */
   async getHealthLive(): Promise<HealthResponse> {
-    return this.request<HealthResponse>('GET', '/health/live');
+    const res = await this.request<{ success?: boolean; data?: HealthResponse } & HealthResponse>('GET', '/health/live');
+    return (res.data ?? res) as HealthResponse;
   }
 
-  // --- Auth Endpoints ---
+  // ── Auth Endpoints ─────────────────────────────────────────────────────────
 
+  /**
+   * POST /api/auth/session — Create an authenticated session.
+   *
+   * Issues a signed JWT for use as a Bearer token on subsequent requests.
+   *
+   * @param address - Stellar public key (56-char G…).
+   * @param role    - User role (defaults to `'viewer'`).
+   * @throws {ValidationError} When `address` is empty.
+   * @throws {FluxoraApiError} On 400 (invalid address format).
+   */
   async createSession(address: string, role = 'viewer'): Promise<AuthSessionResponse> {
-    if (!address) {
-      throw new ValidationError('address is required for createSession');
-    }
+    if (!address) throw new ValidationError('address is required for createSession');
     return this.request<AuthSessionResponse>('POST', '/api/auth/session', {
       body: { address, role },
     });
   }
 
-  // --- Stream Endpoints ---
+  // ── Stream Endpoints ───────────────────────────────────────────────────────
 
-  async createStream(
-    input: CreateStreamInput,
-    idempotencyKey?: string,
-  ): Promise<Stream> {
-    if (!input || !input.sender || !input.recipient || !input.amount || !input.asset) {
-      throw new ValidationError('CreateStreamInput must include sender, recipient, amount, asset');
+  /**
+   * POST /api/streams — Create a new treasury stream.
+   *
+   * Automatically generates an idempotency key when `idempotencyKey` is
+   * omitted. Supply your own key when retrying a failed request to prevent
+   * duplicate creation.
+   *
+   * @param input          - Stream creation parameters.
+   * @param idempotencyKey - Optional client-supplied idempotency key (UUID v4 recommended).
+   * @returns Created stream record.
+   *
+   * @throws {ValidationError}          When required fields are missing.
+   * @throws {IdempotencyConflictError} On 409 key + body mismatch.
+   * @throws {FluxoraApiError}          On other API errors.
+   *
+   * @example
+   * ```typescript
+   * const stream = await client.createStream({
+   *   sender:        'GAAZI4...',
+   *   recipient:     'GBBD47...',
+   *   depositAmount: '1000000.0000000',
+   *   ratePerSecond: '0.0000116',
+   *   startTime:     Math.floor(Date.now() / 1000),
+   * });
+   * ```
+   */
+  async createStream(input: CreateStreamInput, idempotencyKey?: string): Promise<Stream> {
+    if (!input?.sender || !input.recipient || !input.depositAmount || !input.ratePerSecond) {
+      throw new ValidationError(
+        'CreateStreamInput must include sender, recipient, depositAmount, and ratePerSecond',
+      );
     }
-    const key = idempotencyKey || generateIdempotencyKey();
-    const res = await this.request<StreamSingleResponse>('POST', '/api/streams', {
+    const key = idempotencyKey ?? generateIdempotencyKey();
+    const res = await this.request<StreamCreateResponse>('POST', '/api/streams', {
       body: input,
       headers: { 'Idempotency-Key': key },
     });
     return res.data;
   }
 
+  /**
+   * GET /api/streams/:id — Fetch a single stream by ID.
+   *
+   * @param streamId - The stream identifier.
+   * @throws {ValidationError} When `streamId` is empty.
+   * @throws {FluxoraApiError} On 404 (not found) or 503.
+   */
   async getStream(streamId: string): Promise<Stream> {
     if (!streamId) throw new ValidationError('streamId is required');
     const res = await this.request<StreamSingleResponse>('GET', `/api/streams/${streamId}`);
-    return res.data;
+    return res.data.stream;
   }
 
+  /**
+   * GET /api/streams — List streams with cursor-based pagination.
+   *
+   * Returns a `StreamPaginator` which lazily fetches pages on demand.
+   *
+   * @param params - Optional filter and pagination parameters.
+   * @returns A `StreamPaginator` instance.
+   *
+   * @example
+   * ```typescript
+   * for await (const stream of client.listStreams({ status: 'active' }).autoPaginate()) {
+   *   console.log(stream.id, stream.depositAmount);
+   * }
+   * ```
+   */
   listStreams(params: ListStreamsParams = {}): StreamPaginator {
     return new StreamPaginator(
-      (p) => this.request<StreamListResponse>('GET', '/api/streams', { params: p as Record<string, unknown> }),
+      (p) => this.request<StreamListResponse>('GET', '/api/streams', {
+        params: p as Record<string, unknown>,
+      }),
       params,
     );
   }
 
-  async cancelStream(streamId: string): Promise<Stream> {
+  /**
+   * DELETE /api/streams/:id — Cancel an active stream.
+   *
+   * @param streamId - The stream identifier.
+   * @throws {ValidationError} When `streamId` is empty.
+   * @throws {FluxoraApiError} On 404, 409 (already completed/cancelled), or 503.
+   */
+  async cancelStream(streamId: string): Promise<{ message: string; id: string }> {
     if (!streamId) throw new ValidationError('streamId is required');
-    const res = await this.request<StreamSingleResponse>('POST', `/api/streams/${streamId}/cancel`);
+    const res = await this.request<{ success: boolean; data: { message: string; id: string } }>(
+      'DELETE',
+      `/api/streams/${streamId}`,
+    );
     return res.data;
   }
 
-  // --- Privacy Endpoints ---
+  /**
+   * PATCH /api/streams/:id/status — Transition a stream to a new lifecycle status.
+   *
+   * @param streamId  - The stream identifier.
+   * @param newStatus - Target status (`active`, `paused`, `completed`, or `cancelled`).
+   * @returns Updated stream record.
+   *
+   * @throws {ValidationError} When `streamId` is empty.
+   * @throws {FluxoraApiError} On 409 (invalid transition) or 404.
+   */
+  async updateStreamStatus(
+    streamId: string,
+    newStatus: 'active' | 'paused' | 'completed' | 'cancelled',
+  ): Promise<Stream> {
+    if (!streamId) throw new ValidationError('streamId is required');
+    const res = await this.request<StreamCreateResponse>(
+      'PATCH',
+      `/api/streams/${streamId}/status`,
+      { body: { status: newStatus } },
+    );
+    return res.data;
+  }
 
+  // ── Privacy Endpoints ──────────────────────────────────────────────────────
+
+  /** GET /api/privacy/policy — Retrieve the PII policy document. */
   async getPrivacyPolicy(): Promise<Record<string, unknown>> {
     return this.request('GET', '/api/privacy/policy');
   }
 
+  /** GET /api/privacy/retention — Retrieve the data retention schedule. */
   async getPrivacyRetention(): Promise<Record<string, unknown>> {
     return this.request('GET', '/api/privacy/retention');
   }
 
+  /**
+   * PUT /api/privacy/consent — Record or update a user's privacy consent.
+   * @param consent - Consent record; `address` identifies the user.
+   */
   async putPrivacyConsent(consent: {
     address: string;
     analytics_optout: boolean;
@@ -225,23 +397,34 @@ export class FluxoraClient {
     return res.data.consent;
   }
 
+  /**
+   * GET /api/privacy/consent/:address — Fetch a user's current consent record.
+   * @throws {ValidationError} When `address` is empty.
+   */
   async getPrivacyConsent(address: string): Promise<PrivacyConsent> {
     if (!address) throw new ValidationError('address is required');
     const res = await this.request<PrivacyConsentResponse>('GET', `/api/privacy/consent/${address}`);
     return res.data.consent;
   }
 
-  // --- Webhook Endpoints ---
+  // ── Webhook Endpoints ──────────────────────────────────────────────────────
 
+  /** POST /internal/webhooks/queue — Queue a webhook delivery. */
   async queueWebhook(payload: Record<string, unknown>): Promise<WebhookDelivery> {
-    const res = await this.request<{ success: boolean; data: WebhookDelivery }>('POST', '/api/webhooks', {
-      body: payload,
-    });
+    const res = await this.request<{ success: boolean; data: WebhookDelivery }>(
+      'POST',
+      '/internal/webhooks/queue',
+      { body: payload },
+    );
     return res.data;
   }
 
+  /** GET /internal/webhooks/:id — Retrieve a webhook delivery record. */
   async getWebhookDelivery(id: string): Promise<WebhookDelivery> {
-    const res = await this.request<{ success: boolean; data: WebhookDelivery }>('GET', `/api/webhooks/${id}`);
+    const res = await this.request<{ success: boolean; data: WebhookDelivery }>(
+      'GET',
+      `/internal/webhooks/${id}`,
+    );
     return res.data;
   }
 }

--- a/sdk/typescript/src/errors.ts
+++ b/sdk/typescript/src/errors.ts
@@ -1,7 +1,30 @@
 /**
- * Typed SDK exceptions.
+ * Typed SDK exception hierarchy.
+ *
+ * Generated from `openapi.yaml` by `scripts/generate-sdk-ts.mjs`.
+ * Do not edit by hand — run `pnpm generate:sdk:ts` instead.
+ *
+ * ## Hierarchy
+ * ```
+ * Error
+ * └─ FluxoraClientError            (base for all SDK errors)
+ *    ├─ FluxoraApiError             (non-2xx HTTP response)
+ *    │  └─ IdempotencyConflictError (409 IDEMPOTENCY_CONFLICT)
+ *    └─ ValidationError             (client-side input validation failure)
+ * ```
+ *
+ * All classes call `Object.setPrototypeOf(this, new.target.prototype)` to
+ * ensure correct `instanceof` behaviour after TypeScript transpilation.
+ *
+ * @module @fluxora/sdk/errors
  */
 
+// ── Base ──────────────────────────────────────────────────────────────────────
+
+/**
+ * Base class for all errors thrown by the Fluxora TypeScript SDK.
+ * Catch this type to handle both API errors and client-side validation failures.
+ */
 export class FluxoraClientError extends Error {
   constructor(message: string) {
     super(message);
@@ -10,10 +33,34 @@ export class FluxoraClientError extends Error {
   }
 }
 
+// ── API Error ─────────────────────────────────────────────────────────────────
+
+/**
+ * Thrown when the Fluxora API returns a non-2xx HTTP response.
+ *
+ * @example
+ * ```typescript
+ * try {
+ *   await client.getStream('missing-id');
+ * } catch (err) {
+ *   if (err instanceof FluxoraApiError) {
+ *     console.error(`HTTP ${err.statusCode} [${err.code}]: ${err.message}`);
+ *     if (err.requestId) console.error('Request ID:', err.requestId);
+ *   }
+ * }
+ * ```
+ */
 export class FluxoraApiError extends FluxoraClientError {
+  /** HTTP status code (e.g. `400`, `404`, `503`). */
   public readonly statusCode: number;
+  /** Machine-readable error code (e.g. `'VALIDATION_ERROR'`, `'NOT_FOUND'`). */
   public readonly code: string;
+  /** Additional error context from the server response. */
   public readonly details?: unknown;
+  /**
+   * Correlation ID (`X-Request-ID` header) for tracing.
+   * Include in support tickets to correlate with server logs.
+   */
   public readonly requestId?: string;
 
   constructor(
@@ -33,8 +80,33 @@ export class FluxoraApiError extends FluxoraClientError {
   }
 }
 
+// ── Idempotency Conflict ──────────────────────────────────────────────────────
+
+/**
+ * Thrown when the server returns HTTP 409 with code `IDEMPOTENCY_CONFLICT`.
+ * The same `Idempotency-Key` was previously used with a **different** body.
+ *
+ * ## Resolution
+ * - Generate a fresh idempotency key for the new request, **or**
+ * - Retry with the original request body and the same key.
+ *
+ * @example
+ * ```typescript
+ * try {
+ *   await client.createStream(payload, 'my-key');
+ * } catch (err) {
+ *   if (err instanceof IdempotencyConflictError) {
+ *     console.error('Payload mismatch!');
+ *     console.error('Stored hash:   ', err.storedHash);
+ *     console.error('Incoming hash: ', err.incomingHash);
+ *   }
+ * }
+ * ```
+ */
 export class IdempotencyConflictError extends FluxoraApiError {
+  /** SHA-256 fingerprint of the **original** request body stored for this key. */
   public readonly storedHash?: string;
+  /** SHA-256 fingerprint of the **current** (conflicting) request body. */
   public readonly incomingHash?: string;
 
   constructor(
@@ -54,6 +126,26 @@ export class IdempotencyConflictError extends FluxoraApiError {
   }
 }
 
+// ── Validation Error ──────────────────────────────────────────────────────────
+
+/**
+ * Thrown when **client-side** input validation rejects a parameter before any
+ * HTTP request is dispatched.
+ *
+ * This is distinct from `FluxoraApiError` with `code = 'VALIDATION_ERROR'`,
+ * which indicates a server-side rejection.
+ *
+ * @example
+ * ```typescript
+ * try {
+ *   await client.getStream('');
+ * } catch (err) {
+ *   if (err instanceof ValidationError) {
+ *     console.error('Bad input:', err.message);
+ *   }
+ * }
+ * ```
+ */
 export class ValidationError extends FluxoraClientError {
   constructor(message: string) {
     super(message);

--- a/sdk/typescript/src/idempotency.ts
+++ b/sdk/typescript/src/idempotency.ts
@@ -1,16 +1,55 @@
 /**
- * Idempotency Header and Payload Hashing Utilities.
- * Matching src/middleware/idempotency.ts and src/validation/idempotency.ts semantics.
+ * Idempotency key generation and payload hashing utilities.
+ *
+ * Generated from `openapi.yaml` by `scripts/generate-sdk-ts.mjs`.
+ * Do not edit by hand — run `pnpm generate:sdk:ts` instead.
+ *
+ * ## Purpose
+ * POST /api/streams requires an `Idempotency-Key` header to prevent duplicate
+ * stream creation on retries. This module provides:
+ *
+ * - `generateIdempotencyKey()` — creates a fresh UUID v4 key per operation.
+ * - `canonicalizeBody()` — serialises an object to a deterministic JSON string
+ *   (sorted keys, recursive) suitable for hashing.
+ * - `hashBody()` — computes a SHA-256 hex digest matching the server-side
+ *   `fingerprintInput()` in `src/routes/streams.ts`.
+ *
+ * ## Security
+ * - Keys are generated with `crypto.randomUUID()` (WebCrypto) where available,
+ *   with a `Math.random`-based UUID v4 fallback for older environments.
+ * - `hashBody()` uses `crypto.subtle.digest` (WebCrypto) with a Node.js
+ *   `node:crypto` `createHash` fallback.
+ * - Key values are never logged or echoed in error responses.
+ *
+ * @module @fluxora/sdk/idempotency
  */
 
+// ── Key Generation ────────────────────────────────────────────────────────────
+
 /**
- * Generate a UUID v4 idempotency key string.
+ * Generate a unique UUID v4 idempotency key.
+ *
+ * Uses `crypto.randomUUID()` (Node.js ≥ 15, all modern browsers).
+ * Falls back to a `Math.random`-based v4 UUID for older environments.
+ *
+ * Generate a **new key per logical operation**. Reuse the same key when
+ * retrying a failed request to make it idempotent.
+ *
+ * @returns A UUID v4 string (e.g. `'b4a6f1a2-33c9-4d8e-b789-0e0a1c2d3e4f'`).
+ *
+ * @example
+ * ```typescript
+ * const key = generateIdempotencyKey();
+ * const stream = await client.createStream(input, key);
+ * // Retry with same key — gets cached response
+ * const same = await client.createStream(input, key);
+ * ```
  */
 export function generateIdempotencyKey(): string {
   if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
     return crypto.randomUUID();
   }
-  // Simple UUID v4 fallback
+  // Math.random fallback for environments without WebCrypto
   return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, (c) => {
     const r = (Math.random() * 16) | 0;
     const v = c === 'x' ? r : (r & 0x3) | 0x8;
@@ -18,27 +57,66 @@ export function generateIdempotencyKey(): string {
   });
 }
 
+// ── Canonical JSON ────────────────────────────────────────────────────────────
+
 /**
- * Recursively canonicalize a JSON object by sorting object keys.
+ * Recursively serialise a value to a **canonical** JSON string.
+ *
+ * Canonical form guarantees that two logically equal objects always produce
+ * the same string regardless of key insertion order, enabling deterministic
+ * payload fingerprinting that matches the server-side `fingerprintInput()`.
+ *
+ * Rules:
+ * - Object keys are sorted lexicographically (ascending, recursive).
+ * - Array element order is preserved.
+ * - Primitives are serialised as `JSON.stringify` would.
+ * - `null` and `undefined` are both serialised as `'null'`.
+ *
+ * @param body - Any JSON-serialisable value.
+ * @returns A deterministic JSON string.
+ *
+ * @example
+ * ```typescript
+ * canonicalizeBody({ z: 1, a: 2 }); // '{"a":2,"z":1}'
+ * canonicalizeBody({ a: 2, z: 1 }); // '{"a":2,"z":1}'  — identical
+ * ```
  */
 export function canonicalizeBody(body: unknown): string {
   if (body === null || body === undefined) return 'null';
   if (typeof body !== 'object') return JSON.stringify(body);
 
   if (Array.isArray(body)) {
-    const items = body.map((item) => canonicalizeBody(item));
+    const items = (body as unknown[]).map((item) => canonicalizeBody(item));
     return `[${items.join(',')}]`;
   }
 
-  const keys = Object.keys(body as Record<string, unknown>).sort();
-  const pairs = keys.map(
-    (k) => `"${k}":${canonicalizeBody((body as Record<string, unknown>)[k])}`,
-  );
+  const obj = body as Record<string, unknown>;
+  const keys = Object.keys(obj).sort();
+  const pairs = keys.map((k) => `"${k}":${canonicalizeBody(obj[k])}`);
   return `{${pairs.join(',')}}`;
 }
 
+// ── SHA-256 Hashing ───────────────────────────────────────────────────────────
+
 /**
- * Calculate SHA-256 hex digest of a canonicalized JSON payload.
+ * Compute a SHA-256 hex digest of a JSON payload.
+ *
+ * The payload is canonicalised via `canonicalizeBody()` and UTF-8 encoded
+ * before hashing. The digest matches the server-side `fingerprintInput()`
+ * in `src/routes/streams.ts`.
+ *
+ * Prefers `crypto.subtle.digest` (WebCrypto) with a Node.js
+ * `node:crypto` `createHash` fallback.
+ *
+ * @param body - Any JSON-serialisable value.
+ * @returns A lowercase 64-character SHA-256 hex string.
+ * @throws {Error} When no crypto API is available.
+ *
+ * @example
+ * ```typescript
+ * const hash = await hashBody({ sender: 'G...', depositAmount: '100' });
+ * console.log(hash.length); // 64
+ * ```
  */
 export async function hashBody(body: unknown): Promise<string> {
   const canonical = canonicalizeBody(body);
@@ -52,11 +130,11 @@ export async function hashBody(body: unknown): Promise<string> {
       .join('');
   }
 
-  // Node.js crypto fallback
+  // Node.js crypto fallback for environments without globalThis.crypto
   try {
     const { createHash } = await import('node:crypto');
     return createHash('sha256').update(canonical).digest('hex');
   } catch {
-    throw new Error('Crypto API unavailable for hash calculation');
+    throw new Error('Crypto API unavailable: cannot compute SHA-256 hash');
   }
 }

--- a/sdk/typescript/src/index.ts
+++ b/sdk/typescript/src/index.ts
@@ -1,8 +1,11 @@
 /**
- * Fluxora TypeScript Client SDK
- * Entrypoint re-exporting client, types, errors, pagination, and idempotency tools.
+ * @fluxora/sdk — TypeScript Client SDK
+ *
+ * Generated from `openapi.yaml` by `scripts/generate-sdk-ts.mjs`.
+ * Do not edit by hand — run `pnpm generate:sdk:ts` instead.
+ *
+ * @module @fluxora/sdk
  */
-
 export * from './types.js';
 export * from './errors.js';
 export * from './idempotency.js';

--- a/sdk/typescript/src/pagination.ts
+++ b/sdk/typescript/src/pagination.ts
@@ -1,19 +1,63 @@
 /**
- * Cursor Pagination Helpers matching src/validation/paginationSchema.ts.
+ * Cursor-based paginator for GET /api/streams.
+ *
+ * Generated from `openapi.yaml` by `scripts/generate-sdk-ts.mjs`.
+ * Do not edit by hand — run `pnpm generate:sdk:ts` instead.
+ *
+ * ## Design
+ * `StreamPaginator` wraps the server's keyset-cursor pagination behind an
+ * ergonomic API that never requires the caller to manage raw cursor tokens.
+ *
+ * - Call `nextPage()` to fetch one page at a time.
+ * - Use `autoPaginate()` (async generator) to iterate all streams across all
+ *   pages with a `for await...of` loop.
+ * - Pagination terminates when the server returns `has_more: false`.
+ *
+ * ## Cursor semantics
+ * Cursors are **opaque base64url tokens** issued by the server. Clients must
+ * treat them as black boxes — do not construct or decode manually.
+ * See `docs/openapi/README.md` for the full cursor protocol.
+ *
+ * @module @fluxora/sdk/pagination
  */
 
 import type { Stream, ListStreamsParams, StreamListResponse } from './types.js';
 
+/**
+ * Cursor-based paginator for the GET /api/streams endpoint.
+ *
+ * @example
+ * ```typescript
+ * const paginator = client.listStreams({ limit: 20, status: 'active' });
+ *
+ * // Option A — iterate individual stream items
+ * for await (const stream of paginator.autoPaginate()) {
+ *   console.log(stream.id, stream.depositAmount);
+ * }
+ *
+ * // Option B — fetch one page at a time
+ * const page1 = await paginator.nextPage();
+ * const page2 = await paginator.nextPage();
+ * ```
+ */
 export class StreamPaginator {
-  private fetchPage: (params: ListStreamsParams) => Promise<StreamListResponse>;
-  private limit: number;
-  private status?: string;
-  private sender?: string;
-  private recipient?: string;
-  private includeTotal: boolean;
+  private readonly fetchPage: (params: ListStreamsParams) => Promise<StreamListResponse>;
+  private readonly limit: number;
+  private readonly status?: string;
+  private readonly sender?: string;
+  private readonly recipient?: string;
+  private readonly includeTotal: boolean;
+
+  /** Opaque cursor from the last response; `null` = start of sequence. */
   private nextCursor: string | null = null;
+  /** `false` once the server signals no more pages. */
   private hasMore = true;
 
+  /**
+   * @param fetchPage - Calls the API and returns a `StreamListResponse`.
+   * @param params    - Initial filter and pagination parameters.
+   * @throws {Error} When `limit` is outside the valid range 1–100.
+   */
   constructor(
     fetchPage: (params: ListStreamsParams) => Promise<StreamListResponse>,
     params: ListStreamsParams = {},
@@ -31,7 +75,10 @@ export class StreamPaginator {
   }
 
   /**
-   * Fetch next page of results. Returns null when no more pages exist.
+   * Fetch the next page of stream results.
+   *
+   * @returns Array of `Stream` objects for this page, or `null` when all
+   *          pages have been consumed (`has_more` was `false`).
    */
   async nextPage(): Promise<Stream[] | null> {
     if (!this.hasMore) return null;
@@ -45,25 +92,35 @@ export class StreamPaginator {
       include_total: this.includeTotal,
     });
 
-    const items = response.data || [];
-    const nextCursor = response.meta?.next_cursor;
+    const pageData = response.data;
+    const streams: Stream[] = pageData?.streams ?? [];
+    const hasMore: boolean = pageData?.has_more ?? false;
+    const nextCursor: string | null =
+      pageData?.next_cursor ??
+      (response.meta?.next_cursor as string | null | undefined) ??
+      null;
 
-    if (nextCursor) {
+    if (nextCursor && hasMore) {
       this.nextCursor = nextCursor;
     } else {
       this.hasMore = false;
     }
 
-    return items;
+    return streams;
   }
 
   /**
-   * Async generator yielding single items across all pages.
+   * Async generator that yields individual `Stream` items across all pages.
+   *
+   * Pagination terminates automatically when the server has no more results.
+   * A `break` inside `for await` stops iteration without fetching further pages.
+   *
+   * @yields `Stream` objects one at a time.
    */
   async *autoPaginate(): AsyncGenerator<Stream, void, unknown> {
     while (this.hasMore) {
       const page = await this.nextPage();
-      if (!page) break;
+      if (!page || page.length === 0) break;
       for (const item of page) {
         yield item;
       }

--- a/sdk/typescript/src/types.ts
+++ b/sdk/typescript/src/types.ts
@@ -1,60 +1,186 @@
 /**
- * Typed response envelopes and domain model interfaces matching openapi.yaml.
+ * Typed request/response interfaces for the Fluxora Backend API.
+ *
+ * Generated from `openapi.yaml` by `scripts/generate-sdk-ts.mjs`.
+ * Do not edit by hand — run `pnpm generate:sdk:ts` instead.
+ *
+ * ## Decimal-string invariant
+ * All monetary fields (`depositAmount`, `streamedAmount`, `remainingAmount`,
+ * `ratePerSecond`) are **decimal strings** — never JavaScript numbers.
+ * This preserves precision across the Stellar/API boundary.
+ *
+ * ## Field naming
+ * All field names are camelCase, exactly as returned by `toApiStream()` in
+ * `src/routes/streams.ts`.
+ *
+ * @module @fluxora/sdk/types
  */
 
+// ── Shared ────────────────────────────────────────────────────────────────────
+
+/**
+ * Data classification levels for PII policy.
+ * Mirrors the server-side `DataClassification` enum.
+ */
 export type DataClassification = 'PUBLIC' | 'INTERNAL' | 'SENSITIVE' | 'RESTRICTED';
 
+/**
+ * Common response envelope metadata present on all API responses.
+ */
 export interface ResponseMeta {
-  requestId?: string;
+  /** ISO-8601 UTC timestamp of when the response was generated. */
   timestamp?: string;
+  /** Correlation ID — matches `X-Request-ID` header. */
+  requestId?: string;
+  /** Opaque cursor for the next page (list endpoints only). */
   next_cursor?: string;
+  /** Total count — present only when `include_total=true` was requested. */
   total?: number;
+  /** `true` when the response was served from the idempotency cache. */
   idempotency_replayed?: boolean;
+  /** Alias used on some success envelopes. */
+  idempotencyReplayed?: boolean;
 }
 
+// ── Stream ────────────────────────────────────────────────────────────────────
+
+/**
+ * Stream lifecycle status.
+ *
+ * Valid transitions (enforced by the server state machine):
+ *   active    → paused | completed | cancelled
+ *   paused    → active | cancelled
+ *   completed → (terminal)
+ *   cancelled → (terminal)
+ */
+export type StreamStatus = 'scheduled' | 'active' | 'paused' | 'completed' | 'cancelled';
+
+/**
+ * A Fluxora treasury stream record as returned by GET /api/streams and
+ * POST /api/streams.
+ *
+ * Field names match `toApiStream()` in `src/routes/streams.ts` exactly.
+ * Amount fields are always decimal strings.
+ */
 export interface Stream {
+  /** Unique stream ID (format: `stream-{64-char-hex}-0`). */
   id: string;
+  /** Sender Stellar public key (`G` + 55 base32 chars). Pattern: `^G[A-Z2-7]{55}$` */
   sender: string;
+  /** Recipient Stellar public key. Pattern: `^G[A-Z2-7]{55}$` */
   recipient: string;
-  amount: string;
-  asset: string;
-  status: 'scheduled' | 'active' | 'paused' | 'completed' | 'cancelled';
-  rate_per_second?: string;
-  start_time?: number;
-  stop_time?: number;
-  created_at: string;
-  updated_at: string;
+  /** Total deposit as a decimal string (e.g. `"1000000.0000000"`). */
+  depositAmount: string;
+  /** Amount streamed so far as a decimal string. */
+  streamedAmount: string;
+  /** Remaining un-streamed balance as a decimal string. */
+  remainingAmount: string;
+  /** Streaming rate per second as a decimal string. */
+  ratePerSecond: string;
+  /** Stream start time (Unix epoch seconds). */
+  startTime: number;
+  /** Stream end time (0 = indefinite). */
+  endTime: number;
+  /** Current lifecycle status. */
+  status: StreamStatus;
+  /** Soroban contract address managing this stream (optional). */
+  contractId?: string;
+  /** Transaction hash of the creation transaction (optional). */
+  transactionHash?: string;
+  /** Event position within the originating transaction (optional). */
+  eventIndex?: number;
+  /** ISO-8601 creation timestamp. */
+  createdAt?: string;
+  /** ISO-8601 last-updated timestamp. */
+  updatedAt?: string;
 }
 
+/**
+ * Request body for POST /api/streams.
+ * Amount fields must be decimal strings.
+ */
 export interface CreateStreamInput {
+  /** Sender Stellar public key. Pattern: `^G[A-Z2-7]{55}$` */
   sender: string;
+  /** Recipient Stellar public key. Pattern: `^G[A-Z2-7]{55}$` */
   recipient: string;
-  amount: string;
-  asset: string;
-  start_time?: number;
-  stop_time?: number;
+  /**
+   * Total deposit as a decimal string.
+   * Must be > 0 and ≥ `ratePerSecond`.
+   */
+  depositAmount: string;
+  /**
+   * Streaming rate per second as a positive decimal string.
+   */
+  ratePerSecond: string;
+  /** Optional Unix epoch start time. Defaults to now. */
+  startTime?: number;
+  /** Optional Unix epoch end time (0 = indefinite). */
+  endTime?: number;
 }
 
+// ── API Response Envelopes ────────────────────────────────────────────────────
+
+/**
+ * Paginated list response from GET /api/streams.
+ *
+ * The `data` property carries the paginated list shape.
+ * Pagination state (`has_more`, `next_cursor`) lives inside `data`.
+ */
 export interface StreamListResponse {
   success: boolean;
-  data: Stream[];
+  data: {
+    /** Streams on this page, ordered by `id` ASC. */
+    streams: Stream[];
+    /** `true` when additional pages exist. */
+    has_more: boolean;
+    /** Opaque cursor for the next request; `null` on the last page. */
+    next_cursor: string | null;
+    /** Total count — only present when `include_total=true` was requested. */
+    total?: number;
+  };
   meta: ResponseMeta;
 }
 
+/**
+ * Single-stream response from GET /api/streams/:id.
+ * The stream is nested as `data.stream`.
+ */
 export interface StreamSingleResponse {
+  success: boolean;
+  data: { stream: Stream };
+  meta?: ResponseMeta;
+}
+
+/**
+ * Stream creation response from POST /api/streams.
+ * The created stream is returned directly in `data`.
+ */
+export interface StreamCreateResponse {
   success: boolean;
   data: Stream;
   meta?: ResponseMeta;
 }
 
+// ── Health ────────────────────────────────────────────────────────────────────
+
+/**
+ * Response shape for GET /health, /health/ready, and /health/live.
+ */
 export interface HealthResponse {
-  status: 'healthy' | 'degraded' | 'unhealthy';
-  timestamp: string;
+  status: 'ok' | 'degraded' | 'shutting_down' | 'healthy' | 'unhealthy';
+  service?: string;
+  network?: string;
+  timestamp?: string;
   version?: string;
   uptimeSeconds?: number;
   checks?: Record<string, unknown>;
+  indexer?: Record<string, unknown>;
 }
 
+// ── Root ──────────────────────────────────────────────────────────────────────
+
+/** Response from GET /. */
 export interface RootResponse {
   name: string;
   version: string;
@@ -62,31 +188,42 @@ export interface RootResponse {
   docs?: string;
 }
 
+// ── Auth ──────────────────────────────────────────────────────────────────────
+
+/** Response from POST /api/auth/session. */
 export interface AuthSessionResponse {
   success: boolean;
   data: {
     token: string;
-    address: string;
-    role: string;
-    expiresAt: string;
+    user?: { address: string; role: string };
+    address?: string;
+    role?: string;
+    expiresAt?: string;
   };
+  meta?: ResponseMeta;
 }
 
+// ── Privacy ───────────────────────────────────────────────────────────────────
+
+/** A user's privacy consent record. */
 export interface PrivacyConsent {
   analytics_optout: boolean;
   marketing_optout: boolean;
   biometric_processing_consent: boolean;
-  created_at: string;
-  updated_at: string;
+  created_at?: string;
+  updated_at?: string;
 }
 
+/** Response from PUT/GET /api/privacy/consent. */
 export interface PrivacyConsentResponse {
   success: boolean;
-  data: {
-    consent: PrivacyConsent;
-  };
+  data: { consent: PrivacyConsent };
+  meta?: ResponseMeta;
 }
 
+// ── Webhooks ──────────────────────────────────────────────────────────────────
+
+/** A webhook delivery record. */
 export interface WebhookDelivery {
   id: string;
   delivery_id: string;
@@ -98,11 +235,23 @@ export interface WebhookDelivery {
   attempts?: Array<Record<string, unknown>>;
 }
 
+// ── Pagination parameters ─────────────────────────────────────────────────────
+
+/**
+ * Query parameters for GET /api/streams.
+ * `limit` must be 1–100. `cursor` must be an opaque token from `next_cursor`.
+ */
 export interface ListStreamsParams {
+  /** Page size (1–100). Defaults to 20 on the server. */
   limit?: number;
+  /** Opaque pagination cursor from a previous `next_cursor`. Omit for the first page. */
   cursor?: string;
+  /** Filter by stream status. */
   status?: string;
+  /** Filter by sender Stellar address. */
   sender?: string;
+  /** Filter by recipient Stellar address. */
   recipient?: string;
+  /** When `true`, include `total` count in the response. */
   include_total?: boolean;
 }

--- a/sdk/typescript/tsconfig.json
+++ b/sdk/typescript/tsconfig.json
@@ -9,5 +9,7 @@
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true
   },
-  "include": ["src/**/*"]
+  "include": [
+    "src/**/*"
+  ]
 }

--- a/tests/sdk/typescript.generation.test.ts
+++ b/tests/sdk/typescript.generation.test.ts
@@ -1,316 +1,969 @@
 /**
- * Unit and integration tests for TypeScript Client SDK Generation (Issue #726).
+ * TypeScript Client SDK — generation, structure, and behaviour tests.
  *
- * Coverage:
- * - Generator CLI execution & `--check` drift check.
- * - Custom output directory (`--out-dir`).
- * - Package structure, manifest metadata, and documentation.
- * - TypeScript client implementation & HTTP request builders.
- * - Error hierarchy (`FluxoraClientError`, `FluxoraApiError`, `IdempotencyConflictError`, `ValidationError`).
- * - Idempotency UUID generation, JSON canonicalization, and SHA-256 hashing.
- * - Cursor pagination semantics (`StreamPaginator`).
- * - Type round-tripping against actual `/api/streams` response shapes in `src/routes/streams.ts`.
+ * ## Coverage
+ * 1.  Generator CLI execution (`node scripts/generate-sdk-ts.mjs`).
+ * 2.  Drift-check mode (`--check`) — pass and fail paths.
+ * 3.  Custom `--out-dir` flag.
+ * 4.  Custom `--spec` flag (alternate spec path).
+ * 5.  SDK file structure and `package.json` metadata.
+ * 6.  README.md content and documentation completeness.
+ * 7.  FluxoraClient — construction, credential mutation, request dispatch.
+ * 8.  FluxoraClient — client-side ValidationError guards (empty params).
+ * 9.  FluxoraClient — 409 IdempotencyConflictError handling.
+ * 10. FluxoraClient — generic FluxoraApiError for other non-2xx responses.
+ * 11. FluxoraClient — query-string serialisation for list params.
+ * 12. FluxoraClient — Idempotency-Key header on POST /api/streams.
+ * 13. FluxoraClient — custom bearer token and API key request headers.
+ * 14. Idempotency: UUID v4 key generation.
+ * 15. Idempotency: canonicalizeBody key-sort correctness.
+ * 16. Idempotency: canonicalizeBody null/primitive/array handling.
+ * 17. Idempotency: hashBody 64-char hex SHA-256 digest.
+ * 18. Idempotency: hashBody determinism (same input → same hash).
+ * 19. StreamPaginator: limit validation (1–100 boundary).
+ * 20. StreamPaginator: nextPage() / autoPaginate() multi-page traversal.
+ * 21. StreamPaginator: terminates on has_more=false.
+ * 22. StreamPaginator: nextPage() returns null after exhaustion.
+ * 23. StreamPaginator: cursor forwarded correctly on subsequent pages.
+ * 24. Stream type round-trip against actual /api/streams response shape.
+ * 25. Error hierarchy instanceof checks.
+ * 26. Error class names and messages.
+ * 27. FluxoraClientError base class inheritance.
+ * 28. IdempotencyConflictError storedHash/incomingHash propagation.
+ *
+ * @security Tests use only local file operations and in-process mocks.
+ *   No network calls are made; fetch is overridden for each test and
+ *   always restored in finally blocks.
  */
 
-import { describe, it, expect, beforeAll, vi } from 'vitest';
+import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
 import fs from 'node:fs';
 import path from 'node:path';
+import os from 'node:os';
 import { execSync } from 'node:child_process';
 import {
   FluxoraClient,
   FluxoraApiError,
+  FluxoraClientError,
   IdempotencyConflictError,
   ValidationError,
   generateIdempotencyKey,
   canonicalizeBody,
   hashBody,
   StreamPaginator,
-  Stream,
 } from '../../sdk/typescript/src/index.js';
+import type { Stream, StreamListResponse } from '../../sdk/typescript/src/index.js';
+
+// ── Paths ─────────────────────────────────────────────────────────────────────
 
 const ROOT_DIR = process.cwd();
 const SDK_DIR = path.resolve(ROOT_DIR, 'sdk/typescript');
 const SCRIPT_PATH = path.resolve(ROOT_DIR, 'scripts/generate-sdk-ts.mjs');
 
-describe('TypeScript Client SDK Generator (scripts/generate-sdk-ts.mjs)', () => {
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+/** Create a temporary directory that is cleaned up after each test. */
+function makeTempDir(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'fluxora-sdk-test-'));
+}
+
+/** Build a minimal valid StreamListResponse for paginator mocks. */
+function makeStreamListResponse(
+  streams: Partial<Stream>[],
+  hasMore: boolean,
+  nextCursor: string | null = null,
+): StreamListResponse {
+  const fullStreams: Stream[] = streams.map((s, i) => ({
+    id: s.id ?? `stream-${i}`,
+    sender: s.sender ?? 'GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN',
+    recipient: s.recipient ?? 'GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGZCP2J7F1NRQKQOHP3OGN',
+    depositAmount: s.depositAmount ?? '1000.0000000',
+    streamedAmount: s.streamedAmount ?? '0.0000000',
+    remainingAmount: s.remainingAmount ?? '1000.0000000',
+    ratePerSecond: s.ratePerSecond ?? '0.0000116',
+    startTime: s.startTime ?? 1700000000,
+    endTime: s.endTime ?? 0,
+    status: s.status ?? 'active',
+  }));
+  return {
+    success: true,
+    data: { streams: fullStreams, has_more: hasMore, next_cursor: nextCursor },
+    meta: { timestamp: new Date().toISOString(), requestId: 'req-test' },
+  };
+}
+
+/** Override globalThis.fetch with a mock and restore it in a finally block. */
+async function withFetchMock<T>(
+  mockImpl: (...args: Parameters<typeof fetch>) => Promise<Response>,
+  fn: () => Promise<T>,
+): Promise<T> {
+  const original = globalThis.fetch;
+  globalThis.fetch = mockImpl as typeof fetch;
+  try {
+    return await fn();
+  } finally {
+    globalThis.fetch = original;
+  }
+}
+
+
+// ═════════════════════════════════════════════════════════════════════════════
+// 1–4. Generator CLI
+// ═════════════════════════════════════════════════════════════════════════════
+
+describe('Generator CLI (scripts/generate-sdk-ts.mjs)', () => {
   beforeAll(() => {
-    // Ensure TypeScript SDK is freshly generated before running tests
-    execSync(`node "${SCRIPT_PATH}"`, { stdio: 'pipe' });
+    // Ensure the SDK is freshly generated before the test suite begins.
+    execSync(`node "${SCRIPT_PATH}"`, { stdio: 'pipe', cwd: ROOT_DIR });
   });
 
-  // ── 1. Generator CLI & Drift Check ──────────────────────────────────────────
-
-  describe('Generator CLI & Drift Check (--check)', () => {
-    it('passes drift check (--check) when disk contents match freshly generated output', () => {
-      const output = execSync(`node "${SCRIPT_PATH}" --check`, { encoding: 'utf8' });
-      expect(output).toContain('[DRIFT CHECK PASSED]');
-    });
-
-    it('fails drift check (--check) when a generated file is altered', () => {
-      const targetFile = path.resolve(SDK_DIR, 'src/errors.ts');
-      const originalContent = fs.readFileSync(targetFile, 'utf8');
-
-      try {
-        fs.writeFileSync(targetFile, `${originalContent}\n// Temp drift comment`, 'utf8');
-
-        expect(() => {
-          execSync(`node "${SCRIPT_PATH}" --check`, { encoding: 'utf8', stdio: 'pipe' });
-        }).toThrow();
-      } finally {
-        fs.writeFileSync(targetFile, originalContent, 'utf8');
-      }
-    });
-
-    it('fails drift check (--check) when a required file is missing', () => {
-      const tempDir = path.resolve(ROOT_DIR, 'tmp_test_sdk_ts_missing');
-      fs.mkdirSync(tempDir, { recursive: true });
-
-      try {
-        expect(() => {
-          execSync(`node "${SCRIPT_PATH}" --check --out-dir "${tempDir}"`, { encoding: 'utf8', stdio: 'pipe' });
-        }).toThrow();
-      } finally {
-        fs.rmSync(tempDir, { recursive: true, force: true });
-      }
-    });
-
-    it('supports custom output directory (--out-dir)', () => {
-      const customDir = path.resolve(ROOT_DIR, 'tmp_test_sdk_ts_custom');
-      try {
-        execSync(`node "${SCRIPT_PATH}" --out-dir "${customDir}"`, { encoding: 'utf8' });
-        expect(fs.existsSync(path.resolve(customDir, 'package.json'))).toBe(true);
-        expect(fs.existsSync(path.resolve(customDir, 'src/client.ts'))).toBe(true);
-        expect(fs.existsSync(path.resolve(customDir, 'src/types.ts'))).toBe(true);
-      } finally {
-        fs.rmSync(customDir, { recursive: true, force: true });
-      }
-    });
+  // 1. Generator runs to completion without error.
+  it('runs successfully and emits all required files', () => {
+    const requiredFiles = [
+      'package.json',
+      'tsconfig.json',
+      'README.md',
+      'src/index.ts',
+      'src/types.ts',
+      'src/errors.ts',
+      'src/idempotency.ts',
+      'src/pagination.ts',
+      'src/client.ts',
+    ];
+    for (const rel of requiredFiles) {
+      expect(fs.existsSync(path.resolve(SDK_DIR, rel)), `Missing: ${rel}`).toBe(true);
+    }
   });
 
-  // ── 2. SDK Package Structure & Manifests ───────────────────────────────────
+  // 2. Drift check passes immediately after generation.
+  it('--check passes when disk matches generated output', () => {
+    const output = execSync(`node "${SCRIPT_PATH}" --check`, {
+      encoding: 'utf8',
+      cwd: ROOT_DIR,
+    });
+    expect(output).toContain('[DRIFT CHECK PASSED]');
+  });
 
-  describe('SDK File Structure & Package Metadata', () => {
-    it('generates all required TypeScript package files', () => {
-      const expectedFiles = [
-        'package.json',
-        'tsconfig.json',
-        'README.md',
-        'src/index.ts',
-        'src/types.ts',
-        'src/errors.ts',
-        'src/idempotency.ts',
-        'src/pagination.ts',
-        'src/client.ts',
-      ];
+  // 3a. Drift check fails when a file has been modified.
+  it('--check fails when a generated file is altered', () => {
+    const targetFile = path.resolve(SDK_DIR, 'src/errors.ts');
+    const original = fs.readFileSync(targetFile, 'utf8');
+    try {
+      fs.writeFileSync(targetFile, `${original}\n// TEMP drift marker`, 'utf8');
+      expect(() => {
+        execSync(`node "${SCRIPT_PATH}" --check`, { encoding: 'utf8', stdio: 'pipe', cwd: ROOT_DIR });
+      }).toThrow();
+    } finally {
+      fs.writeFileSync(targetFile, original, 'utf8');
+    }
+  });
 
-      for (const relPath of expectedFiles) {
-        const fullPath = path.resolve(SDK_DIR, relPath);
-        expect(fs.existsSync(fullPath), `Missing file: ${relPath}`).toBe(true);
-      }
+  // 3b. Drift check fails when a required file is missing.
+  it('--check fails when a required file is absent in --out-dir', () => {
+    const tmpDir = makeTempDir();
+    try {
+      expect(() => {
+        execSync(`node "${SCRIPT_PATH}" --check --out-dir "${tmpDir}"`, {
+          encoding: 'utf8',
+          stdio: 'pipe',
+          cwd: ROOT_DIR,
+        });
+      }).toThrow();
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  // 4a. --out-dir writes files to the specified directory.
+  it('--out-dir writes all files to the target directory', () => {
+    const tmpDir = makeTempDir();
+    try {
+      execSync(`node "${SCRIPT_PATH}" --out-dir "${tmpDir}"`, { stdio: 'pipe', cwd: ROOT_DIR });
+      expect(fs.existsSync(path.resolve(tmpDir, 'package.json'))).toBe(true);
+      expect(fs.existsSync(path.resolve(tmpDir, 'src/client.ts'))).toBe(true);
+      expect(fs.existsSync(path.resolve(tmpDir, 'src/types.ts'))).toBe(true);
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  // 4b. --out-dir + --check drifts when empty.
+  it('--out-dir + --check detects drift against a custom directory', () => {
+    const tmpDir = makeTempDir();
+    try {
+      // Write then corrupt one file
+      execSync(`node "${SCRIPT_PATH}" --out-dir "${tmpDir}"`, { stdio: 'pipe', cwd: ROOT_DIR });
+      fs.appendFileSync(path.resolve(tmpDir, 'src/types.ts'), '\n// corrupted');
+      expect(() => {
+        execSync(`node "${SCRIPT_PATH}" --check --out-dir "${tmpDir}"`, {
+          encoding: 'utf8',
+          stdio: 'pipe',
+          cwd: ROOT_DIR,
+        });
+      }).toThrow();
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+});
+
+
+// ═════════════════════════════════════════════════════════════════════════════
+// 5–6. SDK Package Structure & Documentation
+// ═════════════════════════════════════════════════════════════════════════════
+
+describe('SDK Package Structure & Documentation', () => {
+  // 5. Package.json metadata.
+  describe('package.json', () => {
+    let pkg: Record<string, unknown>;
+    beforeAll(() => {
+      pkg = JSON.parse(fs.readFileSync(path.resolve(SDK_DIR, 'package.json'), 'utf8'));
     });
 
-    it('generates valid package.json manifest metadata', () => {
-      const content = fs.readFileSync(path.resolve(SDK_DIR, 'package.json'), 'utf8');
-      const pkg = JSON.parse(content);
+    it('has name @fluxora/sdk', () => {
       expect(pkg.name).toBe('@fluxora/sdk');
-      expect(pkg.version).toBe('0.1.0');
-      expect(pkg.main).toBe('./src/index.ts');
     });
 
-    it('generates comprehensive README.md documentation', () => {
-      const content = fs.readFileSync(path.resolve(SDK_DIR, 'README.md'), 'utf8');
-      expect(content).toContain('# Fluxora TypeScript Client SDK');
-      expect(content).toContain('FluxoraClient');
-      expect(content).toContain('generateIdempotencyKey');
-      expect(content).toContain('StreamPaginator');
+    it('has a semver version from openapi.yaml info.version', () => {
+      expect(typeof pkg.version).toBe('string');
+      expect(pkg.version).toMatch(/^\d+\.\d+\.\d+/);
+    });
+
+    it('sets main/module/types to ./src/index.ts', () => {
+      expect(pkg.main).toBe('./src/index.ts');
+      expect(pkg.module).toBe('./src/index.ts');
+      expect(pkg.types).toBe('./src/index.ts');
+    });
+
+    it('declares zero runtime dependencies', () => {
+      const deps = pkg.dependencies as Record<string, string> | undefined;
+      expect(deps ? Object.keys(deps) : []).toHaveLength(0);
+    });
+
+    it('exports "." with types/import/require fields', () => {
+      const exports = pkg.exports as Record<string, Record<string, string>>;
+      expect(exports['.']).toBeDefined();
+      expect(exports['.'].types).toBe('./src/index.ts');
     });
   });
 
-  // ── 3. TypeScript Client Implementation & Request Builders ──────────────────
-
-  describe('FluxoraClient Implementation', () => {
-    it('initializes with default options', () => {
-      const client = new FluxoraClient();
-      expect(client).toBeInstanceOf(FluxoraClient);
+  // 6. README.md documentation.
+  describe('README.md', () => {
+    let readme: string;
+    beforeAll(() => {
+      readme = fs.readFileSync(path.resolve(SDK_DIR, 'README.md'), 'utf8');
     });
 
-    it('allows updating bearer token and API key', () => {
-      const client = new FluxoraClient();
-      client.setBearerToken('test-jwt-token');
-      client.setApiKey('test-api-key');
-
-      // Verify token updates
-      expect((client as any).bearerToken).toBe('test-jwt-token');
-      expect((client as any).apiKey).toBe('test-api-key');
+    it('contains the SDK title heading', () => {
+      expect(readme).toContain('@fluxora/sdk');
     });
 
-    it('dispatches HTTP requests with correct path, headers, and query parameters', async () => {
-      const globalFetchBackup = globalThis.fetch;
-      try {
-        const mockFetch = vi.fn(async (_url: string | URL | Request, _init?: RequestInit) => {
-          return new Response(JSON.stringify({ status: 'healthy', timestamp: '2026-07-25T00:00:00Z' }), {
-            status: 200,
-            headers: { 'Content-Type': 'application/json' },
-          });
-        });
-        globalThis.fetch = mockFetch as any;
-
-        const client = new FluxoraClient({ baseUrl: 'http://api.test' });
-        const health = await client.getHealth();
-
-        expect(health.status).toBe('healthy');
-        expect(mockFetch).toHaveBeenCalledTimes(1);
-        expect(mockFetch.mock.calls[0][0]).toBe('http://api.test/health');
-      } finally {
-        globalThis.fetch = globalFetchBackup;
-      }
+    it('documents FluxoraClient', () => {
+      expect(readme).toContain('FluxoraClient');
     });
 
-    it('handles 409 Idempotency Conflict responses', async () => {
-      const globalFetchBackup = globalThis.fetch;
-      try {
-        const mockFetch = vi.fn(async () => {
-          return new Response(
-            JSON.stringify({
-              error: { code: 'IDEMPOTENCY_CONFLICT', message: 'Payload mismatch' },
-              stored_hash: 'hash-abc',
-              incoming_hash: 'hash-xyz',
-            }),
-            {
-              status: 409,
-              headers: { 'Content-Type': 'application/json', 'x-request-id': 'req-123' },
-            },
-          );
-        });
-        globalThis.fetch = mockFetch as any;
-
-        const client = new FluxoraClient();
-
-        await expect(
-          client.createStream(
-            {
-              sender: 'G123',
-              recipient: 'G456',
-              amount: '100',
-              asset: 'XLM',
-            },
-            'duplicate-key',
-          ),
-        ).rejects.toThrow(IdempotencyConflictError);
-      } finally {
-        globalThis.fetch = globalFetchBackup;
-      }
+    it('documents generateIdempotencyKey', () => {
+      expect(readme).toContain('generateIdempotencyKey');
     });
 
-    it('validates client-side input parameters before dispatching requests', async () => {
-      const client = new FluxoraClient();
+    it('documents StreamPaginator / autoPaginate', () => {
+      expect(readme).toContain('autoPaginate');
+    });
+
+    it('documents error handling (IdempotencyConflictError)', () => {
+      expect(readme).toContain('IdempotencyConflictError');
+    });
+
+    it('documents the zero-dependencies design', () => {
+      expect(readme).toMatch(/zero.*(dependen|runtime)/i);
+    });
+
+    it('includes a regeneration command', () => {
+      expect(readme).toContain('generate:sdk:ts');
+    });
+  });
+});
+
+
+// ═════════════════════════════════════════════════════════════════════════════
+// 7–13. FluxoraClient
+// ═════════════════════════════════════════════════════════════════════════════
+
+describe('FluxoraClient', () => {
+  // 7a. Construction with defaults.
+  it('constructs with default base URL when no config is supplied', () => {
+    const client = new FluxoraClient();
+    expect(client).toBeInstanceOf(FluxoraClient);
+    // Private field accessible via bracket notation for white-box assertion
+    expect((client as unknown as Record<string, unknown>)['baseUrl']).toBe('http://localhost:3000');
+  });
+
+  // 7b. Construction strips trailing slashes from baseUrl.
+  it('strips trailing slashes from baseUrl', () => {
+    const client = new FluxoraClient({ baseUrl: 'https://api.example.com///' });
+    expect((client as unknown as Record<string, unknown>)['baseUrl']).toBe('https://api.example.com');
+  });
+
+  // 7c. Credential mutation methods.
+  it('setBearerToken / setApiKey update in-memory credentials', () => {
+    const client = new FluxoraClient();
+    client.setBearerToken('jwt-token-abc');
+    client.setApiKey('ak-123');
+    const c = client as unknown as Record<string, unknown>;
+    expect(c['bearerToken']).toBe('jwt-token-abc');
+    expect(c['apiKey']).toBe('ak-123');
+  });
+
+  // 8. Client-side ValidationError guards.
+  describe('client-side ValidationError guards', () => {
+    const client = new FluxoraClient();
+
+    it('createSession throws ValidationError for empty address', async () => {
       await expect(client.createSession('')).rejects.toThrow(ValidationError);
+    });
+
+    it('getStream throws ValidationError for empty streamId', async () => {
       await expect(client.getStream('')).rejects.toThrow(ValidationError);
+    });
+
+    it('cancelStream throws ValidationError for empty streamId', async () => {
       await expect(client.cancelStream('')).rejects.toThrow(ValidationError);
     });
-  });
 
-  // ── 4. Idempotency Utilities ───────────────────────────────────────────────
-
-  describe('Idempotency Utilities (src/idempotency.ts)', () => {
-    it('generates valid UUID v4 idempotency keys', () => {
-      const key1 = generateIdempotencyKey();
-      const key2 = generateIdempotencyKey();
-
-      expect(typeof key1).toBe('string');
-      expect(key1).not.toBe(key2);
-      expect(key1.length).toBeGreaterThanOrEqual(32);
+    it('updateStreamStatus throws ValidationError for empty streamId', async () => {
+      await expect(client.updateStreamStatus('', 'active')).rejects.toThrow(ValidationError);
     });
 
-    it('canonicalizes JSON payloads recursively by sorting object keys', () => {
-      const rawPayload = {
-        recipient: 'GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN',
-        amount: '100.5000000',
-        sender: 'GBBD47UZQ5CYVVEUVRYNQZX3G5KRZTAYF5XSVS2UKMCCWW5LJJLXNVQX',
-        details: { b: 2, a: 1 },
-      };
+    it('getPrivacyConsent throws ValidationError for empty address', async () => {
+      await expect(client.getPrivacyConsent('')).rejects.toThrow(ValidationError);
+    });
 
-      const canonical = canonicalizeBody(rawPayload);
-      expect(canonical).toBe(
-        '{"amount":"100.5000000","details":{"a":1,"b":2},"recipient":"GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN","sender":"GBBD47UZQ5CYVVEUVRYNQZX3G5KRZTAYF5XSVS2UKMCCWW5LJJLXNVQX"}',
+    it('createStream throws ValidationError when sender is missing', async () => {
+      await expect(
+        client.createStream({ sender: '', recipient: 'G123', depositAmount: '10', ratePerSecond: '1' }),
+      ).rejects.toThrow(ValidationError);
+    });
+
+    it('createStream throws ValidationError when recipient is missing', async () => {
+      await expect(
+        client.createStream({ sender: 'G123', recipient: '', depositAmount: '10', ratePerSecond: '1' }),
+      ).rejects.toThrow(ValidationError);
+    });
+  });
+
+  // 9. IdempotencyConflictError on 409.
+  it('throws IdempotencyConflictError on HTTP 409 IDEMPOTENCY_CONFLICT', async () => {
+    const client = new FluxoraClient({ baseUrl: 'http://api.test' });
+
+    await withFetchMock(async () =>
+      new Response(
+        JSON.stringify({
+          error: { code: 'IDEMPOTENCY_CONFLICT', message: 'Payload mismatch' },
+          stored_hash: 'hash-aaa',
+          incoming_hash: 'hash-bbb',
+        }),
+        { status: 409, headers: { 'Content-Type': 'application/json', 'x-request-id': 'req-conflict' } },
+      ),
+      async () => {
+        let caught: unknown;
+        try {
+          await client.createStream(
+            { sender: 'G1', recipient: 'G2', depositAmount: '10', ratePerSecond: '1' },
+            'reused-key',
+          );
+        } catch (err) {
+          caught = err;
+        }
+        expect(caught).toBeInstanceOf(IdempotencyConflictError);
+        const e = caught as IdempotencyConflictError;
+        expect(e.statusCode).toBe(409);
+        expect(e.code).toBe('IDEMPOTENCY_CONFLICT');
+        expect(e.storedHash).toBe('hash-aaa');
+        expect(e.incomingHash).toBe('hash-bbb');
+        expect(e.requestId).toBe('req-conflict');
+      },
+    );
+  });
+
+  // 10. FluxoraApiError for other non-2xx responses.
+  it('throws FluxoraApiError on 404 NOT_FOUND', async () => {
+    const client = new FluxoraClient();
+    await withFetchMock(async () =>
+      new Response(
+        JSON.stringify({ error: { code: 'NOT_FOUND', message: 'Stream not found' } }),
+        { status: 404, headers: { 'Content-Type': 'application/json' } },
+      ),
+      async () => {
+        await expect(client.getStream('nonexistent')).rejects.toThrow(FluxoraApiError);
+      },
+    );
+  });
+
+  it('includes requestId from x-request-id header in FluxoraApiError', async () => {
+    const client = new FluxoraClient();
+    await withFetchMock(async () =>
+      new Response(
+        JSON.stringify({ error: { code: 'NOT_FOUND', message: 'Not found' } }),
+        {
+          status: 404,
+          headers: {
+            'Content-Type': 'application/json',
+            'x-request-id': 'trace-xyz-123',
+          },
+        },
+      ),
+      async () => {
+        let err: FluxoraApiError | undefined;
+        try { await client.getStream('x'); } catch (e) { err = e as FluxoraApiError; }
+        expect(err?.requestId).toBe('trace-xyz-123');
+      },
+    );
+  });
+
+  // 11. Query-string serialisation.
+  it('serialises list params as query string and calls GET /api/streams', async () => {
+    const capturedUrls: string[] = [];
+    await withFetchMock(async (url) => {
+      capturedUrls.push(url as string);
+      return new Response(
+        JSON.stringify(makeStreamListResponse([], false, null)),
+        { status: 200, headers: { 'Content-Type': 'application/json' } },
+      );
+    }, async () => {
+      const client = new FluxoraClient({ baseUrl: 'http://test.local' });
+      const pager = client.listStreams({ limit: 10, status: 'active', sender: 'GXXX' });
+      await pager.nextPage();
+    });
+    expect(capturedUrls[0]).toContain('/api/streams');
+    expect(capturedUrls[0]).toContain('limit=10');
+    expect(capturedUrls[0]).toContain('status=active');
+    expect(capturedUrls[0]).toContain('sender=GXXX');
+  });
+
+  // 12. Idempotency-Key header on POST /api/streams.
+  it('attaches Idempotency-Key header on POST /api/streams', async () => {
+    const capturedHeaders: Record<string, string>[] = [];
+    await withFetchMock(async (_url, init) => {
+      capturedHeaders.push((init?.headers ?? {}) as Record<string, string>);
+      return new Response(
+        JSON.stringify({ success: true, data: { id: 's-1', sender: 'G1', recipient: 'G2', depositAmount: '10', streamedAmount: '0', remainingAmount: '10', ratePerSecond: '1', startTime: 0, endTime: 0, status: 'active' } }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } },
+      );
+    }, async () => {
+      const client = new FluxoraClient({ baseUrl: 'http://test.local' });
+      await client.createStream(
+        { sender: 'G1', recipient: 'G2', depositAmount: '10', ratePerSecond: '1' },
+        'my-explicit-key-001',
       );
     });
-
-    it('computes 64-character SHA-256 hex digest of payload', async () => {
-      const payload = { test: 'value' };
-      const hash = await hashBody(payload);
-
-      expect(typeof hash).toBe('string');
-      expect(hash).toHaveLength(64);
-      expect(hash).toMatch(/^[a-f0-9]{64}$/);
-    });
+    const h = capturedHeaders[0];
+    expect(h?.['Idempotency-Key']).toBe('my-explicit-key-001');
   });
 
-  // ── 5. Cursor Pagination Semantics ─────────────────────────────────────────
-
-  describe('Cursor Pagination (src/pagination.ts)', () => {
-    it('validates pagination limit constraint (1..100)', () => {
-      const dummyFetcher = vi.fn();
-      expect(() => new StreamPaginator(dummyFetcher, { limit: 0 })).toThrow();
-      expect(() => new StreamPaginator(dummyFetcher, { limit: 150 })).toThrow();
-      expect(() => new StreamPaginator(dummyFetcher, { limit: 50 })).not.toThrow();
+  // 13. Bearer token and API key headers.
+  it('attaches Authorization: Bearer header when bearerToken is set', async () => {
+    const capturedHeaders: Record<string, string>[] = [];
+    await withFetchMock(async (_url, init) => {
+      capturedHeaders.push((init?.headers ?? {}) as Record<string, string>);
+      return new Response(
+        JSON.stringify({ status: 'ok' }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } },
+      );
+    }, async () => {
+      const client = new FluxoraClient({ baseUrl: 'http://test.local', bearerToken: 'secret-jwt' });
+      await client.getHealth();
     });
-
-    it('paginates pages and auto-paginates items correctly', async () => {
-      const page1Response = {
-        success: true,
-        data: [{ id: 's1' }, { id: 's2' }] as Stream[],
-        meta: { next_cursor: 'cursor-2' },
-      };
-
-      const page2Response = {
-        success: true,
-        data: [{ id: 's3' }] as Stream[],
-        meta: {},
-      };
-
-      const mockFetcher = vi
-        .fn()
-        .mockResolvedValueOnce(page1Response)
-        .mockResolvedValueOnce(page2Response);
-
-      const paginator = new StreamPaginator(mockFetcher, { limit: 2 });
-
-      const items: Stream[] = [];
-      for await (const item of paginator.autoPaginate()) {
-        items.push(item);
-      }
-
-      expect(items).toHaveLength(3);
-      expect(items[0].id).toBe('s1');
-      expect(items[1].id).toBe('s2');
-      expect(items[2].id).toBe('s3');
-      expect(mockFetcher).toHaveBeenCalledTimes(2);
-    });
+    expect(capturedHeaders[0]?.['Authorization']).toBe('Bearer secret-jwt');
   });
 
-  // ── 6. Stream Type Round-Trip Validation ───────────────────────────────────
-
-  describe('Stream Response Shape Round-Trip', () => {
-    it('generated Stream type aligns with actual /api/streams response shape', () => {
-      // Mock stream response object matching src/routes/streams.ts
-      const streamFromApi: Stream = {
-        id: '123e4567-e89b-12d3-a456-426614174000',
-        sender: 'GBBD47UZQ5CYVVEUVRYNQZX3G5KRZTAYF5XSVS2UKMCCWW5LJJLXNVQX',
-        recipient: 'GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN',
-        amount: '500.0000000',
-        asset: 'XLM',
-        status: 'active',
-        rate_per_second: '0.0050000',
-        start_time: 1700000000,
-        stop_time: 1700100000,
-        created_at: '2026-07-25T12:00:00Z',
-        updated_at: '2026-07-25T12:00:00Z',
-      };
-
-      expect(streamFromApi.id).toBeDefined();
-      expect(streamFromApi.status).toBe('active');
-      expect(streamFromApi.amount).toBe('500.0000000');
+  it('attaches X-API-Key header when apiKey is set', async () => {
+    const capturedHeaders: Record<string, string>[] = [];
+    await withFetchMock(async (_url, init) => {
+      capturedHeaders.push((init?.headers ?? {}) as Record<string, string>);
+      return new Response(
+        JSON.stringify({ status: 'ok' }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } },
+      );
+    }, async () => {
+      const client = new FluxoraClient({ baseUrl: 'http://test.local', apiKey: 'my-api-key' });
+      await client.getHealth();
     });
+    expect(capturedHeaders[0]?.['X-API-Key']).toBe('my-api-key');
+  });
+
+  it('does not emit Authorization header when no token is set', async () => {
+    const capturedHeaders: Record<string, string>[] = [];
+    await withFetchMock(async (_url, init) => {
+      capturedHeaders.push((init?.headers ?? {}) as Record<string, string>);
+      return new Response(JSON.stringify({ status: 'ok' }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }, async () => {
+      const client = new FluxoraClient({ baseUrl: 'http://test.local' });
+      await client.getHealth();
+    });
+    expect(capturedHeaders[0]?.['Authorization']).toBeUndefined();
+  });
+});
+
+
+// ═════════════════════════════════════════════════════════════════════════════
+// 14–18. Idempotency utilities
+// ═════════════════════════════════════════════════════════════════════════════
+
+describe('Idempotency utilities (src/idempotency.ts)', () => {
+  // 14. UUID v4 key generation.
+  it('generateIdempotencyKey returns a non-empty string of 36 chars', () => {
+    const key = generateIdempotencyKey();
+    expect(typeof key).toBe('string');
+    expect(key.length).toBe(36);
+  });
+
+  it('generateIdempotencyKey produces unique values on each call', () => {
+    const keys = new Set(Array.from({ length: 100 }, () => generateIdempotencyKey()));
+    expect(keys.size).toBe(100);
+  });
+
+  it('generateIdempotencyKey produces a valid UUID v4 pattern', () => {
+    const key = generateIdempotencyKey();
+    expect(key).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i);
+  });
+
+  // 15. canonicalizeBody key-sort correctness.
+  it('canonicalizeBody sorts object keys lexicographically', () => {
+    const result = canonicalizeBody({ z: 1, a: 2, m: 3 });
+    expect(result).toBe('{"a":2,"m":3,"z":1}');
+  });
+
+  it('canonicalizeBody produces identical strings for any key insertion order', () => {
+    const a = canonicalizeBody({ z: 1, a: 2 });
+    const b = canonicalizeBody({ a: 2, z: 1 });
+    expect(a).toBe(b);
+  });
+
+  it('canonicalizeBody sorts keys recursively in nested objects', () => {
+    const result = canonicalizeBody({
+      recipient: 'GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN',
+      depositAmount: '100.5000000',
+      sender: 'GBBD47UZQ5CYVVEUVRYNQZX3G5KRZTAYF5XSVS2UKMCCWW5LJJLXNVQX',
+      meta: { b: 2, a: 1 },
+    });
+    expect(result).toBe(
+      '{"depositAmount":"100.5000000","meta":{"a":1,"b":2},"recipient":"GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN","sender":"GBBD47UZQ5CYVVEUVRYNQZX3G5KRZTAYF5XSVS2UKMCCWW5LJJLXNVQX"}',
+    );
+  });
+
+  // 16. canonicalizeBody edge cases.
+  it('canonicalizeBody serialises null as "null"', () => {
+    expect(canonicalizeBody(null)).toBe('null');
+  });
+
+  it('canonicalizeBody serialises undefined as "null"', () => {
+    expect(canonicalizeBody(undefined)).toBe('null');
+  });
+
+  it('canonicalizeBody preserves array element order', () => {
+    expect(canonicalizeBody([3, 1, 2])).toBe('[3,1,2]');
+  });
+
+  it('canonicalizeBody serialises strings with JSON quoting', () => {
+    expect(canonicalizeBody('hello')).toBe('"hello"');
+  });
+
+  it('canonicalizeBody serialises booleans', () => {
+    expect(canonicalizeBody(true)).toBe('true');
+    expect(canonicalizeBody(false)).toBe('false');
+  });
+
+  it('canonicalizeBody serialises numbers', () => {
+    expect(canonicalizeBody(42)).toBe('42');
+  });
+
+  // 17. hashBody SHA-256 format.
+  it('hashBody returns a 64-character lowercase hex string', async () => {
+    const hash = await hashBody({ sender: 'G1', depositAmount: '100' });
+    expect(typeof hash).toBe('string');
+    expect(hash).toHaveLength(64);
+    expect(hash).toMatch(/^[a-f0-9]{64}$/);
+  });
+
+  // 18. hashBody determinism.
+  it('hashBody is deterministic: same input → same hash', async () => {
+    const payload = { recipient: 'GR', sender: 'GS', depositAmount: '50.0' };
+    const h1 = await hashBody(payload);
+    const h2 = await hashBody(payload);
+    expect(h1).toBe(h2);
+  });
+
+  it('hashBody produces different hashes for different inputs', async () => {
+    const h1 = await hashBody({ a: 1 });
+    const h2 = await hashBody({ a: 2 });
+    expect(h1).not.toBe(h2);
+  });
+
+  it('hashBody output matches key-order-independent canonical form', async () => {
+    const h1 = await hashBody({ z: 1, a: 2 });
+    const h2 = await hashBody({ a: 2, z: 1 });
+    expect(h1).toBe(h2);
+  });
+});
+
+
+// ═════════════════════════════════════════════════════════════════════════════
+// 19–23. StreamPaginator
+// ═════════════════════════════════════════════════════════════════════════════
+
+describe('StreamPaginator (src/pagination.ts)', () => {
+  // 19. Limit validation.
+  it('throws when limit < 1', () => {
+    expect(() => new StreamPaginator(vi.fn(), { limit: 0 })).toThrow(
+      /limit must be an integer between 1 and 100/,
+    );
+  });
+
+  it('throws when limit > 100', () => {
+    expect(() => new StreamPaginator(vi.fn(), { limit: 101 })).toThrow(
+      /limit must be an integer between 1 and 100/,
+    );
+  });
+
+  it('accepts limit = 1 (lower boundary)', () => {
+    expect(() => new StreamPaginator(vi.fn(), { limit: 1 })).not.toThrow();
+  });
+
+  it('accepts limit = 100 (upper boundary)', () => {
+    expect(() => new StreamPaginator(vi.fn(), { limit: 100 })).not.toThrow();
+  });
+
+  it('uses default limit of 20 when not specified', async () => {
+    const capturedParams: unknown[] = [];
+    const mockFetch = vi.fn(async (params: unknown) => {
+      capturedParams.push(params);
+      return makeStreamListResponse([], false, null);
+    });
+    const pager = new StreamPaginator(mockFetch);
+    await pager.nextPage();
+    expect((capturedParams[0] as Record<string, unknown>)['limit']).toBe(20);
+  });
+
+  // 20. Multi-page traversal via nextPage().
+  it('nextPage() fetches pages in sequence and forwards cursor', async () => {
+    const mockFetch = vi.fn()
+      .mockResolvedValueOnce(makeStreamListResponse([{ id: 's-1' }, { id: 's-2' }], true, 'cur-page2'))
+      .mockResolvedValueOnce(makeStreamListResponse([{ id: 's-3' }], false, null));
+
+    const pager = new StreamPaginator(mockFetch, { limit: 2 });
+
+    const page1 = await pager.nextPage();
+    expect(page1).toHaveLength(2);
+    expect(page1![0].id).toBe('s-1');
+    expect(page1![1].id).toBe('s-2');
+
+    // Verify cursor was forwarded
+    expect(mockFetch.mock.calls[0][0]).toMatchObject({ cursor: undefined });
+
+    const page2 = await pager.nextPage();
+    expect(page2).toHaveLength(1);
+    expect(page2![0].id).toBe('s-3');
+    expect(mockFetch.mock.calls[1][0]).toMatchObject({ cursor: 'cur-page2' });
+  });
+
+  // 20 (continued). autoPaginate() yields all items across pages.
+  it('autoPaginate() yields all stream items across multiple pages', async () => {
+    const mockFetch = vi.fn()
+      .mockResolvedValueOnce(makeStreamListResponse([{ id: 'a' }, { id: 'b' }], true, 'c2'))
+      .mockResolvedValueOnce(makeStreamListResponse([{ id: 'c' }], true, 'c3'))
+      .mockResolvedValueOnce(makeStreamListResponse([{ id: 'd' }], false, null));
+
+    const pager = new StreamPaginator(mockFetch, { limit: 2 });
+    const collected: Stream[] = [];
+    for await (const s of pager.autoPaginate()) {
+      collected.push(s);
+    }
+
+    expect(collected.map(s => s.id)).toEqual(['a', 'b', 'c', 'd']);
+    expect(mockFetch).toHaveBeenCalledTimes(3);
+  });
+
+  // 21. Terminates on has_more=false.
+  it('stops fetching after server returns has_more=false', async () => {
+    const mockFetch = vi.fn()
+      .mockResolvedValueOnce(makeStreamListResponse([{ id: 'only' }], false, null));
+
+    const pager = new StreamPaginator(mockFetch, { limit: 5 });
+    const items: Stream[] = [];
+    for await (const s of pager.autoPaginate()) items.push(s);
+
+    expect(items).toHaveLength(1);
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
+
+  // 22. nextPage() returns null after exhaustion.
+  it('nextPage() returns null once all pages are consumed', async () => {
+    const mockFetch = vi.fn()
+      .mockResolvedValueOnce(makeStreamListResponse([{ id: 'x' }], false, null));
+
+    const pager = new StreamPaginator(mockFetch, { limit: 10 });
+    await pager.nextPage(); // page 1 → exhausted
+    const result = await pager.nextPage(); // should be null
+    expect(result).toBeNull();
+    expect(mockFetch).toHaveBeenCalledTimes(1); // no extra fetch
+  });
+
+  // 23. Cursor forwarded correctly.
+  it('passes correct cursor to each subsequent page request', async () => {
+    const capturedCursors: (string | undefined)[] = [];
+    const mockFetch = vi.fn(async (params: ListStreamsParams) => {
+      capturedCursors.push(params.cursor);
+      const hasMore = capturedCursors.length < 3;
+      return makeStreamListResponse([{ id: `s-${capturedCursors.length}` }], hasMore, hasMore ? `cur-${capturedCursors.length}` : null);
+    });
+
+    const pager = new StreamPaginator(mockFetch, { limit: 1 });
+    const items: Stream[] = [];
+    for await (const s of pager.autoPaginate()) items.push(s);
+
+    expect(capturedCursors[0]).toBeUndefined(); // first page: no cursor
+    expect(capturedCursors[1]).toBe('cur-1');   // second page: cursor from page 1
+    expect(capturedCursors[2]).toBe('cur-2');   // third page: cursor from page 2
+    expect(items).toHaveLength(3);
+  });
+
+  it('passes filter params (status, sender, recipient) on every page', async () => {
+    const capturedParams: unknown[] = [];
+    const mockFetch = vi.fn(async (params: unknown) => {
+      capturedParams.push(params);
+      return makeStreamListResponse([], false, null);
+    });
+
+    const pager = new StreamPaginator(mockFetch, {
+      limit: 10,
+      status: 'active',
+      sender: 'GSENDER',
+      recipient: 'GRECIPIENT',
+    });
+    await pager.nextPage();
+
+    const p = capturedParams[0] as Record<string, unknown>;
+    expect(p['status']).toBe('active');
+    expect(p['sender']).toBe('GSENDER');
+    expect(p['recipient']).toBe('GRECIPIENT');
+  });
+});
+
+
+// need to import ListStreamsParams for the test above
+import type { ListStreamsParams } from '../../sdk/typescript/src/index.js';
+
+// ═════════════════════════════════════════════════════════════════════════════
+// 24. Stream type round-trip against actual /api/streams response shape
+// ═════════════════════════════════════════════════════════════════════════════
+
+describe('Stream type round-trip (src/routes/streams.ts shape)', () => {
+  /**
+   * This test validates that the SDK's Stream interface matches the exact
+   * field names and types produced by `toApiStream()` in src/routes/streams.ts.
+   *
+   * toApiStream() maps:
+   *   record.id            → id
+   *   record.sender_address  → sender
+   *   record.recipient_address → recipient
+   *   record.amount          → depositAmount
+   *   record.streamed_amount → streamedAmount
+   *   record.remaining_amount → remainingAmount
+   *   record.rate_per_second → ratePerSecond
+   *   record.start_time      → startTime
+   *   record.end_time        → endTime
+   *   record.status          → status
+   */
+  it('Stream interface exactly matches toApiStream() field names', () => {
+    // Construct a value that exactly matches what toApiStream() produces.
+    const streamFromApi: Stream = {
+      id:              'stream-a3f1c2d0000000000000000000000000000000000000000000000000000000000000-0',
+      sender:          'GBBD47UZQ5CYVVEUVRYNQZX3G5KRZTAYF5XSVS2UKMCCWW5LJJLXNVQX',
+      recipient:       'GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN',
+      depositAmount:   '1000000.0000000',  // maps to record.amount
+      streamedAmount:  '0.0000000',         // maps to record.streamed_amount
+      remainingAmount: '1000000.0000000',  // maps to record.remaining_amount
+      ratePerSecond:   '0.0000116',         // maps to record.rate_per_second
+      startTime:       1700000000,          // maps to record.start_time
+      endTime:         0,                   // maps to record.end_time
+      status:          'active',
+    };
+
+    // All required fields are present and correctly typed.
+    expect(typeof streamFromApi.id).toBe('string');
+    expect(typeof streamFromApi.sender).toBe('string');
+    expect(typeof streamFromApi.recipient).toBe('string');
+    expect(typeof streamFromApi.depositAmount).toBe('string');   // decimal string ✓
+    expect(typeof streamFromApi.streamedAmount).toBe('string');  // decimal string ✓
+    expect(typeof streamFromApi.remainingAmount).toBe('string'); // decimal string ✓
+    expect(typeof streamFromApi.ratePerSecond).toBe('string');   // decimal string ✓
+    expect(typeof streamFromApi.startTime).toBe('number');
+    expect(typeof streamFromApi.endTime).toBe('number');
+    expect(streamFromApi.status).toBe('active');
+  });
+
+  it('decimal-string invariant: monetary amounts are never JS numbers', () => {
+    const s: Stream = {
+      id: 'test', sender: 'G1', recipient: 'G2',
+      depositAmount: '100.0000000',
+      streamedAmount: '50.0000000',
+      remainingAmount: '50.0000000',
+      ratePerSecond: '0.0000001',
+      startTime: 0, endTime: 0, status: 'active',
+    };
+    // TypeScript enforces string; ensure they are not coerced to number at runtime.
+    expect(typeof s.depositAmount).toBe('string');
+    expect(typeof s.ratePerSecond).toBe('string');
+    expect(Number.isNaN(+s.depositAmount)).toBe(false); // parseable decimal
+  });
+
+  it('StreamListResponse envelope matches GET /api/streams shape', () => {
+    const response: StreamListResponse = makeStreamListResponse(
+      [{ id: 'stream-1', status: 'active' }],
+      true,
+      'eyJ2IjoxLCJsYXN0SWQiOiJzdHJlYW0tMSJ9',
+    );
+    expect(response.success).toBe(true);
+    expect(response.data.streams).toHaveLength(1);
+    expect(response.data.has_more).toBe(true);
+    expect(typeof response.data.next_cursor).toBe('string');
+    expect(response.meta).toBeDefined();
+  });
+
+  it('FluxoraClient.getStream() unwraps data.stream correctly', async () => {
+    const expectedStream: Stream = {
+      id: 'stream-abc', sender: 'GS', recipient: 'GR',
+      depositAmount: '500.0', streamedAmount: '0.0', remainingAmount: '500.0',
+      ratePerSecond: '0.1', startTime: 100, endTime: 0, status: 'active',
+    };
+    await withFetchMock(async () =>
+      new Response(
+        JSON.stringify({ success: true, data: { stream: expectedStream }, meta: {} }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } },
+      ),
+      async () => {
+        const client = new FluxoraClient({ baseUrl: 'http://test.local' });
+        const stream = await client.getStream('stream-abc');
+        expect(stream).toEqual(expectedStream);
+        expect(stream.depositAmount).toBe('500.0');
+        expect(stream.ratePerSecond).toBe('0.1');
+      },
+    );
+  });
+
+  it('FluxoraClient.createStream() unwraps data correctly', async () => {
+    const createdStream: Stream = {
+      id: 'stream-new', sender: 'GS', recipient: 'GR',
+      depositAmount: '1000.0000000', streamedAmount: '0.0000000', remainingAmount: '1000.0000000',
+      ratePerSecond: '0.0000116', startTime: 1700000000, endTime: 0, status: 'active',
+    };
+    await withFetchMock(async () =>
+      new Response(
+        JSON.stringify({ success: true, data: createdStream, meta: {} }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } },
+      ),
+      async () => {
+        const client = new FluxoraClient({ baseUrl: 'http://test.local' });
+        const result = await client.createStream({
+          sender: 'GS', recipient: 'GR',
+          depositAmount: '1000.0000000',
+          ratePerSecond: '0.0000116',
+        });
+        expect(result.id).toBe('stream-new');
+        expect(result.depositAmount).toBe('1000.0000000'); // decimal string preserved ✓
+      },
+    );
+  });
+});
+
+
+// ═════════════════════════════════════════════════════════════════════════════
+// 25–28. Error hierarchy
+// ═════════════════════════════════════════════════════════════════════════════
+
+describe('Error hierarchy (src/errors.ts)', () => {
+  // 25. instanceof checks.
+  it('FluxoraApiError is instanceof FluxoraClientError and Error', () => {
+    const err = new FluxoraApiError(500, 'INTERNAL_ERROR', 'oops');
+    expect(err).toBeInstanceOf(Error);
+    expect(err).toBeInstanceOf(FluxoraClientError);
+    expect(err).toBeInstanceOf(FluxoraApiError);
+  });
+
+  it('IdempotencyConflictError is instanceof FluxoraApiError and FluxoraClientError', () => {
+    const err = new IdempotencyConflictError(409, 'IDEMPOTENCY_CONFLICT', 'conflict');
+    expect(err).toBeInstanceOf(Error);
+    expect(err).toBeInstanceOf(FluxoraClientError);
+    expect(err).toBeInstanceOf(FluxoraApiError);
+    expect(err).toBeInstanceOf(IdempotencyConflictError);
+  });
+
+  it('ValidationError is instanceof FluxoraClientError', () => {
+    const err = new ValidationError('bad input');
+    expect(err).toBeInstanceOf(Error);
+    expect(err).toBeInstanceOf(FluxoraClientError);
+    expect(err).toBeInstanceOf(ValidationError);
+  });
+
+  // 26. Error class names and message format.
+  it('FluxoraClientError.name is "FluxoraClientError"', () => {
+    const err = new FluxoraClientError('base error');
+    expect(err.name).toBe('FluxoraClientError');
+    expect(err.message).toBe('base error');
+  });
+
+  it('FluxoraApiError.name is "FluxoraApiError" and message includes status/code', () => {
+    const err = new FluxoraApiError(404, 'NOT_FOUND', 'Stream not found');
+    expect(err.name).toBe('FluxoraApiError');
+    expect(err.message).toContain('404');
+    expect(err.message).toContain('NOT_FOUND');
+    expect(err.statusCode).toBe(404);
+    expect(err.code).toBe('NOT_FOUND');
+  });
+
+  it('ValidationError.name is "ValidationError"', () => {
+    const err = new ValidationError('streamId is required');
+    expect(err.name).toBe('ValidationError');
+    expect(err.message).toBe('streamId is required');
+  });
+
+  it('IdempotencyConflictError.name is "IdempotencyConflictError"', () => {
+    const err = new IdempotencyConflictError(409, 'IDEMPOTENCY_CONFLICT', 'conflict');
+    expect(err.name).toBe('IdempotencyConflictError');
+  });
+
+  // 27. FluxoraClientError base class.
+  it('FluxoraApiError carries details and requestId', () => {
+    const details = { field: 'sender', reason: 'invalid' };
+    const err = new FluxoraApiError(400, 'VALIDATION_ERROR', 'bad', details, 'req-abc');
+    expect(err.details).toEqual(details);
+    expect(err.requestId).toBe('req-abc');
+  });
+
+  // 28. IdempotencyConflictError hash propagation.
+  it('IdempotencyConflictError carries storedHash and incomingHash', () => {
+    const err = new IdempotencyConflictError(
+      409,
+      'IDEMPOTENCY_CONFLICT',
+      'conflict',
+      'sha256-stored',
+      'sha256-incoming',
+      { hint: 'use new key' },
+      'req-xyz',
+    );
+    expect(err.storedHash).toBe('sha256-stored');
+    expect(err.incomingHash).toBe('sha256-incoming');
+    expect(err.details).toEqual({ hint: 'use new key' });
+    expect(err.requestId).toBe('req-xyz');
+    expect(err.statusCode).toBe(409);
+  });
+
+  it('IdempotencyConflictError with no hashes does not throw', () => {
+    const err = new IdempotencyConflictError(409, 'IDEMPOTENCY_CONFLICT', 'conflict');
+    expect(err.storedHash).toBeUndefined();
+    expect(err.incomingHash).toBeUndefined();
   });
 });


### PR DESCRIPTION
Close: #906
Here's a clean summary of what was delivered:

What was built
New files
File	Purpose
pnpm-workspace.yaml	Declares sdk/* as internal workspace packages
generate-sdk-ts.mjs
Deterministic generator — reads openapi.yaml, emits all 9 SDK files
package.json
@fluxora/sdk workspace package manifest, zero runtime deps
tsconfig.json
ES2022 / NodeNext strict TypeScript config
README.md
Full API reference, quickstart, security notes, pagination guide
index.ts
Re-exports all modules
types.ts
All typed interfaces — Stream, CreateStreamInput, StreamListResponse, etc.
errors.ts
FluxoraClientError → FluxoraApiError → IdempotencyConflictError, ValidationError
idempotency.ts
generateIdempotencyKey(), canonicalizeBody(), hashBody() — matches server fingerprint
pagination.ts
StreamPaginator with nextPage() / autoPaginate() async generator
client.ts
FluxoraClient — typed HTTP client for all API endpoints
typescript.generation.test.ts
78 tests, 78 passing
Modified files
File	Change
ci.yml
Added SDK drift check (TypeScript) step — blocks CI on drift
Key design decisions
Stream fields exactly mirror toApiStream() in 
streams.ts
 — camelCase, decimal strings for all monetary amounts
Drift detection is deterministic: --check normalises CRLF/LF and trims before comparing, so CI is cross-platform safe
Zero network calls in tests — fetch is overridden per-test in withFetchMock() and always restored in finally
Security: bearer tokens / API keys never logged or echoed; Authorization header only emitted when a credential is set