### PR TITLE
feat(audit): add pagination with shared schema and filtering support

### DIFF
--- a/src/routes/audit.ts
+++ b/src/routes/audit.ts
@@ -6,18 +6,21 @@
  * this route (enforce at the gateway / auth middleware layer).
  *
  * Query parameters:
- *   @param limit  - Number of entries to return. Must be 1–100. Defaults to 20.
- *                   Returns 400 if set to 0, negative, or greater than 100.
- *   @param offset - Zero-based offset into the audit log. Must be >= 0. Defaults to 0.
- *                   Returns 400 if negative.
+ *   @param limit      - Number of entries to return. Must be 1–100. Defaults to 20.
+ *                       Returns 400 if out of range.
+ *   @param offset     - Zero-based offset into the audit log. Must be >= 0. Defaults to 0.
+ *                       Returns 400 if negative.
+ *   @param actor      - Filter by actor. Matches against `entry.meta.actor` or `entry.actor`.
+ *   @param actionType - Filter by action type (e.g. STREAM_CREATED, PAUSE_FLAGS_UPDATED).
+ *   @param dateFrom   - ISO-8601 timestamp. Only include entries at or after this time.
+ *   @param dateTo     - ISO-8601 timestamp. Only include entries at or before this time.
  *
  * Response shape:
  *   { success: true, data: { entries: AuditEntry[], total: number }, meta: ResponseMeta }
  *
  * Failure modes:
  *   - No entries yet → 200 with empty array (not 404).
- *   - limit=0 → 400 VALIDATION_ERROR
- *   - limit > 100 → 400 VALIDATION_ERROR
+ *   - limit out of range → 400 VALIDATION_ERROR
  *   - offset < 0 → 400 VALIDATION_ERROR
  *
  * Security notes:
@@ -26,12 +29,14 @@
  *     This prevents accidental exposure of credentials in audit records.
  */
 
+import { z } from 'zod';
 import { Router } from 'express';
 import { getAuditEntries, type AuditEntry } from '../lib/auditLog.js';
 import { successResponse } from '../utils/response.js';
 import { authenticate, requireAuth, requirePermission, Permission } from '../middleware/auth.js';
 import { ApiError } from '../errors.js';
 import { ApiErrorCode } from '../middleware/errorHandler.js';
+import { OffsetPaginationSchema, MAX_PAGE_LIMIT, DEFAULT_PAGE_LIMIT } from '../validation/paginationSchema.js';
 
 export const auditRouter = Router();
 
@@ -60,28 +65,51 @@ function sanitizeEntry(entry: AuditEntry): AuditEntry {
   return { ...entry, meta: redactRestricted(entry.meta) as Record<string, unknown> };
 }
 
+/** Extended schema that adds filter params on top of offset pagination. */
+const AuditQuerySchema = OffsetPaginationSchema.extend({
+  actor: z.string().optional(),
+  actionType: z.string().optional(),
+  dateFrom: z.string().optional(),
+  dateTo: z.string().optional(),
+});
+
 auditRouter.get('/', authenticate, requireAuth, requirePermission(Permission.AUDIT_READ), (req, res, next) => {
   try {
     const requestId = req.correlationId;
 
-    // ── Pagination parameter validation ──────────────────────────────────────
-    const rawLimit = req.query['limit'];
-    const rawOffset = req.query['offset'];
-
-    const limitNum = rawLimit === undefined ? 20 : Number(rawLimit);
-    const offsetNum = rawOffset === undefined ? 0 : Number(rawOffset);
-
-    if (!Number.isFinite(limitNum) || !Number.isInteger(limitNum) || limitNum < 1 || limitNum > 100) {
-      throw new ApiError(400, ApiErrorCode.VALIDATION_ERROR, 'limit must be an integer between 1 and 100', true);
-    }
-    if (!Number.isFinite(offsetNum) || !Number.isInteger(offsetNum) || offsetNum < 0) {
-      throw new ApiError(400, ApiErrorCode.VALIDATION_ERROR, 'offset must be a non-negative integer', true);
+    const parsed = AuditQuerySchema.safeParse(req.query);
+    if (!parsed.success) {
+      const firstIssue = parsed.error.issues[0];
+      throw new ApiError(400, ApiErrorCode.VALIDATION_ERROR, firstIssue?.message ?? 'Invalid query parameters', true);
     }
 
-    const allEntries = getAuditEntries();
-    const page = allEntries.slice(offsetNum, offsetNum + limitNum).map(sanitizeEntry);
+    const { limit, offset, actor, actionType, dateFrom, dateTo } = parsed.data;
+    const limitNum = limit ?? DEFAULT_PAGE_LIMIT;
+    const offsetNum = offset ?? 0;
 
-    res.json(successResponse({ entries: page, total: allEntries.length }, requestId));
+    let filteredEntries = getAuditEntries();
+
+    if (actor !== undefined) {
+      filteredEntries = filteredEntries.filter(
+        (e) => e.meta?.actor === actor || (e as AuditEntry & { actor?: string }).actor === actor,
+      );
+    }
+
+    if (actionType !== undefined) {
+      filteredEntries = filteredEntries.filter((e) => e.action === actionType);
+    }
+
+    if (dateFrom !== undefined) {
+      filteredEntries = filteredEntries.filter((e) => e.timestamp >= dateFrom);
+    }
+
+    if (dateTo !== undefined) {
+      filteredEntries = filteredEntries.filter((e) => e.timestamp <= dateTo);
+    }
+
+    const page = filteredEntries.slice(offsetNum, offsetNum + limitNum).map(sanitizeEntry);
+
+    res.json(successResponse({ entries: page, total: filteredEntries.length }, requestId));
   } catch (err) {
     next(err);
   }

--- a/tests/audit-pagination-filter.test.ts
+++ b/tests/audit-pagination-filter.test.ts
@@ -1,0 +1,184 @@
+/**
+ * Pagination and filtering tests for GET /api/audit
+ *
+ * Covers:
+ * - Pagination with limit/offset (defaults, custom, max clamp)
+ * - Filtering by actionType, dateFrom, dateTo
+ * - Combined filters
+ * - Empty results when no match
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import express from 'express';
+import request from 'supertest';
+
+import { recordAuditEvent, getAuditEntries, _resetAuditLog } from '../src/lib/auditLog.js';
+import { auditRouter } from '../src/routes/audit.js';
+import { correlationIdMiddleware } from '../src/middleware/correlationId.js';
+import { errorHandler } from '../src/middleware/errorHandler.js';
+import { authenticate } from '../src/middleware/auth.js';
+import { generateToken } from '../src/lib/auth.js';
+import { initializeConfig } from '../src/config/env.js';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type SupertestApp = any;
+
+let testToken: string;
+
+function createTestApp(): SupertestApp {
+  const app = express();
+  app.use(express.json());
+  app.use(correlationIdMiddleware);
+  app.use('/api/audit', auditRouter);
+  app.use(errorHandler);
+  return app;
+}
+
+function withAuth(req: request.Test): request.Test {
+  return req.set('Authorization', `Bearer ${testToken}`);
+}
+
+describe('GET /api/audit — Pagination and filtering', () => {
+  let app: SupertestApp;
+
+  beforeEach(() => {
+    _resetAuditLog();
+    process.env.NODE_ENV = 'test';
+    process.env.JWT_SECRET = 'a-very-long-secret-key-for-testing-only-12345';
+    initializeConfig();
+    testToken = generateToken({ address: 'GTEST', role: 'operator' });
+    app = createTestApp();
+  });
+
+  // ── Pagination ─────────────────────────────────────────────────────────────
+
+  it('returns first page with default limit (20)', async () => {
+    for (let i = 0; i < 25; i++) {
+      recordAuditEvent('STREAM_CREATED', 'stream', `stream-${i}`);
+    }
+    const res = await withAuth(request(app).get('/api/audit')).expect(200);
+    expect(res.body.data.entries).toHaveLength(20);
+    expect(res.body.data.total).toBe(25);
+  });
+
+  it('returns custom page size (limit=5)', async () => {
+    for (let i = 0; i < 10; i++) {
+      recordAuditEvent('STREAM_CREATED', 'stream', `stream-${i}`);
+    }
+    const res = await withAuth(request(app).get('/api/audit?limit=5')).expect(200);
+    expect(res.body.data.entries).toHaveLength(5);
+    expect(res.body.data.total).toBe(10);
+    expect(res.body.data.entries[0].resourceId).toBe('stream-0');
+    expect(res.body.data.entries[4].resourceId).toBe('stream-4');
+  });
+
+  it('returns second page (offset=5, limit=5)', async () => {
+    for (let i = 0; i < 15; i++) {
+      recordAuditEvent('STREAM_CREATED', 'stream', `stream-${i}`);
+    }
+    const res = await withAuth(request(app).get('/api/audit?offset=5&limit=5')).expect(200);
+    expect(res.body.data.entries).toHaveLength(5);
+    expect(res.body.data.entries[0].resourceId).toBe('stream-5');
+    expect(res.body.data.entries[4].resourceId).toBe('stream-9');
+  });
+
+  it('enforces max page size (limit=200 clamped to 100)', async () => {
+    for (let i = 0; i < 150; i++) {
+      recordAuditEvent('STREAM_CREATED', 'stream', `stream-${i}`);
+    }
+    const res = await withAuth(request(app).get('/api/audit?limit=200')).expect(400);
+    expect(res.body.error).toBeDefined();
+  });
+
+  it('returns empty array when offset exceeds total', async () => {
+    recordAuditEvent('STREAM_CREATED', 'stream', 's1');
+    recordAuditEvent('STREAM_CREATED', 'stream', 's2');
+    const res = await withAuth(request(app).get('/api/audit?offset=100')).expect(200);
+    expect(res.body.data.entries).toHaveLength(0);
+    expect(res.body.data.total).toBe(2);
+  });
+
+  // ── Filtering by actionType ────────────────────────────────────────────────
+
+  it('filters by actionType (only STREAM_CREATED entries)', async () => {
+    recordAuditEvent('STREAM_CREATED', 'stream', 's1');
+    recordAuditEvent('STREAM_CANCELLED', 'stream', 's2');
+    recordAuditEvent('STREAM_CREATED', 'stream', 's3');
+    recordAuditEvent('PAUSE_FLAGS_UPDATED', 'pauseFlags', 'system');
+    const res = await withAuth(
+      request(app).get('/api/audit?actionType=STREAM_CREATED')
+    ).expect(200);
+    expect(res.body.data.entries).toHaveLength(2);
+    expect(res.body.data.entries.every((e: { action: string }) => e.action === 'STREAM_CREATED')).toBe(true);
+    expect(res.body.data.total).toBe(2);
+  });
+
+  // ── Filtering by date range ────────────────────────────────────────────────
+
+  it('filters by dateFrom (entries at or after timestamp)', async () => {
+    // Record entries with known timestamps
+    recordAuditEvent('STREAM_CREATED', 'stream', 'old');
+    // The timestamps are auto-generated, so we use the recorded entries
+    const allEntries = getAuditEntries();
+    const cutoff = allEntries[0]!.timestamp;
+
+    recordAuditEvent('STREAM_CREATED', 'stream', 'new1');
+    recordAuditEvent('STREAM_CREATED', 'stream', 'new2');
+
+    const res = await withAuth(
+      request(app).get(`/api/audit?dateFrom=${encodeURIComponent(cutoff)}`)
+    ).expect(200);
+    // Should include the entry at cutoff and all after
+    expect(res.body.data.entries.length).toBeGreaterThanOrEqual(3);
+  });
+
+  it('filters by dateTo (entries at or before timestamp)', async () => {
+    recordAuditEvent('STREAM_CREATED', 'stream', 's1');
+    recordAuditEvent('STREAM_CREATED', 'stream', 's2');
+    const allEntries = getAuditEntries();
+    const cutoff = allEntries[0]!.timestamp;
+
+    recordAuditEvent('STREAM_CREATED', 'stream', 's3');
+
+    const res = await withAuth(
+      request(app).get(`/api/audit?dateTo=${encodeURIComponent(cutoff)}`)
+    ).expect(200);
+    // Only entries at or before cutoff
+    expect(res.body.data.entries).toHaveLength(1);
+    expect(res.body.data.entries[0].resourceId).toBe('s1');
+  });
+
+  // ── Combined filters ───────────────────────────────────────────────────────
+
+  it('combines actionType + date range filters', async () => {
+    recordAuditEvent('STREAM_CREATED', 'stream', 's1');
+    const allEntries = getAuditEntries();
+    const cutoff = allEntries[0]!.timestamp;
+
+    recordAuditEvent('STREAM_CREATED', 'stream', 's2');
+    recordAuditEvent('STREAM_CANCELLED', 'stream', 's3');
+    recordAuditEvent('STREAM_CREATED', 'stream', 's4');
+
+    const res = await withAuth(
+      request(app).get(
+        `/api/audit?actionType=STREAM_CREATED&dateFrom=${encodeURIComponent(cutoff)}`
+      )
+    ).expect(200);
+    // Should include s1 (at cutoff), s2, s4 — but NOT s3 (CANCELLED)
+    expect(res.body.data.entries.every((e: { action: string }) => e.action === 'STREAM_CREATED')).toBe(true);
+    expect(res.body.data.total).toBe(3);
+  });
+
+  // ── No match ───────────────────────────────────────────────────────────────
+
+  it('returns empty array when no entries match filters', async () => {
+    recordAuditEvent('STREAM_CREATED', 'stream', 's1');
+    recordAuditEvent('STREAM_CREATED', 'stream', 's2');
+
+    const res = await withAuth(
+      request(app).get('/api/audit?actionType=NONEXISTENT_ACTION')
+    ).expect(200);
+    expect(res.body.data.entries).toHaveLength(0);
+    expect(res.body.data.total).toBe(0);
+  });
+});


### PR DESCRIPTION
Closes #676

## Summary

Migrated `src/routes/audit.ts` from inline limit/offset validation to the shared `OffsetPaginationSchema` from `src/validation/paginationSchema.ts`, and added filtering capabilities.

### Changes

- **Pagination**: Uses `OffsetPaginationSchema` for consistent validation across endpoints. Enforces `MAX_PAGE_LIMIT` (100) server-side regardless of client-requested limit.
- **Filtering**: Added 4 optional filter query params:
  - `actor` — matches `entry.meta.actor` or `entry.actor`
  - `actionType` — exact match on `entry.action`
  - `dateFrom` — ISO-8601, entries at or after this timestamp
  - `dateTo` — ISO-8601, entries at or before this timestamp
- **JSDoc**: Updated endpoint documentation with new filter params.

### Tests Added (10 new)

- Default limit (20), custom page size, second page offset
- Max page size enforcement (limit=200 → 400)
- Empty results when offset exceeds total
- Filter by actionType, dateFrom, dateTo
- Combined filters (actionType + date range)
- Empty results when no entries match filters