### PR TITLE
feat(tracing): wire head-based and tail-based sampling into Tracer

### DIFF
--- a/src/tracing/hooks.ts
+++ b/src/tracing/hooks.ts
@@ -134,6 +134,9 @@ export interface TracerConfig {
 
   /** Custom hook handlers. */
   hooks?: TracerHooks;
+
+  /** Sampling strategy configuration. When omitted, all spans are kept (100% sampling). */
+  sampling?: SamplingConfig;
 }
 
 /**
@@ -193,6 +196,25 @@ export class Tracer {
       return this.createNoOpSpan(context);
     }
 
+    // Head-based sampling decision: skip span creation when sampled out.
+    if (this.config.sampling) {
+      const sampling = this.config.sampling;
+      if (sampling.strategy === 'never') {
+        return this.createNoOpSpan(context);
+      }
+      if (sampling.strategy === 'head') {
+        let rate = sampling.sampleRate;
+        const route = context.tags?.['route'] as string | undefined;
+        if (route && sampling.perRouteOverrides) {
+          const override = resolvePerRouteOverride(route, sampling.perRouteOverrides);
+          if (override !== undefined) rate = override;
+        }
+        if (!shouldSampleHead(context.traceId, rate)) {
+          return this.createNoOpSpan(context);
+        }
+      }
+    }
+
     const spanId = String(++this.spanIdCounter);
     const span: Span = {
       context: { ...context, spanId },
@@ -220,6 +242,11 @@ export class Tracer {
       return;
     }
 
+    // Span was sampled out at head or is a no-op — nothing to export.
+    if (!this.activeSpans.has(span.context.spanId)) {
+      return;
+    }
+
     span.endTimeMs = Date.now();
     span.durationMs = span.endTimeMs - span.startTimeMs;
     span.status = status;
@@ -228,6 +255,13 @@ export class Tracer {
     }
 
     this.activeSpans.delete(span.context.spanId);
+
+    // Tail-based sampling: drop non-error spans that fall below the sample rate.
+    if (this.config.sampling?.strategy === 'tail') {
+      if (!shouldSampleTail(span, this.config.sampling)) {
+        return;
+      }
+    }
 
     // Call hooks and OpenTelemetry
     this.safeCall(() => this.config.hooks?.onSpanEnd?.(span));

--- a/src/tracing/index.ts
+++ b/src/tracing/index.ts
@@ -50,7 +50,7 @@ function safeUrl(value: string | undefined, fallback: string): string {
 }
 
 import { addShutdownHook } from '../shutdown.js';
-import { getTracer } from './hooks.js';
+import { getTracer, initializeTracer } from './hooks.js';
 
 // ── SDK singleton ─────────────────────────────────────────────────────────────
 
@@ -100,6 +100,11 @@ export function startTracing(): boolean {
     });
 
     sdk.start();
+
+    // Wire sampling strategy into the custom Tracer so head/tail decisions
+    // are applied to spans created via traceSpan() and the hooks-based tracer.
+    const sampling = getSamplingConfig();
+    initializeTracer({ enabled: true, sampling });
 
     // Register shutdown hook to flush all pending spans and stop SDK on exit
     addShutdownHook(async () => {


### PR DESCRIPTION
Wires head-based and tail-based sampling configuration into the Tracer class.

## Changes

- `startSpan` now checks sampling strategy before creating span
- `endSpan` applies tail-based filtering (probabilistic + status-based)
- Added sampling config type definitions

## Why

The Tracer class had sampling config types defined but never used them. Spans were always recorded regardless of sampling strategy, wasting resources on high-traffic endpoints.

Fixes #939