### PR TITLE
fix: add missing webhookDeliveriesTotal counter to businessMetrics.ts

### DIFF
--- a/src/metrics/businessMetrics.ts
+++ b/src/metrics/businessMetrics.ts
@@ -88,6 +88,15 @@ export const webhookDeliveriesSuppressedTotal =
     registers: [registry],
   });
 
+export const webhookDeliveriesTotal =
+  (registry.getSingleMetric('fluxora_webhook_deliveries_total') as Counter<'outcome'>) ||
+  new Counter({
+    name: 'fluxora_webhook_deliveries_total',
+    help: 'Total number of webhook delivery attempts, labeled by outcome',
+    labelNames: ['outcome'] as const,
+    registers: [registry],
+  });
+
 export const webhookDeliveryDurationSeconds =
   (registry.getSingleMetric('fluxora_webhook_delivery_duration_seconds') as Histogram) ||
   new Histogram({


### PR DESCRIPTION
# Fix: Add missing `webhookDeliveriesTotal` counter (#873)

Closes #873 

## Problem

`src/webhooks/service.ts` imports `webhookDeliveriesTotal` from `businessMetrics.ts`, but the export was never defined. This causes a `TS2305` compile error and breaks the entire outbound webhook delivery pipeline at the build level.

## Root Cause

The metric name `fluxora_webhook_deliveries_total` was already referenced in the `deRegisterBusinessMetrics()` cleanup helper (line 281), confirming it was always intended — but the actual `Counter` export was never added to `businessMetrics.ts`.

## Fix

Added the missing `webhookDeliveriesTotal` Counter to `src/metrics/businessMetrics.ts`:

```ts
export const webhookDeliveriesTotal =
  (registry.getSingleMetric('fluxora_webhook_deliveries_total') as Counter<'outcome'>) ||
  new Counter({
    name: 'fluxora_webhook_deliveries_total',
    help: 'Total number of webhook delivery attempts, labeled by outcome',
    labelNames: ['outcome'] as const,
    registers: [registry],
  });
```

- **Prometheus name**: `fluxora_webhook_deliveries_total`
- **Labels**: `outcome` (`'success'` | `'failed'`) — matches existing usage in `service.ts`
- Follows the same registry pattern (idempotent get-or-create) used by all sibling metrics

## Acceptance Criteria

- [x] `src/webhooks/service.ts` compiles cleanly (TS2305 resolved)
- [x] `webhookDeliveriesTotal` is confirmed present in the Prometheus registry and incremented on delivery attempts at lines 405, 431, and 461 of `service.ts`

## Testing

- `tsc --noEmit` confirms no new type errors introduced
- Pre-existing errors in unrelated modules are unchanged
