### PR TITLE
test: stabilize script-based db ops

### DIFF
--- a/src/scripts/db-ops.ts
+++ b/src/scripts/db-ops.ts
@@ -168,13 +168,16 @@ export async function backupDatabase(
   outputPath: string,
   s3Target?: S3Target,
 ): Promise<DbOperationResult> {
-  const urlCheck = validateDatabaseUrl(databaseUrl)
+  const normalizedDatabaseUrl = databaseUrl.trim()
+  const normalizedOutputPath = outputPath.trim()
+
+  const urlCheck = validateDatabaseUrl(normalizedDatabaseUrl)
   if (!urlCheck.valid) {
     return { success: false, message: urlCheck.reason! }
   }
 
   if (!s3Target) {
-    const pathCheck = validatePath(outputPath, 'Output')
+    const pathCheck = validatePath(normalizedOutputPath, 'Output')
     if (!pathCheck.valid) {
       return { success: false, message: pathCheck.reason! }
     }
@@ -184,7 +187,7 @@ export async function backupDatabase(
     if (s3Target) {
       // ── S3 streaming path ────────────────────────────────────────────────
       // Spawn pg_dump writing to stdout, pipe directly to S3 upload.
-      const args = ['--format=custom', '--no-password', databaseUrl]
+      const args = ['--format=custom', '--no-password', normalizedDatabaseUrl]
       const child = spawn('pg_dump', args, { stdio: ['ignore', 'pipe', 'pipe'] })
 
       const passThrough = new PassThrough()
@@ -223,15 +226,15 @@ export async function backupDatabase(
       const args = [
         '--format=custom',
         '--no-password',
-        `--file=${outputPath}`,
-        databaseUrl,
+        `--file=${normalizedOutputPath}`,
+        normalizedDatabaseUrl,
       ]
 
       await execFileAsync('pg_dump', args)
 
       return {
         success: true,
-        message: `Backup successfully written to ${outputPath}`,
+        message: `Backup successfully written to ${normalizedOutputPath}`,
       }
     }
   } catch (error: unknown) {
@@ -282,13 +285,16 @@ export async function restoreDatabase(
   inputPath: string,
   s3Source?: S3Target,
 ): Promise<DbOperationResult> {
-  const urlCheck = validateDatabaseUrl(databaseUrl)
+  const normalizedDatabaseUrl = databaseUrl.trim()
+  const normalizedInputPath = inputPath.trim()
+
+  const urlCheck = validateDatabaseUrl(normalizedDatabaseUrl)
   if (!urlCheck.valid) {
     return { success: false, message: urlCheck.reason! }
   }
 
   if (!s3Source) {
-    const pathCheck = validatePath(inputPath, 'Input')
+    const pathCheck = validatePath(normalizedInputPath, 'Input')
     if (!pathCheck.valid) {
       return { success: false, message: pathCheck.reason! }
     }
@@ -342,7 +348,7 @@ export async function restoreDatabase(
         '--clean',
         '--no-owner',
         '--no-password',
-        `--dbname=${databaseUrl}`,
+        `--dbname=${normalizedDatabaseUrl}`,
       ]
 
       const child = spawn('pg_restore', args, { stdio: ['pipe', 'pipe', 'pipe'] })
@@ -378,15 +384,15 @@ export async function restoreDatabase(
         '--clean',
         '--no-owner',
         '--no-password',
-        `--dbname=${databaseUrl}`,
-        inputPath,
+        `--dbname=${normalizedDatabaseUrl}`,
+        normalizedInputPath,
       ]
 
       await execFileAsync('pg_restore', args)
 
       return {
         success: true,
-        message: `Restore successfully completed from ${inputPath}`,
+        message: `Restore successfully completed from ${normalizedInputPath}`,
       }
     }
   } catch (error: unknown) {

--- a/tests/db-ops.test.ts
+++ b/tests/db-ops.test.ts
@@ -145,6 +145,21 @@ describe('backupDatabase', () => {
     expect(result.success).toBe(true)
   })
 
+  it('trims surrounding whitespace from DATABASE_URL and outputPath before invoking pg_dump', async () => {
+    mockExecFileSuccess()
+
+    const result = await backupDatabase(`  ${VALID_URL}  `, `  ${LOCAL_PATH}  `)
+
+    expect(result.success).toBe(true)
+
+    const mock = childProcess.execFile as unknown as MockInstance
+    expect(mock).toHaveBeenCalledOnce()
+
+    const [, args] = mock.mock.calls[0] as [string, string[]]
+    expect(args).toContain(VALID_URL)
+    expect(args).toContain(`--file=${LOCAL_PATH}`)
+  })
+
   it('fails when outputPath is empty in local mode', async () => {
     const result = await backupDatabase(VALID_URL, '')
     expect(result.success).toBe(false)
@@ -313,6 +328,21 @@ describe('restoreDatabase', () => {
     expect(args).toContain('--no-owner')
     // URL passed via --dbname=<url>, never as a bare shell string
     expect(args.some((a: string) => a.startsWith('--dbname='))).toBe(true)
+    expect(args).toContain(LOCAL_PATH)
+  })
+
+  it('trims surrounding whitespace from DATABASE_URL and inputPath before invoking pg_restore', async () => {
+    mockExecFileSuccess()
+
+    const result = await restoreDatabase(`  ${VALID_URL}  `, `  ${LOCAL_PATH}  `)
+
+    expect(result.success).toBe(true)
+
+    const mock = childProcess.execFile as unknown as MockInstance
+    expect(mock).toHaveBeenCalledOnce()
+
+    const [, args] = mock.mock.calls[0] as [string, string[]]
+    expect(args).toContain(`--dbname=${VALID_URL}`)
     expect(args).toContain(LOCAL_PATH)
   })
 


### PR DESCRIPTION
Closes #1096

---

# Stabilize script-based db ops behavior

## Summary
This PR stabilizes the script-based database operation flow by making backup and restore input handling deterministic across retries and deploys.

## What changed
- Normalized database URLs and local backup/restore paths by trimming surrounding whitespace before invoking pg_dump/pg_restore.
- Added regression tests covering whitespace-trimmed inputs for both backup and restore operations.

## Why
Previously, script-based DB ops could behave inconsistently when callers passed whitespace around the database URL or file path. This change preserves the current API and behavior while making the edge cases explicit and regression-safe.

## Testing
- Ran:
  - `pnpm vitest run tests/db-ops.test.ts --no-file-parallelism`

