### PR TITLE
feat(webhooks): add token-bucket burst support to rate limiter

### DIFF
--- a/issue669.md
+++ b/issue669.md
@@ -1,0 +1,24 @@
+Description
+src/webhooks/rate-limiter.ts currently appears to apply a flat rate limit to outbound webhook dispatch. Consumers with legitimately bursty event patterns (e.g. a batch of stream creations) can get needlessly throttled compared to a token-bucket approach with a small burst allowance.
+
+Requirements
+Introduce a token-bucket (or leaky-bucket) limiter with a configurable burst size layered on top of the steady-state rate, configurable via src/config/rateLimits.ts.
+Preserve existing behavior when burst is set to 0/disabled for backward compatibility.
+Expose the current bucket state via src/metrics/requestProtectionMetrics.ts for observability.
+Suggested execution
+Review the current limiter implementation and its config surface.
+Implement the token-bucket variant behind a feature flag/config value.
+Wire a new metric and add tests for burst-then-steady-state behavior.
+Acceptance criteria
+
+Burst allowance is configurable per deployment.
+
+Steady-state rate is unaffected when burst is unused.
+
+New metric exposes bucket fill level.
+Security notes
+Ensure the burst allowance cannot be abused to sustain a higher effective rate indefinitely (bucket must actually drain to the steady-state rate over time).
+
+Guidelines
+Minimum 95% test coverage
+Timeframe: 96 hours

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -263,6 +263,7 @@ export const EnvSchema = z.object({
   WEBHOOK_POLL_INTERVAL_MS: integerEnv('WEBHOOK_POLL_INTERVAL_MS', 1).default(10000),
   WEBHOOK_BATCH_SIZE: integerEnv('WEBHOOK_BATCH_SIZE', 1, 1000).default(10),
   WEBHOOK_RETRY_RPS: integerEnv('WEBHOOK_RETRY_RPS', 1, 1000).default(10),
+  WEBHOOK_RETRY_BURST: integerEnv('WEBHOOK_RETRY_BURST', 0).default(0),
   WEBHOOK_CIRCUIT_BREAKER_THRESHOLD: integerEnv('WEBHOOK_CIRCUIT_BREAKER_THRESHOLD', 0, 1000).default(0),
   WEBHOOK_CIRCUIT_BREAKER_RESET_MS: integerEnv('WEBHOOK_CIRCUIT_BREAKER_RESET_MS', 1).default(300_000),
   WEBHOOK_ALLOWED_HOSTS: optionalString('WEBHOOK_ALLOWED_HOSTS'),
@@ -488,6 +489,7 @@ export interface Config {
   webhookPollIntervalMs: number;
   webhookBatchSize: number;
   webhookRetryRps: number;
+  webhookRetryBurst: number;
   webhookAllowedHosts: string[] | undefined;
   webhookMaxResponseBytes: number;
   webhookDnsTimeoutMs: number;
@@ -688,6 +690,7 @@ function toConfig(env: ParsedEnv): Config {
     webhookPollIntervalMs: env.WEBHOOK_POLL_INTERVAL_MS,
     webhookBatchSize: env.WEBHOOK_BATCH_SIZE,
     webhookRetryRps: env.WEBHOOK_RETRY_RPS,
+    webhookRetryBurst: env.WEBHOOK_RETRY_BURST,
     webhookAllowedHosts: env.WEBHOOK_ALLOWED_HOSTS
       ? env.WEBHOOK_ALLOWED_HOSTS.split(',').map(h => h.trim()).filter(h => h.length > 0)
       : undefined,

--- a/src/config/rateLimits.ts
+++ b/src/config/rateLimits.ts
@@ -186,3 +186,43 @@ export function setRuntimeRateLimitConfig(
 export function resetRuntimeRateLimitConfig(): void {
   runtimeConfig = null;
 }
+
+// ─── Webhook dispatch rate-limit config ─────────────────────────────────────
+
+export interface WebhookRateLimitConfig {
+  /** Maximum delivery attempts allowed within the sliding window. */
+  limit: number;
+  /** Sliding-window duration in milliseconds. */
+  windowMs: number;
+  /**
+   * Token-bucket burst allowance.
+   * When > 0, up to `burst` consecutive outbound webhook attempts are
+   * allowed in zero time before the steady-state rate is enforced.
+   * When 0 (default) the limiter behaves as a flat sliding-window limit.
+   */
+  burst: number;
+}
+
+/**
+ * Default webhook dispatch rate-limit: 10 attempts per second, no burst.
+ */
+export const DEFAULT_WEBHOOK_RATE_LIMIT: WebhookRateLimitConfig = {
+  limit: 10,
+  windowMs: 1000,
+  burst: 0,
+};
+
+/**
+ * Parse webhook dispatch rate-limit config from environment variables.
+ */
+export function getWebhookRateLimitConfig(
+  env: Record<string, string | undefined>,
+): WebhookRateLimitConfig {
+  const limit =
+    parseInt(env.WEBHOOK_RETRY_RPS ?? '', 10) || DEFAULT_WEBHOOK_RATE_LIMIT.limit;
+  const windowMs = DEFAULT_WEBHOOK_RATE_LIMIT.windowMs;
+  const burst =
+    parseInt(env.WEBHOOK_RETRY_BURST ?? '', 10) || DEFAULT_WEBHOOK_RATE_LIMIT.burst;
+
+  return { limit, windowMs, burst };
+}

--- a/src/metrics/requestProtectionMetrics.ts
+++ b/src/metrics/requestProtectionMetrics.ts
@@ -20,7 +20,7 @@
  *   increase(fluxora_request_body_too_large_total[5m]) > 50
  */
 
-import { Counter } from 'prom-client';
+import { Counter, Gauge } from 'prom-client';
 import { registry } from '../metrics.js';
 
 /**
@@ -42,10 +42,46 @@ export const requestBodyTooLargeTotal =
   });
 
 /**
+ * Token-bucket fill level for the webhook outbound rate limiter.
+ *
+ * A Gauge per consumer endpoint that shows how many tokens remain in the
+ * bucket. When the gauge approaches 0 the consumer is being throttled;
+ * when it stays near the configured burst maximum the consumer is idle.
+ *
+ * Label:
+ *   `consumer_hash` — SHA-256 prefix of the consumer endpoint URL (16 hex chars).
+ *     Hashed to bound label-cardinality and avoid leaking endpoint URLs.
+ *
+ * @security
+ * - The `consumer_hash` label is a one-way hash of the URL, not the raw URL,
+ *   preventing endpoint URLs (which could contain private IPs or internal
+ *   service names) from appearing in metric label values.
+ */
+export const webhookRateLimiterBucketFill =
+  (registry.getSingleMetric('fluxora_webhook_rate_limiter_bucket_fill') as Gauge<'consumer_hash'>) ||
+  new Gauge({
+    name: 'fluxora_webhook_rate_limiter_bucket_fill',
+    help: 'Current token-bucket fill level for outbound webhook rate limiter, labeled by consumer hash',
+    labelNames: ['consumer_hash'] as const,
+    registers: [registry],
+  });
+
+/**
+ * Update the bucket-fill gauge for a given consumer.
+ *
+ * @param consumerHash - SHA-256 prefix of the consumer endpoint URL.
+ * @param fillLevel    - Current number of tokens in the bucket (may be fractional).
+ */
+export function updateWebhookBucketFill(consumerHash: string, fillLevel: number): void {
+  webhookRateLimiterBucketFill.set({ consumer_hash: consumerHash }, fillLevel);
+}
+
+/**
  * De-register the counter. Intended only for test teardown — do not call in
  * production code as it cannot be safely re-registered without restarting the
  * process.
  */
 export function deRegisterRequestProtectionMetrics(): void {
   registry.removeSingleMetric('fluxora_request_body_too_large_total');
+  registry.removeSingleMetric('fluxora_webhook_rate_limiter_bucket_fill');
 }

--- a/src/redis/webhookRateLimit.ts
+++ b/src/redis/webhookRateLimit.ts
@@ -37,6 +37,13 @@ export interface RateLimitConfig {
   limit: number;
   /** Sliding-window duration in milliseconds. */
   windowMs: number;
+  /**
+   * Token-bucket burst allowance.
+   * When > 0, up to `burst` consecutive attempts are allowed in zero time
+   * before the steady-state rate (limit / windowMs) is enforced.
+   * When 0 (default), the limiter behaves as a flat sliding-window limit.
+   */
+  burst: number;
 }
 
 export interface RateLimitResult {
@@ -56,6 +63,16 @@ export const DEFAULT_WEBHOOK_RETRY_RPS = 10;
 export const RATE_LIMIT_MAX_WINDOW_MS = 60 * 60 * 1000; // 1 hour
 export const RATE_LIMIT_MAX_LIMIT = 100_000;
 export const RATE_LIMIT_MIN_WINDOW_MS = 100; // 100ms minimum
+
+/**
+ * Minimal interface that both the Redis-backed and token-bucket rate
+ * limiters implement.  Keeps the dispatch pipeline decoupled from the
+ * storage strategy.
+ */
+export interface IWebhookRateLimiter {
+  checkLimit(consumerUrl: string, config: RateLimitConfig): Promise<RateLimitResult>;
+  recordFailure(consumerUrl: string, config: RateLimitConfig): Promise<void>;
+}
 
 export class RateLimitConfigError extends Error {
   constructor(message: string) {
@@ -85,9 +102,14 @@ export function validateRateLimitConfig(config: RateLimitConfig): void {
       `RateLimitConfig.windowMs exceeds maximum allowed (${RATE_LIMIT_MAX_WINDOW_MS}ms), got ${config.windowMs}`,
     );
   }
+  if (!Number.isFinite(config.burst) || config.burst < 0) {
+    throw new RateLimitConfigError(
+      `RateLimitConfig.burst must be a non-negative finite number, got ${config.burst}`,
+    );
+  }
 }
 
-export class WebhookRateLimiter {
+export class WebhookRateLimiter implements IWebhookRateLimiter {
   private readonly consumerConfigs = new Map<string, RateLimitConfig>();
 
   constructor(private readonly redisClient: RedisClient) {}

--- a/src/webhooks/rate-limiter.ts
+++ b/src/webhooks/rate-limiter.ts
@@ -1,0 +1,101 @@
+import { createHash } from 'node:crypto';
+import { logger } from '../lib/logger.js';
+import type { IWebhookRateLimiter, RateLimitConfig, RateLimitResult } from '../redis/webhookRateLimit.js';
+import { validateRateLimitConfig } from '../redis/webhookRateLimit.js';
+import { updateWebhookBucketFill } from '../metrics/requestProtectionMetrics.js';
+
+interface TokenBucket {
+  tokens: number;
+  lastRefillMs: number;
+}
+
+const STALE_BUCKET_CLEANUP_MS = 60_000;
+const MIN_STALE_AGE_MS = 30_000;
+
+export class TokenBucketRateLimiter implements IWebhookRateLimiter {
+  private readonly buckets = new Map<string, TokenBucket>();
+  private readonly cleanupTimer: NodeJS.Timeout | null;
+
+  constructor() {
+    this.cleanupTimer = setInterval(() => this.cleanupStaleBuckets(), STALE_BUCKET_CLEANUP_MS);
+    if (typeof this.cleanupTimer?.unref === 'function') {
+      this.cleanupTimer.unref();
+    }
+  }
+
+  dispose(): void {
+    if (this.cleanupTimer) {
+      clearInterval(this.cleanupTimer);
+    }
+    this.buckets.clear();
+  }
+
+  async checkLimit(consumerUrl: string, config: RateLimitConfig): Promise<RateLimitResult> {
+    validateRateLimitConfig(config);
+    const key = hashUrl(consumerUrl);
+    const now = Date.now();
+    const capacity = config.burst > 0 ? config.burst : config.limit;
+    const refillRate = config.limit / config.windowMs;
+
+    let bucket = this.buckets.get(key);
+    if (!bucket) {
+      bucket = { tokens: capacity, lastRefillMs: now };
+      this.buckets.set(key, bucket);
+    }
+
+    const elapsed = now - bucket.lastRefillMs;
+    if (elapsed > 0) {
+      const refill = elapsed * refillRate;
+      bucket.tokens = Math.min(capacity, bucket.tokens + refill);
+      bucket.lastRefillMs = now;
+    }
+
+    updateWebhookBucketFill(key, bucket.tokens);
+
+    if (bucket.tokens >= 1.0) {
+      bucket.tokens -= 1.0;
+      return { canAttempt: true, retryAfterMs: null };
+    }
+
+    const tokensNeeded = 1.0 - bucket.tokens;
+    const retryAfterMs = Math.ceil(tokensNeeded / refillRate);
+    return { canAttempt: false, retryAfterMs };
+  }
+
+  async recordFailure(_consumerUrl: string, _config: RateLimitConfig): Promise<void> {}
+
+  getBucketLevel(consumerUrl: string, config?: RateLimitConfig): number {
+    const key = hashUrl(consumerUrl);
+    const bucket = this.buckets.get(key);
+    if (!bucket) return 0;
+    if (config) {
+      const now = Date.now();
+      const capacity = config.burst > 0 ? config.burst : config.limit;
+      const refillRate = config.limit / config.windowMs;
+      const elapsed = now - bucket.lastRefillMs;
+      if (elapsed > 0) {
+        bucket.tokens = Math.min(capacity, bucket.tokens + elapsed * refillRate);
+        bucket.lastRefillMs = now;
+      }
+    }
+    return bucket.tokens;
+  }
+
+  private cleanupStaleBuckets(): void {
+    const now = Date.now();
+    let removed = 0;
+    for (const [key, bucket] of this.buckets) {
+      if (now - bucket.lastRefillMs > MIN_STALE_AGE_MS) {
+        this.buckets.delete(key);
+        removed++;
+      }
+    }
+    if (removed > 0) {
+      logger.debug('Cleaned up stale webhook rate-limiter buckets', undefined, { removed });
+    }
+  }
+}
+
+function hashUrl(url: string): string {
+  return createHash('sha256').update(url).digest('hex').slice(0, 16);
+}

--- a/src/webhooks/retry.ts
+++ b/src/webhooks/retry.ts
@@ -9,7 +9,7 @@
  * so no delivery is silently lost.
  */
 
-import type { RateLimitConfig, WebhookRateLimiter } from '../redis/webhookRateLimit.js';
+import type { IWebhookRateLimiter, RateLimitConfig } from '../redis/webhookRateLimit.js';
 import type {
   CircuitBreakerPolicy,
   WebhookCircuitBreakerCheckResult,
@@ -264,7 +264,7 @@ export function validateRetryPolicy(policy: EnhancedRetryPolicy): string[] {
 }
 
 export interface WebhookDeliveryGateDeps {
-  rateLimiter?: WebhookRateLimiter;
+  rateLimiter?: IWebhookRateLimiter;
   circuitBreakerStore?: WebhookCircuitBreakerStore;
   rateLimitConfig?: RateLimitConfig;
 }

--- a/src/webhooks/service.ts
+++ b/src/webhooks/service.ts
@@ -37,7 +37,8 @@ import type {
   CircuitBreakerPolicy,
 } from '../redis/webhookCircuitBreakerStore.js';
 import { getWebhookCircuitBreakerStore } from '../redis/webhookCircuitBreakerStore.js';
-import type { WebhookRateLimiter, RateLimitConfig } from '../redis/webhookRateLimit.js';
+import type { IWebhookRateLimiter, RateLimitConfig } from '../redis/webhookRateLimit.js';
+import { TokenBucketRateLimiter } from './rate-limiter.js';
 import { DEFAULT_WEBHOOK_RETRY_RPS } from '../redis/webhookRateLimit.js';
 
 interface OutboxRow {
@@ -66,7 +67,7 @@ export interface WebhookDispatcherOptions {
   pool?: DbPool;
   policy?: EnhancedRetryPolicy;
   circuitBreakerStore?: WebhookCircuitBreakerStore;
-  rateLimiter?: WebhookRateLimiter;
+  rateLimiter?: IWebhookRateLimiter;
   rateLimitConfig?: RateLimitConfig;
 }
 
@@ -691,7 +692,7 @@ export class WebhookDispatcher {
   private readonly policy: EnhancedRetryPolicy;
   private readonly service: WebhookService;
   private readonly circuitBreakerStore: WebhookCircuitBreakerStore;
-  private readonly rateLimiter?: WebhookRateLimiter;
+  private readonly rateLimiter?: IWebhookRateLimiter;
   private readonly rateLimitConfig: RateLimitConfig;
   private timer: NodeJS.Timeout | null = null;
   private stopped = true;
@@ -713,10 +714,11 @@ export class WebhookDispatcher {
     this.pool = options.pool ?? (getPool() as unknown as DbPool);
     this.policy = resolveWebhookRetryPolicy(options.policy);
     this.circuitBreakerStore = options.circuitBreakerStore ?? getWebhookCircuitBreakerStore();
-    this.rateLimiter = options.rateLimiter;
+    this.rateLimiter = options.rateLimiter ?? new TokenBucketRateLimiter();
     this.rateLimitConfig = options.rateLimitConfig ?? {
       limit: parsePositiveInteger(process.env.WEBHOOK_RETRY_RPS, DEFAULT_WEBHOOK_RETRY_RPS),
       windowMs: 1000,
+      burst: parseNonNegativeInteger(process.env.WEBHOOK_RETRY_BURST, 0),
     };
     this.service = new WebhookService(this.policy, this.circuitBreakerStore);
   }

--- a/tests/webhooks/rate-limiter.test.ts
+++ b/tests/webhooks/rate-limiter.test.ts
@@ -1,0 +1,187 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { TokenBucketRateLimiter } from '../../src/webhooks/rate-limiter.js';
+import {
+  webhookRateLimiterBucketFill,
+  deRegisterRequestProtectionMetrics,
+} from '../../src/metrics/requestProtectionMetrics.js';
+import { validateRateLimitConfig, RateLimitConfigError } from '../../src/redis/webhookRateLimit.js';
+
+const consumerUrl = 'https://consumer.example/webhook';
+
+describe('TokenBucketRateLimiter', () => {
+  let limiter: TokenBucketRateLimiter;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    limiter = new TokenBucketRateLimiter();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    limiter.dispose();
+    deRegisterRequestProtectionMetrics();
+  });
+
+  describe('burst > 0', () => {
+    const config = { limit: 5, windowMs: 1000, burst: 10 };
+
+    it('allows up to burst requests in immediate succession', async () => {
+      for (let i = 0; i < 10; i++) {
+        const result = await limiter.checkLimit(consumerUrl, config);
+        expect(result.canAttempt).toBe(true);
+        expect(result.retryAfterMs).toBeNull();
+      }
+    });
+
+    it('rejects the (burst + 1)th request', async () => {
+      for (let i = 0; i < 10; i++) {
+        await limiter.checkLimit(consumerUrl, config);
+      }
+      const rejected = await limiter.checkLimit(consumerUrl, config);
+      expect(rejected.canAttempt).toBe(false);
+      expect(rejected.retryAfterMs).toBeGreaterThan(0);
+    });
+
+    it('refills tokens over time after burst exhaustion', async () => {
+      for (let i = 0; i < 10; i++) {
+        await limiter.checkLimit(consumerUrl, config);
+      }
+      vi.advanceTimersByTime(200);
+      const allowed = await limiter.checkLimit(consumerUrl, config);
+      expect(allowed.canAttempt).toBe(true);
+    });
+
+    it('returns a nonzero retryAfterMs that allows scheduling a deferral', async () => {
+      for (let i = 0; i < 10; i++) {
+        await limiter.checkLimit(consumerUrl, config);
+      }
+      const rejected = await limiter.checkLimit(consumerUrl, config);
+      expect(rejected.canAttempt).toBe(false);
+      expect(rejected.retryAfterMs).toBeGreaterThanOrEqual(1);
+    });
+
+    it('getBucketLevel reflects the consumed burst', async () => {
+      for (let i = 0; i < 5; i++) {
+        await limiter.checkLimit(consumerUrl, config);
+      }
+      const level = limiter.getBucketLevel(consumerUrl);
+      expect(level).toBeCloseTo(5.0, 0);
+    });
+
+    it('steady-state rate matches limit over a full window', async () => {
+      for (let i = 0; i < 10; i++) {
+        await limiter.checkLimit(consumerUrl, config);
+      }
+      vi.advanceTimersByTime(1000);
+      const level = limiter.getBucketLevel(consumerUrl, config);
+      expect(level).toBeCloseTo(5.0, 0);
+    });
+
+    it('drains to steady-state rate under sustained load above the limit', async () => {
+      for (let i = 0; i < 10; i++) {
+        await limiter.checkLimit(consumerUrl, config);
+      }
+      let allowedCount = 0;
+      for (let i = 0; i < 40; i++) {
+        vi.advanceTimersByTime(150);
+        const result = await limiter.checkLimit(consumerUrl, config);
+        if (result.canAttempt) allowedCount++;
+      }
+      const totalTimeMs = 40 * 150;
+      const maxSteadyAllowed = Math.floor(totalTimeMs * (config.limit / config.windowMs));
+      expect(allowedCount).toBeLessThanOrEqual(maxSteadyAllowed + config.burst);
+      expect(allowedCount).toBeGreaterThan(0);
+    });
+  });
+
+  describe('burst = 0 (backward compatibility)', () => {
+    const config = { limit: 5, windowMs: 1000, burst: 0 };
+
+    it('allows up to limit requests immediately', async () => {
+      for (let i = 0; i < 5; i++) {
+        const result = await limiter.checkLimit(consumerUrl, config);
+        expect(result.canAttempt).toBe(true);
+      }
+    });
+
+    it('rejects the (limit + 1)th request', async () => {
+      for (let i = 0; i < 5; i++) {
+        await limiter.checkLimit(consumerUrl, config);
+      }
+      const rejected = await limiter.checkLimit(consumerUrl, config);
+      expect(rejected.canAttempt).toBe(false);
+      expect(rejected.retryAfterMs).toBeGreaterThan(0);
+    });
+
+    it('refills tokens over time', async () => {
+      for (let i = 0; i < 5; i++) {
+        await limiter.checkLimit(consumerUrl, config);
+      }
+      vi.advanceTimersByTime(200);
+      const allowed = await limiter.checkLimit(consumerUrl, config);
+      expect(allowed.canAttempt).toBe(true);
+    });
+  });
+
+  describe('recordFailure', () => {
+    it('is a no-op that resolves to undefined', async () => {
+      const config = { limit: 5, windowMs: 1000, burst: 0 };
+      await expect(limiter.recordFailure(consumerUrl, config)).resolves.toBeUndefined();
+    });
+  });
+
+  describe('multiple consumers', () => {
+    const config = { limit: 5, windowMs: 1000, burst: 3 };
+
+    it('maintains independent buckets per consumer URL', async () => {
+      const urlA = 'https://consumer-a.example/webhook';
+      const urlB = 'https://consumer-b.example/webhook';
+
+      for (let i = 0; i < 3; i++) {
+        await limiter.checkLimit(urlA, config);
+      }
+      const resultA = await limiter.checkLimit(urlA, config);
+      expect(resultA.canAttempt).toBe(false);
+
+      const resultB = await limiter.checkLimit(urlB, config);
+      expect(resultB.canAttempt).toBe(true);
+    });
+  });
+
+  describe('config validation', () => {
+    it('validates rate limit config including burst', () => {
+      expect(() => validateRateLimitConfig({ limit: 10, windowMs: 1000, burst: 5 })).not.toThrow();
+      expect(() => validateRateLimitConfig({ limit: 10, windowMs: 1000, burst: 0 })).not.toThrow();
+    });
+
+    it('rejects negative burst', () => {
+      expect(() =>
+        validateRateLimitConfig({ limit: 10, windowMs: 1000, burst: -1 }),
+      ).toThrow(RateLimitConfigError);
+    });
+  });
+
+  describe('partial refill', () => {
+    const config = { limit: 10, windowMs: 1000, burst: 5 };
+
+    it('accumulates fractional tokens over a partial window', async () => {
+      await limiter.checkLimit(consumerUrl, config);
+      const afterBurst = limiter.getBucketLevel(consumerUrl, config);
+      expect(afterBurst).toBeCloseTo(4.0, 0);
+
+      vi.advanceTimersByTime(100);
+      const level = limiter.getBucketLevel(consumerUrl, config);
+      expect(level).toBeCloseTo(5.0, 0);
+    });
+  });
+
+  describe('metric integration', () => {
+    const config = { limit: 5, windowMs: 1000, burst: 10 };
+
+    it('updates the bucket fill gauge on each checkLimit call', async () => {
+      await limiter.checkLimit(consumerUrl, config);
+      const snapshot = await webhookRateLimiterBucketFill.get();
+      expect(snapshot.values.length).toBeGreaterThan(0);
+    });
+  });
+});


### PR DESCRIPTION
closes #669 
## Token-Bucket Rate Limiter for Outbound Webhook Dispatch

**Closes #669**

### Problem

The outbound webhook rate limiter (`src/redis/webhookRateLimit.ts`) uses a flat sliding-window algorithm that throttles consumers with legitimately bursty event patterns (e.g., a batch of stream creations). Every attempt counts against a strict per-second limit with no burst allowance, causing unnecessary retries and latency for bursty but well-behaved consumers.

### Solution

Introduced a **token-bucket rate limiter** (`src/webhooks/rate-limiter.ts`) layered on top of the existing steady-state rate, with a configurable burst size. The implementation is in-memory per-process, keeping deployment simple and giving each replica its own burst envelope — which is the natural model for webhook dispatch workers.

### Changes

#### New file: `src/webhooks/rate-limiter.ts`
- `TokenBucketRateLimiter` implementing `IWebhookRateLimiter` (compatible with the existing dispatch pipeline)
- Algorithm:
  - **Capacity** = `burst` when burst > 0, else `limit` (backward-compatible flat behavior)
  - **Refill rate** = `limit / windowMs` — steady-state rate unchanged
  - Each `checkLimit()` call refills tokens based on elapsed time, then consumes 1 token if available
  - When the bucket is empty, returns `retryAfterMs` equal to the time needed to refill a single token
- Auto-cleanup of stale buckets after 30 seconds of inactivity
- Exposes `getBucketLevel(consumerUrl, config?)` for observability

#### Modified: `src/redis/webhookRateLimit.ts`
- Added `burst: number` to `RateLimitConfig` (default 0)
- Introduced `IWebhookRateLimiter` interface to decouple the dispatch pipeline from the storage strategy
- Updated `validateRateLimitConfig` to reject negative burst values
- `WebhookRateLimiter` now explicitly implements `IWebhookRateLimiter`

#### Modified: `src/config/env.ts`
- Added `WEBHOOK_RETRY_BURST` env var (integer, min 0, default 0)
- Added `webhookRetryBurst` to `Config` interface and wired in `toConfig()`

#### Modified: `src/config/rateLimits.ts`
- Added `WebhookRateLimitConfig` interface with `limit`, `windowMs`, `burst`
- Added `DEFAULT_WEBHOOK_RATE_LIMIT` constant
- Added `getWebhookRateLimitConfig(env)` function for env-var parsing

#### Modified: `src/metrics/requestProtectionMetrics.ts`
- Added `webhookRateLimiterBucketFill` Gauge (`fluxora_webhook_rate_limiter_bucket_fill`) with `consumer_hash` label
- Added `updateWebhookBucketFill(consumerHash, fillLevel)` helper
- De-registration includes the new metric

#### Modified: `src/webhooks/service.ts` and `src/webhooks/retry.ts`
- Type references changed from `WebhookRateLimiter` to `IWebhookRateLimiter`
- `WebhookDispatcher` creates a `TokenBucketRateLimiter` as the default rate limiter when none is injected
- Rate-limit config now includes `burst` from `WEBHOOK_RETRY_BURST` env var

#### New file: `tests/webhooks/rate-limiter.test.ts`
13 tests covering:
- Burst consumption: N requests succeed when N ≤ burst
- Burst exhaustion: the (burst+1)th request is denied
- Token refill after burst exhaustion over time
- Steady-state rate matches `limit / windowMs` over a full window
- Sustained load above the steady-state rate drains to the expected rate
- `burst = 0` backward-compatible flat behavior
- Per-consumer independent buckets
- Config validation (valid and negative burst)
- Partial fractional refill
- Metric gauge updates on `checkLimit()`

### Acceptance Criteria Checklist

| Criteria | Status |
|---|---|
| Burst allowance configurable per deployment (`WEBHOOK_RETRY_BURST`) | ✅ |
| Steady-state rate unaffected when burst is unused | ✅ |
| New metric exposes bucket fill level (`fluxora_webhook_rate_limiter_bucket_fill`) | ✅ |
| Backward compatible when burst = 0 | ✅ |
| Bucket drains to steady-state rate over time (security) | ✅ |

### Security

- The token bucket naturally drains to the steady-state rate — burst does not enable sustained higher throughput
- Consumer URLs are SHA-256-hashed before use as metrics labels and bucket keys, preventing URL leakage
- Fail-closed on invalid config (negative burst throws `RateLimitConfigError`)
