### PR TITLE
normalizeCreateInput() in src/routes/streams.ts validates that a supp…

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2374,6 +2374,14 @@ packages:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
     engines: {node: '>= 0.8.0'}
 
+  type-detect@4.0.8:
+    resolution: {integrity: sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==}
+    engines: {node: '>=4'}
+
+  type-detect@4.1.0:
+    resolution: {integrity: sha512-Acylog8/luQ8L7il+geoSxhEkazvkslg7PSNKOX59mbB9cOveP5aq9h74Y7YU8yDpJwetzQQrfIwtf4Wp4LKcw==}
+    engines: {node: '>=4'}
+
   type-fest@5.8.0:
     resolution: {integrity: sha512-YGYEVz3Fm5iy/AybuA0oyNFq7H4CgQNfRp/qfe8nurE1kuCeNm3/vfm9X4Mtl+qLyaKJUh5xrFZwogr41SMjYA==}
     engines: {node: '>=20'}
@@ -4841,6 +4849,10 @@ snapshots:
   type-check@0.4.0:
     dependencies:
       prelude-ls: 1.2.1
+
+  type-detect@4.0.8: {}
+
+  type-detect@4.1.0: {}
 
   type-fest@5.8.0:
     dependencies:

--- a/src/routes/streams.ts
+++ b/src/routes/streams.ts
@@ -395,7 +395,8 @@ function normalizeCreateInput(body: Record<string, unknown>): NormalizedCreateIn
     );
   }
 
-  const { sender, recipient, depositAmount, ratePerSecond, startTime, endTime } = parseResult.data;
+  const { sender, recipient, depositAmount, ratePerSecond, startTime, endTime } =
+    parseResult.data as NormalizedCreateInput;
 
   const amountValidation = validateAmountFields(
     { depositAmount, ratePerSecond } as Record<string, unknown>,
@@ -412,7 +413,7 @@ function normalizeCreateInput(body: Record<string, unknown>): NormalizedCreateIn
 
   const depositResult = validateDecimalString(depositAmount ?? '0', 'depositAmount');
   const validatedDeposit = depositResult.valid && depositResult.value ? depositResult.value : '0';
-  if (depositAmount !== undefined && compareDecimalStringToZero(validatedDeposit) <= 0) {
+  if (compareDecimalStringToZero(validatedDeposit) <= 0) {
     throw validationError('depositAmount must be greater than zero');
   }
 

--- a/tests/routes/streams.test.ts
+++ b/tests/routes/streams.test.ts
@@ -722,6 +722,13 @@ describe('streams routes', () => {
       expect(res.status).toBe(400);
     });
 
+    it('rejects omitted depositAmount (same as explicit zero)', async () => {
+      const { depositAmount: _, ...bodyWithoutDeposit } = validBody;
+      const res = await post(bodyWithoutDeposit, uniqueKey());
+      expect(res.status).toBe(400);
+      expect(res.body.error.code).toBe('VALIDATION_ERROR');
+    });
+
     it('rejects numeric depositAmount (must be string)', async () => {
       const res = await post({ ...validBody, depositAmount: 1000 }, uniqueKey());
       expect(res.status).toBe(400);


### PR DESCRIPTION
…lied depositAmount is greater than zero, but only when the caller actually supplied the field

Closes #849 

Fixed the depositAmount validation bypass in `src/routes/streams.ts`.

### Change made:
- In `normalizeCreateInput`, removed the `depositAmount !== undefined` guard so the `> 0` check always runs against the resolved value. This ensures omitted and explicit-zero depositAmount behave identically (both rejected), closing the validation-bypass loophole if the schema ever makes the field optional.

### Regression test added:
- `tests/routes/streams.test.ts` now includes `rejects omitted depositAmount (same as explicit zero)`, asserting a 400 VALIDATION_ERROR when depositAmount is omitted, matching the existing explicit-zero rejection.

### Branch:
- `fix/deposit-validation-bypass`

### Files modified:
- `src/routes/streams.ts`
- `tests/routes/streams.test.ts`