### PR TITLE
test(tracing): add edge-case coverage for per-route override resolution

### DIFF
--- a/src/tracing/hooks.test.ts
+++ b/src/tracing/hooks.test.ts
@@ -1,0 +1,154 @@
+/**
+ * Comprehensive edge-case tests for resolvePerRouteOverride() in src/tracing/hooks.ts
+ */
+
+import { describe, it, expect } from 'vitest';
+import { resolvePerRouteOverride } from './hooks.js';
+
+describe('resolvePerRouteOverride()', () => {
+  describe('Exact Match', () => {
+    it('prefers an exact route override over prefix matches', () => {
+      const overrides: Record<string, number> = {
+        '/api': 0.2,
+        '/api/streams': 0.5,
+        '/api/streams/live': 1.0,
+      };
+
+      expect(resolvePerRouteOverride('/api/streams', overrides)).toBe(0.5);
+      expect(resolvePerRouteOverride('/api', overrides)).toBe(0.2);
+      expect(resolvePerRouteOverride('/api/streams/live', overrides)).toBe(1.0);
+    });
+
+    it('returns exact match rate when rate is 0', () => {
+      const overrides: Record<string, number> = {
+        '/health': 0,
+        '/api': 0.5,
+      };
+
+      expect(resolvePerRouteOverride('/health', overrides)).toBe(0);
+    });
+  });
+
+  describe('Longest Prefix Match', () => {
+    it('selects the most specific (longest) prefix match', () => {
+      const overrides: Record<string, number> = {
+        '/api': 0.2,
+        '/api/streams': 0.5,
+      };
+
+      expect(resolvePerRouteOverride('/api/streams/abc', overrides)).toBe(0.5);
+    });
+
+    it('chooses the longest matching key across multiple nested prefixes', () => {
+      const overrides: Record<string, number> = {
+        '/api': 0.2,
+        '/api/streams': 0.5,
+        '/api/streams/live': 1.0,
+      };
+
+      expect(resolvePerRouteOverride('/api/streams/live/abc', overrides)).toBe(1.0);
+      expect(resolvePerRouteOverride('/api/streams/vod/123', overrides)).toBe(0.5);
+      expect(resolvePerRouteOverride('/api/users/456', overrides)).toBe(0.2);
+    });
+
+    it('handles shorter prefix when longer prefix does not match', () => {
+      const overrides: Record<string, number> = {
+        '/api': 0.2,
+        '/api/streams': 0.5,
+      };
+
+      expect(resolvePerRouteOverride('/api/webhooks', overrides)).toBe(0.2);
+    });
+  });
+
+  describe('Substring False-Positive Prevention', () => {
+    it('does NOT match routes that share a character prefix but are not path-segment descendants', () => {
+      const overrides: Record<string, number> = {
+        '/api/str': 0.8,
+      };
+
+      expect(resolvePerRouteOverride('/api/stream-x', overrides)).toBeUndefined();
+      expect(resolvePerRouteOverride('/api/streamSomething', overrides)).toBeUndefined();
+    });
+
+    it('verifies regression coverage: matches valid path-segment descendants and exact matches', () => {
+      const overrides: Record<string, number> = {
+        '/api/str': 0.8,
+      };
+
+      expect(resolvePerRouteOverride('/api/str', overrides)).toBe(0.8);
+      expect(resolvePerRouteOverride('/api/str/foo', overrides)).toBe(0.8);
+      expect(resolvePerRouteOverride('/api/str/foo/bar', overrides)).toBe(0.8);
+      expect(resolvePerRouteOverride('/api/stream-x', overrides)).toBeUndefined();
+    });
+
+    it('prevents substring false-positive when target route has extra characters after prefix without slash', () => {
+      const overrides: Record<string, number> = {
+        '/api': 0.5,
+      };
+
+      expect(resolvePerRouteOverride('/apiv2', overrides)).toBeUndefined();
+      expect(resolvePerRouteOverride('/apiv2/users', overrides)).toBeUndefined();
+      expect(resolvePerRouteOverride('/api-v2', overrides)).toBeUndefined();
+    });
+  });
+
+  describe('No Match', () => {
+    it('returns undefined when no override matches', () => {
+      const overrides: Record<string, number> = {
+        '/api': 0.2,
+        '/admin': 0.9,
+      };
+
+      expect(resolvePerRouteOverride('/metrics', overrides)).toBeUndefined();
+      expect(resolvePerRouteOverride('/health', overrides)).toBeUndefined();
+      expect(resolvePerRouteOverride('/', overrides)).toBeUndefined();
+    });
+
+    it('does not throw exceptions or return default sample rates for unknown routes', () => {
+      const overrides: Record<string, number> = {
+        '/api': 0.5,
+      };
+
+      expect(() => resolvePerRouteOverride('/unknown/route', overrides)).not.toThrow();
+      expect(resolvePerRouteOverride('/unknown/route', overrides)).toBeUndefined();
+    });
+  });
+
+  describe('Regression & Special Configurations', () => {
+    it('returns undefined for an empty override map', () => {
+      expect(resolvePerRouteOverride('/api/streams', {})).toBeUndefined();
+    });
+
+    it('handles single override configuration correctly', () => {
+      const overrides: Record<string, number> = {
+        '/api': 0.5,
+      };
+
+      expect(resolvePerRouteOverride('/api', overrides)).toBe(0.5);
+      expect(resolvePerRouteOverride('/api/users', overrides)).toBe(0.5);
+      expect(resolvePerRouteOverride('/apiv2', overrides)).toBeUndefined();
+      expect(resolvePerRouteOverride('/other', overrides)).toBeUndefined();
+    });
+
+    it('handles root path override ("/") correctly', () => {
+      const overrides: Record<string, number> = {
+        '/': 0.1,
+      };
+
+      expect(resolvePerRouteOverride('/', overrides)).toBe(0.1);
+      expect(resolvePerRouteOverride('/api/streams', overrides)).toBe(0.1);
+      expect(resolvePerRouteOverride('/health', overrides)).toBe(0.1);
+    });
+
+    it('handles override key with trailing slash correctly', () => {
+      const overrides: Record<string, number> = {
+        '/api/': 0.6,
+      };
+
+      expect(resolvePerRouteOverride('/api/streams', overrides)).toBe(0.6);
+      expect(resolvePerRouteOverride('/api/', overrides)).toBe(0.6);
+      expect(resolvePerRouteOverride('/api', overrides)).toBeUndefined();
+    });
+  });
+});

--- a/src/tracing/hooks.ts
+++ b/src/tracing/hooks.ts
@@ -111,7 +111,6 @@ export interface TracerHooks {
   shutdown?(): Promise<void>;
 }
 
-
 /**
  * Configuration for the tracer.
  */
@@ -296,11 +295,7 @@ export class Tracer {
   /**
    * Record an error with correlation context.
    */
-  recordError(
-    correlationId: string,
-    error: Error,
-    context?: Record<string, unknown>
-  ): void {
+  recordError(correlationId: string, error: Error, context?: Record<string, unknown>): void {
     if (!this.config.enabled) {
       return;
     }
@@ -445,12 +440,14 @@ export class Tracer {
       // Tracer implementation errors never escape to application code
       // They're logged to stderr for debugging but don't break the request
       const message = err instanceof Error ? err.message : String(err);
-      console.error(JSON.stringify({
-        level: 'error',
-        timestamp: new Date().toISOString(),
-        message: `Tracer hook error: ${message}`,
-        ...(err instanceof Error && err.stack && { stack: err.stack }),
-      }));
+      console.error(
+        JSON.stringify({
+          level: 'error',
+          timestamp: new Date().toISOString(),
+          message: `Tracer hook error: ${message}`,
+          ...(err instanceof Error && err.stack && { stack: err.stack }),
+        })
+      );
     }
   }
 }
@@ -471,7 +468,7 @@ export async function traceSpan<T>(
   correlationId: string,
   tags: Record<string, unknown>,
   fn: (span: Span) => Promise<T>,
-  parentSpanId?: string,
+  parentSpanId?: string
 ): Promise<T> {
   const tracer = getTracer();
   const startContext: Omit<SpanContext, 'spanId'> = {
@@ -547,10 +544,15 @@ import { trace, context, SpanStatusCode } from '@opentelemetry/api';
 export async function traceDbQuery<T>(
   sql: string,
   dbName: string,
-  fn: () => Promise<T>,
+  fn: () => Promise<T>
 ): Promise<T> {
   const correlationId = getCorrelationIdFromContext();
-  return traceSpan('db.query', correlationId, { 'db.system': 'postgresql', 'db.name': dbName, 'db.statement': sql }, async () => fn());
+  return traceSpan(
+    'db.query',
+    correlationId,
+    { 'db.system': 'postgresql', 'db.name': dbName, 'db.statement': sql },
+    async () => fn()
+  );
 }
 
 /**
@@ -562,10 +564,15 @@ export async function traceDbQuery<T>(
 export async function traceRedisCommand<T>(
   command: string,
   key: string,
-  fn: () => Promise<T>,
+  fn: () => Promise<T>
 ): Promise<T> {
   const correlationId = getCorrelationIdFromContext();
-  return traceSpan('redis.command', correlationId, { 'db.system': 'redis', 'db.operation': command, 'db.redis.key': key }, async () => fn());
+  return traceSpan(
+    'redis.command',
+    correlationId,
+    { 'db.system': 'redis', 'db.operation': command, 'db.redis.key': key },
+    async () => fn()
+  );
 }
 
 /**
@@ -573,12 +580,14 @@ export async function traceRedisCommand<T>(
  *
  * @param operation — RPC method name (e.g. "getLatestLedger")
  */
-export async function traceStellarRpc<T>(
-  operation: string,
-  fn: () => Promise<T>,
-): Promise<T> {
+export async function traceStellarRpc<T>(operation: string, fn: () => Promise<T>): Promise<T> {
   const correlationId = getCorrelationIdFromContext();
-  return traceSpan('stellar.rpc', correlationId, { 'rpc.system': 'stellar', 'rpc.method': operation }, async () => fn());
+  return traceSpan(
+    'stellar.rpc',
+    correlationId,
+    { 'rpc.system': 'stellar', 'rpc.method': operation },
+    async () => fn()
+  );
 }
 
 /**
@@ -592,10 +601,15 @@ export async function traceWebhookDispatch<T>(
   event: string,
   url: string,
   attempt: number,
-  fn: () => Promise<T>,
+  fn: () => Promise<T>
 ): Promise<T> {
   const correlationId = getCorrelationIdFromContext();
-  return traceSpan('webhook.dispatch', correlationId, { 'webhook.event': event, 'webhook.url': url, 'webhook.retry': attempt }, async () => fn());
+  return traceSpan(
+    'webhook.dispatch',
+    correlationId,
+    { 'webhook.event': event, 'webhook.url': url, 'webhook.retry': attempt },
+    async () => fn()
+  );
 }
 
 /**
@@ -623,7 +637,7 @@ export function recordCircuitBreakerTransition(
   prevState: string,
   newState: string,
   failureCount: number,
-  failureKind?: string,
+  failureKind?: string
 ): void {
   const attributes: Record<string, unknown> = {
     'circuit_breaker.prev_state': prevState,
@@ -660,7 +674,11 @@ export function recordCircuitBreakerTransition(
 export function recordWsBroadcast(streamId: string, eventId: string, recipients: number): void {
   const activeSpan = trace.getActiveSpan();
   if (!activeSpan) return;
-  activeSpan.addEvent('ws.broadcast', { 'ws.stream_id': streamId, 'ws.event_id': eventId, 'ws.recipients': recipients });
+  activeSpan.addEvent('ws.broadcast', {
+    'ws.stream_id': streamId,
+    'ws.event_id': eventId,
+    'ws.recipients': recipients,
+  });
 }
 
 /**
@@ -688,7 +706,7 @@ export function enrichSpanWithStream(
   span: Span,
   streamId?: string,
   sender?: string,
-  recipient?: string,
+  recipient?: string
 ): void {
   if (!span) return;
   if (!span.context) {
@@ -734,7 +752,7 @@ export function enrichSpanWithStream(
 export function enrichActiveSpanWithStream(
   streamId?: string,
   sender?: string,
-  recipient?: string,
+  recipient?: string
 ): void {
   try {
     const activeSpan = trace.getActiveSpan();
@@ -747,7 +765,6 @@ export function enrichActiveSpanWithStream(
     // ignore active span errors
   }
 }
-
 
 // ── Sampling Strategies ───────────────────────────────────────────────────────
 //
@@ -918,17 +935,18 @@ export function shouldSampleTail(span: Span, config: TailSamplingConfig): boolea
  */
 export function resolvePerRouteOverride(
   route: string,
-  overrides: Record<string, number>,
+  overrides: Record<string, number>
 ): number | undefined {
   // 1. Exact match
   if (Object.prototype.hasOwnProperty.call(overrides, route)) {
     return overrides[route];
   }
 
-  // 2. Longest prefix match
+  // 2. Longest prefix match (segment-aware)
   let best: { key: string; rate: number } | undefined;
   for (const [key, rate] of Object.entries(overrides)) {
-    if (route.startsWith(key)) {
+    const isPrefix = key.endsWith('/') ? route.startsWith(key) : route.startsWith(`${key}/`);
+    if (isPrefix) {
       if (best === undefined || key.length > best.key.length) {
         best = { key, rate };
       }
@@ -1170,7 +1188,7 @@ export class BatchSpanExporter implements TracerHooks {
           level: 'error',
           timestamp: new Date().toISOString(),
           message: `[BatchSpanExporter] ${msg}: ${err instanceof Error ? err.message : String(err)}`,
-        }),
+        })
       );
     }
   }
@@ -1179,10 +1197,6 @@ export class BatchSpanExporter implements TracerHooks {
 /**
  * Factory helper to create a BatchSpanExporter instance.
  */
-export function createBatchSpanExporter(
-  config: BatchSpanExporterConfig = {},
-): BatchSpanExporter {
+export function createBatchSpanExporter(config: BatchSpanExporterConfig = {}): BatchSpanExporter {
   return new BatchSpanExporter(config);
 }
-
-


### PR DESCRIPTION
## Closes #867 

## Summary

Add comprehensive edge-case tests for `resolvePerRouteOverride()` to verify exact matching, longest-prefix resolution, substring boundary handling, and unmatched routes. If necessary, tighten the matching logic to avoid false-positive prefix matches.

## Problem

`resolvePerRouteOverride()` determines per-route trace sampling rates using exact-match and longest-prefix logic. While functional, it lacks dedicated coverage for several important edge cases:

- Overlapping prefix overrides.
- Character-based substring matches that are not valid path-segment prefixes.
- Routes with no matching override.

Without these tests, future changes could introduce incorrect sampling behavior, impacting observability and tracing costs.

## Solution

- Added comprehensive unit tests covering:
  - Exact match precedence.
  - Longest-prefix selection.
  - Overlapping prefix configurations.
  - No-match behavior.
  - Potential substring false-positive cases.
- If reproduced, updated the matching logic to require a valid path-segment boundary while preserving existing legitimate prefix behavior.

## Implementation Details

### Tests
Added coverage in `src/tracing/hooks.test.ts` for:

- Exact route matches.
- Longest-prefix resolution.
- Multiple overlapping prefixes.
- No matching override.
- Empty override map.
- Regression tests for substring boundary behavior.
- Existing valid prefix configurations.

### Implementation (if required)

Updated `src/tracing/hooks.ts` to require:

- `route === key`
- **OR**
- `route.startsWith(\`${key}/\`)`

instead of relying solely on character-based `startsWith()`.

This prevents unintended matches such as:

- `/api/str` matching `/api/stream-x`

while preserving valid descendant routes like:

- `/api/str/foo`

## Testing Checklist

- [x] Exact matches take precedence.
- [x] Longest valid prefix is selected.
- [x] Overlapping prefixes resolve correctly.
- [x] Substring false positives are covered or fixed.
- [x] No matching override returns `undefined`.
- [x] Existing legitimate behavior remains unchanged.
- [x] Module coverage remains at least 95%.
- [x] Full test suite passes.

## Screenshots

N/A (Backend test and logic improvement)