### PR TITLE
test: simulate network-partitioned WebSocket clients and verify backp…

### DIFF
--- a/docs/websocket.md
+++ b/docs/websocket.md
@@ -1,5 +1,11 @@
 # WebSocket Streams
 
+<!--
+  NatSpec / doc-comment style: this file documents both the public WebSocket
+  protocol and internal resilience mechanisms, with explicit security and
+  testing notes for each component.
+-->
+
 Fluxora exposes real-time treasury stream updates on `/ws/streams` using standard WebSockets.
 
 ## Connection Handshake
@@ -176,6 +182,100 @@ hub.on('backpressure', (event) => {
 It also writes a structured `ws_backpressure` warning log with the same metadata.
 The event and log intentionally exclude payload bodies, JWTs, API keys, and raw
 request headers.
+
+## Network Partition Resilience
+
+Fluxora's `StreamHub` is designed to tolerate network-partitioned clients —
+clients whose TCP connection accepts writes into the kernel send buffer but
+never reads or acknowledges data. In production, this occurs when a client's
+network drops inbound packets while keeping the TCP socket half-open (e.g.
+unplugged Wi-Fi, firewall silences inbound traffic, client process hangs).
+
+### Detection via `bufferedAmount`
+
+The hub checks `ws.bufferedAmount` before every outbound frame. When the
+remote peer stops reading, the kernel buffer fills and `bufferedAmount` grows.
+The hub acts at two thresholds:
+
+| Threshold                        | Action                                              |
+| -------------------------------- | --------------------------------------------------- |
+| `BACKPRESSURE_DROP_BYTES` (1 MiB) | Drop the frame for that client.                    |
+| `BACKPRESSURE_TERMINATE_BYTES` (4 MiB) | Drop the frame, terminate the connection, clean up subscriptions. |
+
+Both thresholds are configurable per-hub instance via
+`StreamHubOptions.dropBytes` / `StreamHubOptions.terminateBytes` or at
+runtime with `hub.setBackpressureThresholds({ dropBytes, terminateBytes })`.
+
+### Per-connection isolation
+
+Backpressure is applied independently per connection. A partitioned client
+never blocks delivery to healthy subscribers on the same stream. The hub
+iterates subscribers in a tight loop and skips or terminates slow sockets
+without `await` — no slow client can stall the broadcast.
+
+### Events and observability
+
+Each drop or termination emits a `backpressure` event:
+
+```ts
+hub.on('backpressure', (event) => {
+  // { action: 'drop' | 'terminate', streamId, eventId,
+  //   connectionId, bufferedAmount, thresholdBytes, timestamp }
+});
+```
+
+A structured `ws_backpressure` warning log is written with the same metadata.
+Neither the event nor the log includes payload bodies, JWTs, or user
+identifiers.
+
+### Testing with simulated network partitions
+
+The test fixture in `tests/ws/fixtures/slowClient.ts` provides
+`simulatePartition()` which emulates a full TCP receive-window stall:
+
+1. Sets a `partitioned` flag on the raw socket's `write` override.
+2. Each `ws.send()` call from that point forward increments an internal
+   `bufferedAmount` counter instead of writing to the real socket.
+3. The overridden write returns `true` (data accepted into the simulated OS
+   buffer) but never fires drain callbacks — the remote peer never acks.
+4. The hub sees `bufferedAmount` grow naturally with each broadcast and
+   applies the same drop/terminate thresholds as in production.
+
+See `tests/ws/ws.networkPartition.test.ts` for comprehensive tests covering:
+
+- `bufferedAmount` accumulation per broadcast
+- Drop-threshold crossing with backpressure event emission
+- Terminate-threshold crossing with connection cleanup
+- Bounded delivery latency to healthy peers during partition
+- Multiple partitioned clients handled independently
+- Subscription state cleanup after partition-triggered termination
+
+Example usage in a test:
+
+```ts
+const slow = await createSlowClient(port, hub);
+slow.subscribe('my-stream');
+slow.simulatePartition();
+
+// Each broadcast increases bufferedAmount naturally
+await hub.broadcast({ streamId: 'my-stream', eventId: 'e1', payload: {} });
+expect(slow.getBufferedAmount()).toBeGreaterThan(0);
+
+// Eventually thresholds are crossed
+await hub.broadcast({ streamId: 'my-stream', eventId: 'e2', payload: {} });
+// → backpressure event emitted, client may be terminated
+```
+
+### Security notes (partition handling)
+
+- No per-client unbounded queuing: the hub never queues messages for slow
+  clients beyond a single broadcast cycle.
+- Terminated connections have their subscriptions fully cleaned up:
+  `streamSubscriptions`, `recipientSubscriptions`, and per-client batch
+  accumulators are all purged.
+- The `backpressure` event intentionally excludes payloads, JWTs, and PII.
+- All termination is unidirectional (server originates close) — a partitioned
+  client cannot force the hub to hold state.
 
 ## Security Notes
 

--- a/src/metrics/wsBackpressure.ts
+++ b/src/metrics/wsBackpressure.ts
@@ -1,22 +1,167 @@
-import { Histogram } from 'prom-client';
+import { Counter, Gauge, Histogram, register } from 'prom-client';
+
+/**
+ * Register a metric safely, reusing an existing registration if one exists.
+ * This is necessary because tests that use `vi.resetModules()` may re-import
+ * this module multiple times, which would otherwise throw "already registered".
+ */
+function metric<T>(name: string, factory: () => T): T {
+  const existing = register.getSingleMetric(name);
+  if (existing) return existing as unknown as T;
+  return factory();
+}
 
 /**
  * Histogram tracking the age of the oldest event in a batch when flushed.
  * Buckets are tuned specifically for sub-second to low-second micro-batching windows.
  */
-export const wsBroadcastBatchFlushLatencySeconds = new Histogram({
-  name: 'fluxora_ws_broadcast_batch_flush_seconds',
-  help: 'Latency (in seconds) from the oldest event enqueued to the moment the batch is flushed to WebSockets.',
-  buckets: [0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5],
-});
+export const wsBroadcastBatchFlushLatencySeconds = metric(
+  'fluxora_ws_broadcast_batch_flush_seconds',
+  () =>
+    new Histogram({
+      name: 'fluxora_ws_broadcast_batch_flush_seconds',
+      help: 'Latency (in seconds) from the oldest event enqueued to the moment the batch is flushed to WebSockets.',
+      buckets: [0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5],
+    }),
+);
 
 /**
  * Helper to record batch flush latency in seconds.
- *
- * @param durationSeconds Latency in seconds.
  */
 export function recordWsBroadcastBatchFlushLatency(durationSeconds: number): void {
   if (durationSeconds >= 0) {
     wsBroadcastBatchFlushLatencySeconds.observe(durationSeconds);
   }
+}
+
+// ── Per-client backpressure gauge ─────────────────────────────────────────
+
+export const wsClientBufferedBytes = metric(
+  'fluxora_ws_backpressure_buffered_bytes',
+  () =>
+    new Gauge({
+      name: 'fluxora_ws_backpressure_buffered_bytes',
+      help: 'Current bufferedAmount per WebSocket connection.',
+      labelNames: ['connection_id'],
+    }),
+);
+
+export const wsMaxBufferedBytes = metric(
+  'fluxora_ws_max_buffered_bytes',
+  () =>
+    new Gauge({
+      name: 'fluxora_ws_max_buffered_bytes',
+      help: 'Maximum bufferedAmount across all connected WebSocket clients.',
+    }),
+);
+
+export const wsSlowClients = metric(
+  'fluxora_ws_slow_clients',
+  () =>
+    new Gauge({
+      name: 'fluxora_ws_slow_clients',
+      help: 'Number of WebSocket clients whose bufferedAmount exceeds the slow threshold.',
+    }),
+);
+
+// ── Subscription cardinality gauge ────────────────────────────────────────
+
+export const wsStreamSubscriberCount = metric(
+  'fluxora_ws_stream_subscriber_count',
+  () =>
+    new Gauge({
+      name: 'fluxora_ws_stream_subscriber_count',
+      help: 'Number of subscribers per stream (top-N capped).',
+      labelNames: ['stream_id'],
+    }),
+);
+
+// ── Batch flush counters ──────────────────────────────────────────────────
+
+export const wsBatchFlushTotal = metric(
+  'fluxora_ws_batch_flush_total',
+  () =>
+    new Counter({
+      name: 'fluxora_ws_batch_flush_total',
+      help: 'Total number of batch flushes (one frame emitted per flush).',
+    }),
+);
+
+export const wsBatchEventsCoalescedTotal = metric(
+  'fluxora_ws_batch_events_coalesced_total',
+  () =>
+    new Counter({
+      name: 'fluxora_ws_batch_events_coalesced_total',
+      help: 'Total number of individual events coalesced across all batch flushes.',
+    }),
+);
+
+export const wsBatchSizeExceededTotal = metric(
+  'fluxora_ws_batch_size_exceeded_total',
+  () =>
+    new Counter({
+      name: 'fluxora_ws_batch_size_exceeded_total',
+      help: 'Number of batch flushes triggered early by hitting the max-size cap.',
+    }),
+);
+
+// ── Constants ─────────────────────────────────────────────────────────────
+
+export const DEFAULT_WS_BACKPRESSURE_INTERVAL_MS = 5_000;
+export const DEFAULT_WS_SLOW_CLIENT_BYTES = 1 * 1024 * 1024;
+export const DEFAULT_WS_STREAM_CARDINALITY_TOP_N = 20;
+
+// ── Collection ────────────────────────────────────────────────────────────
+
+export function collectWsBackpressureMetrics(
+  hub: {
+    _getClients?: () => IterableIterator<[unknown, { id: string }]>;
+    _getStreamSubscriptions?: () => ReadonlyMap<string, Set<unknown>>;
+  },
+  slowThresholdBytes: number = DEFAULT_WS_SLOW_CLIENT_BYTES,
+  topN: number = DEFAULT_WS_STREAM_CARDINALITY_TOP_N,
+): void {
+  const clientIterator = hub._getClients?.();
+  if (clientIterator) {
+    let max = 0;
+    let slowCount = 0;
+
+    for (const [ws, state] of clientIterator) {
+      const socket = ws as { readyState?: number; bufferedAmount?: number };
+      if (socket.readyState !== 1) continue;
+
+      const ba = typeof socket.bufferedAmount === 'number' ? socket.bufferedAmount : 0;
+      wsClientBufferedBytes.set({ connection_id: state.id }, ba);
+
+      if (ba > max) max = ba;
+      if (ba > slowThresholdBytes) slowCount++;
+    }
+
+    wsMaxBufferedBytes.set(max);
+    wsSlowClients.set(slowCount);
+  }
+
+  const streamSubs = hub._getStreamSubscriptions?.();
+  if (streamSubs) {
+    const sorted = Array.from(streamSubs.entries())
+      .map(([id, set]) => [id, set.size] as const)
+      .sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]))
+      .slice(0, topN);
+
+    wsStreamSubscriberCount.reset();
+    for (const [id, count] of sorted) {
+      wsStreamSubscriberCount.set({ stream_id: id }, count);
+    }
+  }
+}
+
+export function removeWsClientBackpressureGauge(connectionId: string): void {
+  wsClientBufferedBytes.remove({ connection_id: connectionId });
+}
+
+export function resetWsBackpressureMetrics(): void {
+  wsClientBufferedBytes.reset();
+  wsMaxBufferedBytes.reset();
+  wsSlowClients.reset();
+  wsStreamSubscriberCount.reset();
 }

--- a/tests/ws/fixtures/slowClient.ts
+++ b/tests/ws/fixtures/slowClient.ts
@@ -16,6 +16,7 @@ export interface SlowClient {
   messages: unknown[];
   subscribe(streamId: string): void;
   setBufferedAmount(bytes: number): void;
+  getBufferedAmount(): number;
   releaseDrain(): void;
   simulatePartition(): void;
   restore(): void;
@@ -38,12 +39,25 @@ export function wait(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
+/**
+ * Compute byte length of a value passed to `net.Socket.write()`.
+ * Handles string and Buffer — the two types used by the `ws` library.
+ */
+function byteLengthOfWriteArg(arg: unknown): number {
+  if (typeof arg === 'string') return Buffer.byteLength(arg, 'utf8');
+  if (Buffer.isBuffer(arg)) return arg.length;
+  if (arg instanceof ArrayBuffer) return arg.byteLength;
+  if (ArrayBuffer.isView(arg)) return arg.byteLength;
+  return 0;
+}
+
 export async function createSlowClient(port: number, hub: StreamHub): Promise<SlowClient> {
   const client = await connectClient(port);
   const localPort = getClientLocalPort(client);
   const serverSocket = findServerSocket(hub, localPort);
   const messages: unknown[] = [];
   let bufferedAmount = 0;
+  let partitioned = false;
 
   client.on('message', (data) => {
     messages.push(JSON.parse(data.toString()));
@@ -58,7 +72,9 @@ export async function createSlowClient(port: number, hub: StreamHub): Promise<Sl
   const rawSocket = (serverSocket as ServerWebSocket)._socket;
   const originalWrite = rawSocket?.write?.bind(rawSocket);
   const queuedWriteCallbacks: Array<() => void> = [];
+
   const restore = (): void => {
+    partitioned = false;
     if (rawSocket && originalWrite) {
       rawSocket.write = originalWrite as typeof rawSocket.write;
     }
@@ -72,6 +88,20 @@ export async function createSlowClient(port: number, hub: StreamHub): Promise<Sl
   if (rawSocket?.write) {
     rawSocket.write = ((...args: unknown[]): boolean => {
       const callback = args.find((arg): arg is () => void => typeof arg === 'function');
+
+      if (partitioned) {
+        // Network partition mode: accept writes into the simulated OS buffer
+        // (return true), accumulate bytes as bufferedAmount, but never fire
+        // drain callbacks — the remote end never reads/acks.
+        const data = args[0];
+        if (data !== undefined) {
+          bufferedAmount += byteLengthOfWriteArg(data);
+        }
+        return true;
+      }
+
+      // Normal slow-client mode (legacy): queue the callback and signal
+      // backpressure by returning false.
       if (callback) queuedWriteCallbacks.push(callback);
       return false;
     }) as typeof rawSocket.write;
@@ -87,12 +117,15 @@ export async function createSlowClient(port: number, hub: StreamHub): Promise<Sl
     setBufferedAmount(bytes: number): void {
       bufferedAmount = bytes;
     },
+    getBufferedAmount(): number {
+      return bufferedAmount;
+    },
     simulatePartition(): void {
-      if (rawSocket && typeof rawSocket.pause === 'function') {
-        rawSocket.pause();
-      }
+      partitioned = true;
+      bufferedAmount = 0;
     },
     releaseDrain(): void {
+      partitioned = false;
       bufferedAmount = 0;
       if (rawSocket && originalWrite) {
         rawSocket.write = originalWrite as typeof rawSocket.write;

--- a/tests/ws/ws.networkPartition.test.ts
+++ b/tests/ws/ws.networkPartition.test.ts
@@ -1,15 +1,22 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import http from 'http';
-import { StreamHub } from '../../src/ws/hub.js';
+import { WebSocket } from 'ws';
+import {
+  StreamHub,
+  type StreamHubBackpressureEvent,
+} from '../../src/ws/hub.js';
 import { _resetLimiter } from '../../src/ws/connectionLimiter.js';
-import { createSlowClient, wait, type SlowClient } from './fixtures/slowClient.js';
+import {
+  connectClient,
+  createSlowClient,
+  sendJson,
+  wait,
+  type SlowClient,
+} from './fixtures/slowClient.js';
 
 function setup(): Promise<{ server: http.Server; hub: StreamHub; port: number }> {
   const server = http.createServer();
-  const hub = new StreamHub(server, {
-    dropBytes: 1024,
-    terminateBytes: 2048,
-  });
+  const hub = new StreamHub(server);
 
   return new Promise((resolve) => {
     server.listen(0, '127.0.0.1', () => {
@@ -29,54 +36,266 @@ describe('StreamHub Network Partition', () => {
   let server: http.Server;
   let hub: StreamHub;
   let port: number;
+  const slowClients: SlowClient[] = [];
+  const plainClients: WebSocket[] = [];
 
   beforeEach(async () => {
     ({ server, hub, port } = await setup());
     _resetLimiter();
+    hub._resetDedup();
+    hub._resetMetrics();
+    slowClients.length = 0;
+    plainClients.length = 0;
   });
 
   afterEach(async () => {
+    for (const sc of slowClients) {
+      try { sc.close(); } catch { /* ignore */ }
+    }
+    for (const ws of plainClients) {
+      try {
+        if (ws.readyState === WebSocket.OPEN || ws.readyState === WebSocket.CONNECTING) {
+          ws.close();
+        }
+      } catch { /* ignore */ }
+    }
+    await wait(50);
     _resetLimiter();
     await teardown(server, hub);
   });
 
-  it('correctly classifies backpressured connections and terminates them on network partition', async () => {
-    const slowClient = await createSlowClient(port, hub);
-    const streamId = 'partition-stream';
-    
-    slowClient.subscribe(streamId);
+  it('simulation: bufferedAmount grows with each broadcast in partition mode', async () => {
+    const slow = await createSlowClient(port, hub);
+    slowClients.push(slow);
+    slow.subscribe('accumulate');
     await wait(50);
 
-    // Simulate partition
-    slowClient.simulatePartition();
-    
-    // Send a message large enough to cross the terminate threshold
-    const largeMessage = 'A'.repeat(3000);
-    slowClient.setBufferedAmount(3000);
-    
-    // We can listen for the backpressure event
-    let backpressureEventTriggered = false;
-    hub.on('backpressure', (event) => {
-      if (event.action === 'terminate') {
-        backpressureEventTriggered = true;
+    expect(slow.getBufferedAmount()).toBe(0);
+
+    slow.simulatePartition();
+
+    await hub.broadcast({ streamId: 'accumulate', eventId: 'evt-1', payload: { seq: 1 } });
+    await wait(20);
+    const afterOne = slow.getBufferedAmount();
+    expect(afterOne).toBeGreaterThan(0);
+
+    await hub.broadcast({ streamId: 'accumulate', eventId: 'evt-2', payload: { seq: 2 } });
+    await wait(20);
+    const afterTwo = slow.getBufferedAmount();
+    expect(afterTwo).toBeGreaterThan(afterOne);
+  });
+
+  it('drops events for a partitioned client when bufferedAmount exceeds dropBytes', async () => {
+    hub.setBackpressureThresholds({ dropBytes: 600, terminateBytes: 50000 });
+    const events = collectBackpressureEvents(hub);
+
+    const slow = await createSlowClient(port, hub);
+    slowClients.push(slow);
+    slow.subscribe('drop-stream');
+    await wait(50);
+
+    slow.simulatePartition();
+
+    for (let i = 0; i < 15; i++) {
+      await hub.broadcast({ streamId: 'drop-stream', eventId: `evt-drop-${i}`, payload: { n: i } });
+    }
+    await wait(50);
+
+    const dropEvents = events.filter((e) => e.action === 'drop');
+    expect(dropEvents.length).toBeGreaterThan(0);
+
+    const metrics = hub.getMetrics();
+    expect(metrics.droppedMessages).toBeGreaterThan(0);
+    expect(metrics.terminatedConnections).toBe(0);
+    expect(hub.clientCount).toBe(1);
+  });
+
+  it('terminates a partitioned client when bufferedAmount exceeds terminateBytes', async () => {
+    hub.setBackpressureThresholds({ dropBytes: 50000, terminateBytes: 1200 });
+
+    const slow = await createSlowClient(port, hub);
+    slowClients.push(slow);
+    slow.subscribe('terminate-stream');
+    await wait(50);
+
+    let terminateFired = false;
+    hub.on('backpressure', (evt) => {
+      if ((evt as StreamHubBackpressureEvent).action === 'terminate') {
+        terminateFired = true;
       }
     });
 
-    // Send broadcast
-    await hub.broadcast({
-      streamId,
-      eventId: 'evt-large-1',
-      payload: { data: largeMessage }
-    });
+    slow.simulatePartition();
 
-    // It should have terminated the client
+    for (let i = 0; i < 20; i++) {
+      await hub.broadcast({
+        streamId: 'terminate-stream',
+        eventId: `evt-term-${i}`,
+        payload: { n: i },
+      });
+      if (hub.clientCount === 0) break;
+    }
     await wait(50);
-    
-    expect(backpressureEventTriggered).toBe(true);
-    
-    // Subscription should be cleared
-    expect(hub.getStreamSubscriptionCount(streamId)).toBe(0);
-    
-    slowClient.close();
+
+    expect(terminateFired).toBe(true);
+
+    const metrics = hub.getMetrics();
+    expect(metrics.terminatedConnections).toBeGreaterThanOrEqual(1);
+
+    expect(hub.getStreamSubscriptionCount('terminate-stream')).toBe(0);
+    expect(hub.clientCount).toBe(0);
+  });
+
+  it('delivers to a healthy client with bounded latency while a partitioned peer is reaped', async () => {
+    hub.setBackpressureThresholds({ dropBytes: 50000, terminateBytes: 2000 });
+    const slowEvents = collectBackpressureEvents(hub);
+
+    const slow = await createSlowClient(port, hub);
+    slowClients.push(slow);
+    slow.subscribe('mixed-latency');
+    slow.simulatePartition();
+
+    const fast = await connectClient(port);
+    plainClients.push(fast);
+    const fastMessages: unknown[] = [];
+    fast.on('message', (data) => {
+      fastMessages.push(JSON.parse(data.toString()));
+    });
+    sendJson(fast, { type: 'subscribe', streamId: 'mixed-latency' });
+    await wait(50);
+
+    const latencies: number[] = [];
+
+    for (let i = 0; i < 20; i++) {
+      const before = Date.now();
+      await hub.broadcast({
+        streamId: 'mixed-latency',
+        eventId: `evt-latency-${i}`,
+        payload: { seq: i },
+      });
+      const after = Date.now();
+      latencies.push(after - before);
+
+      if (hub.clientCount === 0) break;
+    }
+    await wait(100);
+
+    const terminateEvents = slowEvents.filter((e) => e.action === 'terminate');
+    expect(terminateEvents.length).toBeGreaterThanOrEqual(1);
+
+    const healthyUpdates = fastMessages.filter(
+      (m) => (m as Record<string, unknown>).type === 'stream_update',
+    );
+    expect(healthyUpdates.length).toBeGreaterThanOrEqual(1);
+
+    for (const lat of latencies) {
+      expect(lat).toBeLessThan(500);
+    }
+  });
+
+  it('handles multiple partitioned clients independently', async () => {
+    hub.setBackpressureThresholds({ dropBytes: 50000, terminateBytes: 2000 });
+    const events = collectBackpressureEvents(hub);
+
+    const [slowA, slowB] = await Promise.all([
+      createSlowClient(port, hub),
+      createSlowClient(port, hub),
+    ]);
+    slowClients.push(slowA, slowB);
+    slowA.subscribe('multi-partition');
+    slowB.subscribe('multi-partition');
+    await wait(50);
+
+    slowA.simulatePartition();
+    slowB.simulatePartition();
+
+    for (let i = 0; i < 20; i++) {
+      await hub.broadcast({
+        streamId: 'multi-partition',
+        eventId: `evt-mp-${i}`,
+        payload: { n: i },
+      });
+      if (hub.clientCount === 0) break;
+    }
+    await wait(100);
+
+    const terminateEvents = events.filter((e) => e.action === 'terminate');
+    expect(terminateEvents.length).toBeGreaterThanOrEqual(2);
+
+    const metrics = hub.getMetrics();
+    expect(metrics.terminatedConnections).toBeGreaterThanOrEqual(2);
+  });
+
+  it('does not let a partitioned client block delivery to healthy subscribers', async () => {
+    hub.setBackpressureThresholds({ dropBytes: 50000, terminateBytes: 2000 });
+
+    const slow = await createSlowClient(port, hub);
+    slowClients.push(slow);
+    slow.subscribe('non-blocking');
+    slow.simulatePartition();
+
+    const fast = await connectClient(port);
+    plainClients.push(fast);
+    const fastMessages: unknown[] = [];
+    fast.on('message', (data) => {
+      fastMessages.push(JSON.parse(data.toString()));
+    });
+    sendJson(fast, { type: 'subscribe', streamId: 'non-blocking' });
+    await wait(50);
+
+    for (let i = 0; i < 20; i++) {
+      await hub.broadcast({
+        streamId: 'non-blocking',
+        eventId: `evt-nb-${i}`,
+        payload: { seq: i },
+      });
+      if (hub.clientCount === 0) break;
+    }
+    await wait(100);
+
+    const healthyUpdates = fastMessages.filter(
+      (m) => (m as Record<string, unknown>).type === 'stream_update',
+    );
+    expect(healthyUpdates.length).toBeGreaterThanOrEqual(1);
+
+    expect(hub.getMetrics().sentMessages).toBeGreaterThanOrEqual(1);
+  });
+
+  it('cleans up subscription state after partition-triggered termination', async () => {
+    hub.setBackpressureThresholds({ dropBytes: 50000, terminateBytes: 2000 });
+
+    const slow = await createSlowClient(port, hub);
+    slowClients.push(slow);
+    slow.subscribe('cleanup-stream');
+    await wait(50);
+
+    slow.simulatePartition();
+
+    for (let i = 0; i < 20; i++) {
+      await hub.broadcast({
+        streamId: 'cleanup-stream',
+        eventId: `evt-clean-${i}`,
+        payload: { n: i },
+      });
+      if (hub.clientCount === 0) break;
+    }
+    await wait(50);
+
+    expect(hub.getStreamSubscriptionCount('cleanup-stream')).toBe(0);
+    expect(hub.clientCount).toBe(0);
+
+    await hub.broadcast({
+      streamId: 'cleanup-stream',
+      eventId: 'evt-clean-after',
+      payload: { done: true },
+    });
   });
 });
+
+function collectBackpressureEvents(hub: StreamHub): StreamHubBackpressureEvent[] {
+  const events: StreamHubBackpressureEvent[] = [];
+  hub.on('backpressure', (event) => {
+    events.push(event as StreamHubBackpressureEvent);
+  });
+  return events;
+}


### PR DESCRIPTION
closes #927 

Extend the slow-client fixture (tests/ws/fixtures/slowClient.ts) with a simulatePartition() mode that tracks bufferedAmount growth on each ws.send() call without draining. Write comprehensive tests in tests/ws/ws.networkPartition.test.ts covering:

- Natural bufferedAmount accumulation across successive broadcasts
- Drop-threshold crossing (BACKPRESSURE_DROP_BYTES) with event emission
- Terminate-threshold crossing (BACKPRESSURE_TERMINATE_BYTES) with connection reaping and subscription cleanup
- Bounded (<500ms) delivery latency to healthy peers during partition reaping
- Independent handling of multiple partitioned clients
- Non-blocking delivery guarantee for healthy subscribers
- Full state cleanup after partition-triggered termination

Also fix pre-existing missing exports in src/metrics/wsBackpressure.ts (gauges, counters, collect/remove/reset functions required by hub.ts) and make metric registration tolerant of vi.resetModules() re-imports.

Update docs/websocket.md with Network Partition Resilience section.