### PR TITLE
fix(ws): add channel-level authorization check for stream subscriptions

### DIFF
--- a/src/ws/hub.ts
+++ b/src/ws/hub.ts
@@ -63,6 +63,7 @@ import {
   checkAndReserve,
   untrackConnection,
 } from './connectionLimiter.js';
+import { streamRepository } from '../db/repositories/streamRepository.js';
 import {
   collectWsBackpressureMetrics,
   removeWsClientBackpressureGauge,
@@ -698,7 +699,7 @@ export class StreamHub extends EventEmitter {
 
   // ── Message handling ───────────────────────────────────────────────────────
 
-  private handleMessage(ws: WebSocket, raw: string): void {
+  private async handleMessage(ws: WebSocket, raw: string): Promise<void> {
     const result = validateWebSocketMessage(raw);
     if (!result.ok) {
       this.sendError(ws, result.code, result.message);
@@ -710,7 +711,7 @@ export class StreamHub extends EventEmitter {
       return;
     }
 
-    const authorized = this.authorizeSubscriptionFilter(ws, result.message.filter);
+    const authorized = await this.authorizeSubscriptionFilter(ws, result.message.filter);
     if (!authorized.ok) {
       this.sendError(ws, authorized.code, authorized.message);
       return;
@@ -746,16 +747,26 @@ export class StreamHub extends EventEmitter {
     this.removeSubscriptionFromIndexes(ws, existing);
   }
 
-  private authorizeSubscriptionFilter(
+  private async authorizeSubscriptionFilter(
     ws: WebSocket,
     filter: SubscriptionFilter
-  ): { ok: true; filter: SubscriptionFilter } | { ok: false; code: string; message: string } {
+  ): Promise<{ ok: true; filter: SubscriptionFilter } | { ok: false; code: string; message: string }> {
     const state = this.clients.get(ws);
     if (!state) {
       return { ok: false, code: 'UNAUTHORIZED', message: 'WebSocket client is not registered' };
     }
 
     if (filter.streamId !== undefined) {
+      const stream = await streamRepository.getById(filter.streamId);
+      if (!stream) {
+        return { ok: false, code: 'NOT_FOUND', message: 'Stream not found' };
+      }
+
+      const subject = state.authenticatedSubject;
+      if (!subject || (stream.sender !== subject && stream.recipient !== subject)) {
+        return { ok: false, code: 'FORBIDDEN', message: 'Not authorized for this stream' };
+      }
+
       return { ok: true, filter };
     }
 


### PR DESCRIPTION
Closes #675

## Summary

Fixes security vulnerability where any authenticated WebSocket client could subscribe to arbitrary stream events without ownership verification.

## Changes

**src/ws/hub.ts:**
- Made `authorizeSubscriptionFilter` async to support database lookups
- Added stream ownership verification: fetch stream via `streamRepository.getById` and verify client's `authenticatedSubject` matches either `sender` or `recipient`
- Return `FORBIDDEN` if client not authorized for the stream
- Return `NOT_FOUND` if stream doesn't exist
- Made `handleMessage` async to await the authorization check

## Security Impact

Before: Clients could subscribe to any streamId and receive events for streams they don't own.

After: Clients can only subscribe to streams where they are the sender or recipient.