### PR TITLE
fix(jobs): add stopBackgroundJobs and register shutdown hook

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -59,7 +59,7 @@ import { getRateLimitConfig } from './config/rateLimits.js';
 import { successResponse, errorResponse } from './utils/response.js';
 import { docsRouter } from './routes/docs.js';
 import { startVacuumCollector } from './metrics/vacuumCollector.js';
-import { startBackgroundJobs } from './jobs/queue.js';
+import { startBackgroundJobs, stopBackgroundJobs } from './jobs/queue.js';
 import { csrfMiddleware } from './middleware/csrf.js';
 
 export interface AppOptions {
@@ -421,6 +421,7 @@ export function createApp(options: AppOptions = {}): Express {
   if (options.pool) {
     app.locals.vacuumInterval = startVacuumCollector(options.pool);
     startBackgroundJobs(options.pool);
+    addShutdownHook(() => stopBackgroundJobs());
   }
 
   // Wire the Redis-backed idempotency store (fire-and-forget; errors handled internally).

--- a/src/jobs/queue.ts
+++ b/src/jobs/queue.ts
@@ -242,11 +242,14 @@ export async function stopBackgroundJobs(): Promise<void> {
   }
   try {
     await queue.stop();
-    setJobQueue(null);
     logger.info('Background jobs stopped');
   } catch (err) {
     logger.error('Failed to stop background jobs', undefined, {
       error: err instanceof Error ? err.message : String(err),
     });
+  } finally {
+    // Always clear the singleton so subsequent shutdown hooks
+    // or tests can detect the queue is no longer active.
+    setJobQueue(null);
   }
 }

--- a/src/jobs/queue.ts
+++ b/src/jobs/queue.ts
@@ -180,6 +180,10 @@ export function setJobQueue(queue: JobQueue | null): void {
  * Should be called once at startup with the application's Postgres pool.
  */
 export function startBackgroundJobs(pool: Pool): void {
+  if (_jobQueue) {
+    logger.warn('Background jobs already started, skipping duplicate init');
+    return;
+  }
   const queue = new JobQueue(pool);
   setJobQueue(queue);
 
@@ -222,4 +226,27 @@ export function startBackgroundJobs(pool: Pool): void {
   }).catch((err: Error) => {
     logger.error('Failed to enqueue startup partition maintenance', undefined, { error: err.message });
   });
+}
+
+/**
+ * Stops background jobs and clears the singleton JobQueue instance.
+ *
+ * Matches the `vacuumCollector.ts` pattern where a paired stop function is
+ * exported alongside the start function. Safe to call multiple times.
+ */
+export async function stopBackgroundJobs(): Promise<void> {
+  const queue = getJobQueue();
+  if (!queue) {
+    logger.warn('No background jobs to stop — queue was never started');
+    return;
+  }
+  try {
+    await queue.stop();
+    setJobQueue(null);
+    logger.info('Background jobs stopped');
+  } catch (err) {
+    logger.error('Failed to stop background jobs', undefined, {
+      error: err instanceof Error ? err.message : String(err),
+    });
+  }
 }

--- a/tests/jobs/queue.test.ts
+++ b/tests/jobs/queue.test.ts
@@ -247,3 +247,53 @@ describe('JobQueue singleton', () => {
     expect(mod.getJobQueue()).toBeNull();
   });
 });
+
+// ── stopBackgroundJobs tests ──────────────────────────────────────────────
+
+describe('stopBackgroundJobs', () => {
+  beforeEach(async () => {
+    const { setJobQueue } = await import('../../src/jobs/queue.js');
+    setJobQueue(null);
+  });
+
+  it('stops the queue and clears the singleton when a queue is set', async () => {
+    const mod = await import('../../src/jobs/queue.js');
+    const mockBoss = createMockBoss();
+    const q = mod.JobQueue.withBoss(mockBoss as never);
+    // Register and start so workSubscriptions is populated
+    q.register('test-job', vi.fn());
+    await q.start();
+    expect(q.isStarted).toBe(true);
+    mod.setJobQueue(q);
+
+    await mod.stopBackgroundJobs();
+
+    expect(mockBoss.offWork).toHaveBeenCalledWith('test-job');
+    expect(mockBoss.stop).toHaveBeenCalledWith({ graceful: true, timeout: 30000 });
+    expect(mod.getJobQueue()).toBeNull();
+  });
+
+  it('handles the case when no queue is set gracefully', async () => {
+    const mod = await import('../../src/jobs/queue.js');
+    mod.setJobQueue(null);
+
+    // Should not throw when no queue exists
+    await expect(mod.stopBackgroundJobs()).resolves.toBeUndefined();
+    expect(mod.getJobQueue()).toBeNull();
+  });
+
+  it('handles stop errors gracefully without throwing', async () => {
+    const mod = await import('../../src/jobs/queue.js');
+    const mockBoss = createMockBoss();
+    mockBoss.stop.mockRejectedValueOnce(new Error('stop failed'));
+    const q = mod.JobQueue.withBoss(mockBoss as never);
+    q.register('test-job', vi.fn());
+    await q.start();
+    mod.setJobQueue(q);
+
+    // Should not throw even when boss.stop() rejects
+    await expect(mod.stopBackgroundJobs()).resolves.toBeUndefined();
+    // Singleton should still be cleared
+    expect(mod.getJobQueue()).toBeNull();
+  });
+});


### PR DESCRIPTION
## Overview

This PR adds proper cleanup for background jobs during graceful shutdown by introducing a paired `stopBackgroundJobs()` function and registering it as a shutdown hook. The fix follows the established patterns in the codebase (vacuumCollector.ts's paired start/stop, oidcProvider.ts's shutdown hook registration).

## Related Issue
Closes #825

## Changes
- [ADD] `stopBackgroundJobs()` export in `src/jobs/queue.ts` — stops the `JobQueue` and clears the singleton, matching the `vacuumCollector.ts` pattern
- [MODIFY] `startBackgroundJobs()` — added idempotency guard to prevent duplicate initialization
- [MODIFY] `createApp()` in `src/app.ts` — registers `stopBackgroundJobs` as a shutdown hook via `addShutdownHook()`

## Verification Results
- Code compiles with existing TypeScript configuration
- Follows established patterns (vacuumCollector.ts, oidcProvider.ts)

## Acceptance Criteria
| Criteria | Status |
|----------|--------|
| A stop function exists and is registered as a shutdown hook | ✅ |
| Matches the vacuumCollector.ts paired start/stop pattern | ✅ |
| The job queue stops firing after shutdown | ✅ via JobQueue.stop() |
