### PR TITLE
test(admin): document and lock down admin route authorization behavior

### DIFF
--- a/docs/api/admin-endpoints.md
+++ b/docs/api/admin-endpoints.md
@@ -1,6 +1,103 @@
 # Admin API Endpoints
 
-All endpoints under `/api/admin` require an `Authorization: Bearer <ADMIN_API_KEY>` header unless noted otherwise. Requests without valid admin credentials are rejected by `requireAdminAuth`.
+## Authorization and guard contract
+
+`GET /api/admin/status/read-only` is registered before the router's authorization
+guard and is public. It returns only the current pause flags. The route remains
+available when admin authentication is unconfigured, and an invalid
+`Authorization` header is ignored on this route.
+
+Every other request that reaches the `/api/admin` router passes through
+`requireAdminAuth` before route matching, handler validation, database access,
+state mutation, or handler audit events. This includes requests for unknown
+paths and non-GET methods sent to `/status/read-only`. Consequently, an unknown
+admin path returns an auth failure to an unauthenticated caller and reaches the
+normal `404` response only after successful authentication.
+
+Global middleware runs before the admin router. Content negotiation, JSON
+parsing, body-size limits, rate limiting, and similar global checks can
+therefore reject a request before the admin guard.
+
+### Accepted credentials
+
+Admin auth is enabled only when `ADMIN_API_KEY` is non-empty. Once it is
+configured, either of these credentials is accepted:
+
+- The exact `ADMIN_API_KEY` value. Comparison is length-checked and
+  timing-safe; a match establishes `req.user` as `{ role: "admin" }`.
+- A valid application JWT whose `role` is exactly `admin` or
+  `data-protection-officer`. The verified JWT payload becomes `req.user`.
+
+The router does not call the granular `requirePermission` middleware. JWT
+authorization is based on `role`, so an allowed role does not need an
+`admin:*` permission claim, and an `operator` or `viewer` is rejected even if
+its JWT contains an admin-named permission.
+
+`ADMIN_API_KEY` is still the feature switch for JWT access: when it is unset,
+the guard returns `503` before attempting to verify a JWT.
+
+### Header parsing and failures
+
+The accepted header shape is exactly `Authorization: Bearer <token>`:
+`Bearer` is case-sensitive, there must be exactly one space, and the complete
+header may not exceed 8,192 characters. The guard preserves the existing bare
+JSON error shape rather than the standard API error envelope.
+
+| Condition                                                      | Status | Response body                                                                        |
+| -------------------------------------------------------------- | -----: | ------------------------------------------------------------------------------------ |
+| `ADMIN_API_KEY` unset or empty                                 |  `503` | `{"error":"Admin API is not configured. Set ADMIN_API_KEY to enable admin access."}` |
+| Header missing                                                 |  `401` | `{"error":"Missing Authorization header."}`                                          |
+| Header longer than 8,192 characters                            |  `401` | `{"error":"Authorization header too large."}`                                        |
+| Scheme, spacing, or part count malformed                       |  `401` | `{"error":"Authorization header must use Bearer scheme."}`                           |
+| Token present but neither the static key nor an authorized JWT |  `403` | `{"error":"Invalid admin credentials."}`                                             |
+
+No `WWW-Authenticate` or `Retry-After` header is added by this guard.
+
+### Validation, retry, and side effects
+
+- Authorization runs before validation inside admin route handlers. A valid
+  JSON request with an invalid or missing credential cannot trigger handler
+  validation, state mutation, database work, or a handler audit event.
+- The guard is stateless and has no credential lockout of its own. A request
+  rejected with `401` or `403` can be retried immediately with corrected
+  credentials, subject to the global rate limiter that runs earlier.
+- A `503` caused by missing `ADMIN_API_KEY` is recoverable once configuration
+  is supplied. The guard does not cache the previous failure.
+- Retrying `POST /api/admin/reindex` after a successful `202` while the same
+  job is running returns `409`; it does not start a second job.
+- If `PUT /api/admin/pause` cannot persist its state, it returns `503` and
+  leaves the in-memory pause flags unchanged, so a later retry is safe.
+
+### Observability and audit behavior
+
+Each execution of `requireAdminAuth` records one
+`fluxora_auth_apikey_lookup_duration_seconds` histogram observation labeled
+only with `outcome="success"` or `outcome="failure"`. The metric never includes
+the token, key identifier, address, or role. Requests to the public
+`/status/read-only` route do not execute this guard and therefore do not add an
+admin-auth observation.
+
+The guard itself does not create business audit records. Mutation handlers
+write their documented audit events only after authorization and their
+operation-specific success point; rejected authorization attempts do not
+produce those events. All requests still pass through the application's
+request logging and HTTP metrics middleware before reaching the router.
+
+### Regression surface
+
+Changes to any of the following are externally observable and require an
+intentional compatibility decision:
+
+- moving `/status/read-only` below the router guard or registering another
+  route above it;
+- changing the static-key/JWT role rules, or adding granular permission checks;
+- normalizing Bearer scheme casing or whitespace;
+- changing `503`/`401`/`403` classification or the legacy bare error bodies;
+- moving handler validation or side effects ahead of the guard;
+- allowing unknown `/api/admin/*` paths to bypass authorization;
+- adding auth retries, lockout, audit writes, identity metric labels, or token
+  material to logs;
+- changing reindex conflict or pause-persistence retry semantics.
 
 ## WebSocket disconnect
 
@@ -64,7 +161,12 @@ Response:
 {
   "results": [
     { "streamId": "stream-123", "action": "pause", "status": "success" },
-    { "streamId": "stream-456", "action": "cancel", "status": "failed", "error": "Stream not found" },
+    {
+      "streamId": "stream-456",
+      "action": "cancel",
+      "status": "failed",
+      "error": "Stream not found"
+    },
     { "streamId": "stream-789", "action": "reindex", "status": "success" }
   ],
   "successCount": 2,

--- a/tests/middleware/adminAuth.test.ts
+++ b/tests/middleware/adminAuth.test.ts
@@ -1,8 +1,10 @@
-import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { describe, it, expect, beforeAll, beforeEach, afterEach } from 'vitest';
 import request from 'supertest';
 import express from 'express';
 import { requireAdminAuth } from '../../src/middleware/adminAuth.js';
 import { authApiKeyLookupDurationSeconds } from '../../src/metrics/businessMetrics.js';
+import { generateToken } from '../../src/lib/auth.js';
+import { initializeConfig } from '../../src/config/env.js';
 
 function buildApp() {
   const app = express();
@@ -17,6 +19,10 @@ function buildApp() {
 describe('requireAdminAuth middleware', () => {
   const ADMIN_KEY = 'test-admin-secret-key-1234';
   let originalKey: string | undefined;
+
+  beforeAll(() => {
+    initializeConfig();
+  });
 
   beforeEach(() => {
     originalKey = process.env.ADMIN_API_KEY;
@@ -73,9 +79,7 @@ describe('requireAdminAuth middleware', () => {
 
   it('returns 403 when token has wrong length', async () => {
     process.env.ADMIN_API_KEY = ADMIN_KEY;
-    const res = await request(buildApp())
-      .get('/protected')
-      .set('Authorization', 'Bearer short');
+    const res = await request(buildApp()).get('/protected').set('Authorization', 'Bearer short');
     expect(res.status).toBe(403);
     expect(res.body.error).toMatch(/Invalid admin credentials/i);
   });
@@ -89,12 +93,64 @@ describe('requireAdminAuth middleware', () => {
     expect(res.body).toEqual({ ok: true });
   });
 
+  it.each(['admin', 'data-protection-officer'])(
+    'passes through for a valid JWT with the %s role',
+    async (role) => {
+      process.env.ADMIN_API_KEY = ADMIN_KEY;
+      const token = generateToken({ address: 'GADMIN', role, permissions: [] });
+
+      const res = await request(buildApp())
+        .get('/protected')
+        .set('Authorization', `Bearer ${token}`);
+
+      expect(res.status).toBe(200);
+      expect(res.body).toEqual({ ok: true });
+    }
+  );
+
+  it.each(['operator', 'viewer'])(
+    'returns 403 for a correctly signed JWT with the %s role',
+    async (role) => {
+      process.env.ADMIN_API_KEY = ADMIN_KEY;
+      const token = generateToken({ address: 'GNONADMIN', role });
+
+      const res = await request(buildApp())
+        .get('/protected')
+        .set('Authorization', `Bearer ${token}`);
+
+      expect(res.status).toBe(403);
+      expect(res.body).toEqual({ error: 'Invalid admin credentials.' });
+    }
+  );
+
+  it('fails closed before JWT verification when ADMIN_API_KEY is not configured', async () => {
+    delete process.env.ADMIN_API_KEY;
+    const token = generateToken({ address: 'GADMIN', role: 'admin' });
+
+    const res = await request(buildApp()).get('/protected').set('Authorization', `Bearer ${token}`);
+
+    expect(res.status).toBe(503);
+    expect(res.body).toEqual({
+      error: 'Admin API is not configured. Set ADMIN_API_KEY to enable admin access.',
+    });
+  });
+
+  it.each([
+    ['lowercase scheme', `bearer ${ADMIN_KEY}`],
+    ['repeated whitespace', `Bearer  ${ADMIN_KEY}`],
+  ])('returns 401 for %s instead of normalizing the header', async (_case, header) => {
+    process.env.ADMIN_API_KEY = ADMIN_KEY;
+
+    const res = await request(buildApp()).get('/protected').set('Authorization', header);
+
+    expect(res.status).toBe(401);
+    expect(res.body).toEqual({ error: 'Authorization header must use Bearer scheme.' });
+  });
+
   it('returns 401 when Authorization header exceeds maximum length', async () => {
     process.env.ADMIN_API_KEY = ADMIN_KEY;
     const oversized = 'Bearer ' + 'A'.repeat(8186);
-    const res = await request(buildApp())
-      .get('/protected')
-      .set('Authorization', oversized);
+    const res = await request(buildApp()).get('/protected').set('Authorization', oversized);
     expect(res.status).toBe(401);
     expect(res.body.error).toMatch(/too large/i);
   });
@@ -103,9 +159,7 @@ describe('requireAdminAuth middleware', () => {
     process.env.ADMIN_API_KEY = ADMIN_KEY;
     const exact = 'Bearer ' + 'A'.repeat(8185);
     expect(exact.length).toBe(8192);
-    const res = await request(buildApp())
-      .get('/protected')
-      .set('Authorization', exact);
+    const res = await request(buildApp()).get('/protected').set('Authorization', exact);
     // Header passed the length check and entered normal auth (token won't match)
     expect(res.status).toBe(403);
     expect(res.body.error).toMatch(/Invalid admin credentials/i);
@@ -115,9 +169,7 @@ describe('requireAdminAuth middleware', () => {
     process.env.ADMIN_API_KEY = ADMIN_KEY;
     const oversized = 'Bearer ' + ADMIN_KEY + 'A'.repeat(8200);
     expect(oversized.length).toBeGreaterThan(8192);
-    const res = await request(buildApp())
-      .get('/protected')
-      .set('Authorization', oversized);
+    const res = await request(buildApp()).get('/protected').set('Authorization', oversized);
     // Returns oversized error (401) rather than credential error (403),
     // proving split/timingSafeEqual were never reached.
     expect(res.status).toBe(401);
@@ -136,11 +188,17 @@ describe('requireAdminAuth middleware', () => {
      * declared labels). We assert on the count series to confirm the label
      * set is bounded to `outcome`.
      */
-    function findApiKeyCountSeries(values: any[], outcome: string) {
+    type HistogramValue = {
+      metricName?: string;
+      labels: Partial<Record<string, string | number>>;
+      value: number;
+    };
+
+    function findApiKeyCountSeries(values: HistogramValue[], outcome: string) {
       return values.find(
         (v) =>
           v.metricName === 'fluxora_auth_apikey_lookup_duration_seconds_count' &&
-          (v.labels as Record<string, string>).outcome === outcome,
+          (v.labels as Record<string, string>).outcome === outcome
       );
     }
 
@@ -155,6 +213,22 @@ describe('requireAdminAuth middleware', () => {
       const success = findApiKeyCountSeries(val.values, 'success');
       expect(success).toBeDefined();
       expect(success?.value).toBeGreaterThanOrEqual(1);
+      expect(Object.keys(success!.labels)).toEqual(['outcome']);
+    });
+
+    it('records outcome=success for an authorized JWT without adding identity labels', async () => {
+      process.env.ADMIN_API_KEY = ADMIN_KEY;
+      const token = generateToken({ address: 'GADMIN', role: 'admin' });
+
+      await request(buildApp())
+        .get('/protected')
+        .set('Authorization', `Bearer ${token}`)
+        .expect(200);
+
+      const val = await authApiKeyLookupDurationSeconds.get();
+      const success = findApiKeyCountSeries(val.values, 'success');
+      expect(success).toBeDefined();
+      expect(success?.value).toBe(1);
       expect(Object.keys(success!.labels)).toEqual(['outcome']);
     });
 

--- a/tests/routes/admin.test.ts
+++ b/tests/routes/admin.test.ts
@@ -1,7 +1,9 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeAll, beforeEach, afterEach } from 'vitest';
 import request from 'supertest';
 import { app } from '../../src/app.js';
 import { _resetForTest } from '../../src/state/adminState.js';
+import { generateToken } from '../../src/lib/auth.js';
+import { initializeConfig } from '../../src/config/env.js';
 
 const ADMIN_KEY = 'test-admin-key-for-routes';
 
@@ -11,6 +13,10 @@ function authed(req: request.Test): request.Test {
 
 describe('admin routes', () => {
   let originalKey: string | undefined;
+
+  beforeAll(() => {
+    initializeConfig();
+  });
 
   beforeEach(() => {
     originalKey = process.env.ADMIN_API_KEY;
@@ -31,12 +37,11 @@ describe('admin routes', () => {
   it('rejects unauthenticated requests to admin routes', async () => {
     const res = await request(app).get('/api/admin/status');
     expect(res.status).toBe(401);
+    expect(res.body).toEqual({ error: 'Missing Authorization header.' });
   });
 
   it('rejects requests with bad credentials', async () => {
-    const res = await request(app)
-      .get('/api/admin/status')
-      .set('Authorization', 'Bearer wrong');
+    const res = await request(app).get('/api/admin/status').set('Authorization', 'Bearer wrong');
     expect(res.status).toBe(403);
   });
 
@@ -51,6 +56,88 @@ describe('admin routes', () => {
       ingestion: false,
     });
     expect(res.body.meta).toHaveProperty('timestamp');
+  });
+
+  it('keeps read-only status public when admin auth is unconfigured or invalid', async () => {
+    delete process.env.ADMIN_API_KEY;
+
+    const unconfigured = await request(app).get('/api/admin/status/read-only');
+    const malformed = await request(app)
+      .get('/api/admin/status/read-only')
+      .set('Authorization', 'Basic ignored-on-public-route');
+
+    expect(unconfigured.status).toBe(200);
+    expect(malformed.status).toBe(200);
+  });
+
+  it('fails protected routes closed with 503 when admin auth is unconfigured', async () => {
+    delete process.env.ADMIN_API_KEY;
+
+    const res = await request(app).get('/api/admin/status');
+
+    expect(res.status).toBe(503);
+    expect(res.body).toEqual({
+      error: 'Admin API is not configured. Set ADMIN_API_KEY to enable admin access.',
+    });
+  });
+
+  it('protects other methods on the public read-only path', async () => {
+    const res = await request(app).post('/api/admin/status/read-only');
+
+    expect(res.status).toBe(401);
+    expect(res.body).toEqual({ error: 'Missing Authorization header.' });
+  });
+
+  it('runs the guard before returning 404 for unknown admin paths', async () => {
+    const unauthenticated = await request(app).get('/api/admin/not-a-route');
+    const authenticated = await authed(request(app).get('/api/admin/not-a-route'));
+
+    expect(unauthenticated.status).toBe(401);
+    expect(authenticated.status).toBe(404);
+    expect(authenticated.body).toMatchObject({
+      success: false,
+      error: { code: 'NOT_FOUND' },
+    });
+  });
+
+  it.each(['admin', 'data-protection-officer'])(
+    'allows a valid JWT with the %s role through the route guard',
+    async (role) => {
+      const token = generateToken({ address: 'GADMIN', role, permissions: [] });
+      const res = await request(app)
+        .get('/api/admin/status')
+        .set('Authorization', `Bearer ${token}`);
+
+      expect(res.status).toBe(200);
+    }
+  );
+
+  it('rejects a valid non-admin JWT even when it carries an admin-named permission', async () => {
+    const token = generateToken({
+      address: 'GOPERATOR',
+      role: 'operator',
+      permissions: ['admin:pause'],
+    });
+    const res = await request(app).get('/api/admin/status').set('Authorization', `Bearer ${token}`);
+
+    expect(res.status).toBe(403);
+    expect(res.body).toEqual({ error: 'Invalid admin credentials.' });
+  });
+
+  it('does not lock out a later retry with valid credentials', async () => {
+    await request(app).get('/api/admin/status').set('Authorization', 'Bearer wrong').expect(403);
+
+    const retry = await authed(request(app).get('/api/admin/status'));
+
+    expect(retry.status).toBe(200);
+  });
+
+  it('runs authorization before handler validation and mutation', async () => {
+    const rejected = await request(app).put('/api/admin/pause').send({ streamCreation: true });
+    const state = await authed(request(app).get('/api/admin/pause'));
+
+    expect(rejected.status).toBe(401);
+    expect(state.body.data).toEqual({ streamCreation: false, ingestion: false });
   });
 
   // ── GET /api/admin/status ──────────────────────────────────
@@ -89,9 +176,7 @@ describe('admin routes', () => {
 
   describe('PUT /api/admin/pause', () => {
     it('updates streamCreation flag in envelope', async () => {
-      const res = await authed(
-        request(app).put('/api/admin/pause').send({ streamCreation: true }),
-      );
+      const res = await authed(request(app).put('/api/admin/pause').send({ streamCreation: true }));
       expect(res.status).toBe(200);
       expect(res.body).toHaveProperty('success', true);
       expect(res.body).toHaveProperty('data');
@@ -102,9 +187,7 @@ describe('admin routes', () => {
     });
 
     it('updates ingestion flag in envelope', async () => {
-      const res = await authed(
-        request(app).put('/api/admin/pause').send({ ingestion: true }),
-      );
+      const res = await authed(request(app).put('/api/admin/pause').send({ ingestion: true }));
       expect(res.status).toBe(200);
       expect(res.body).toHaveProperty('success', true);
       expect(res.body.data.pauseFlags.ingestion).toBe(true);
@@ -112,9 +195,7 @@ describe('admin routes', () => {
 
     it('updates both flags at once in envelope', async () => {
       const res = await authed(
-        request(app)
-          .put('/api/admin/pause')
-          .send({ streamCreation: true, ingestion: true }),
+        request(app).put('/api/admin/pause').send({ streamCreation: true, ingestion: true })
       );
       expect(res.status).toBe(200);
       expect(res.body).toHaveProperty('success', true);
@@ -123,9 +204,7 @@ describe('admin routes', () => {
     });
 
     it('returns 400 error envelope when body is empty', async () => {
-      const res = await authed(
-        request(app).put('/api/admin/pause').send({}),
-      );
+      const res = await authed(request(app).put('/api/admin/pause').send({}));
       expect(res.status).toBe(400);
       expect(res.body).toHaveProperty('success', false);
       expect(res.body).toHaveProperty('error');
@@ -136,7 +215,7 @@ describe('admin routes', () => {
 
     it('returns 400 error envelope when streamCreation is not boolean', async () => {
       const res = await authed(
-        request(app).put('/api/admin/pause').send({ streamCreation: 'yes' }),
+        request(app).put('/api/admin/pause').send({ streamCreation: 'yes' })
       );
       expect(res.status).toBe(400);
       expect(res.body).toHaveProperty('success', false);
@@ -144,9 +223,7 @@ describe('admin routes', () => {
     });
 
     it('returns 400 error envelope when ingestion is not boolean', async () => {
-      const res = await authed(
-        request(app).put('/api/admin/pause').send({ ingestion: 42 }),
-      );
+      const res = await authed(request(app).put('/api/admin/pause').send({ ingestion: 42 }));
       expect(res.status).toBe(400);
       expect(res.body).toHaveProperty('success', false);
       expect(res.body.error.message).toMatch(/boolean/i);


### PR DESCRIPTION
## PR Title

closes #1077 

## Summary

This PR documents the current admin route authorization and guard behavior and adds regression coverage for previously implicit edge cases.

No production route or middleware behavior has been changed.

## What changed

- Documented the `/api/admin` authorization contract.
- Clarified that `GET /api/admin/status/read-only` is public.
- Confirmed all other `/api/admin/*` requests pass through `requireAdminAuth`.
- Documented accepted credentials:
  - Exact `ADMIN_API_KEY`
  - Valid JWT with `admin` role
  - Valid JWT with `data-protection-officer` role
- Documented existing `503`, `401`, and `403` failure behavior.
- Documented validation ordering, retry behavior, audit behavior, and auth metrics.
- Added regression tests covering:
  - Fail-closed behavior when admin auth is unconfigured
  - Bearer header parsing edge cases
  - Admin and DPO JWT authorization
  - Rejection of operator/viewer JWTs, including tokens with admin-named permissions
  - Public read-only route behavior
  - Guarding unknown admin routes before returning `404`
  - Guard execution before handler validation and mutation
  - Successful retry after invalid credentials
  - JWT authentication metric labels

## Current behavior preserved

- `GET /api/admin/status/read-only` remains publicly accessible.
- Missing `ADMIN_API_KEY` returns `503`.
- Missing or malformed authorization returns `401`.
- Invalid credentials return `403`.
- Static admin keys and authorized JWT roles continue to work.
- Admin auth errors retain their existing bare JSON response shape.
- Rejected requests do not reach handler validation, mutation, or business audit events.
- Reindex and pause retry semantics remain unchanged.

## Regression surface

Future changes should explicitly consider compatibility when modifying:

- The placement of the public read-only route
- Static-key or JWT role authorization
- Bearer scheme parsing
- Auth status codes or response bodies
- Guard and validation ordering
- Unknown admin route handling
- Authentication metrics or audit behavior
- Pause persistence and reindex conflict semantics

## Testing

- `54/54` focused admin authorization, pause, and reindex tests passed.
- Targeted ESLint passed.
- Prettier validation passed.
- `git diff --check` passed.

## Known repository issue

The repository-wide TypeScript check is currently blocked by pre-existing syntax errors in:

- `tests/integration/broadcast-auth.test.ts`
- `tests/redis/dedup.test.ts`

These files were not modified by this PR.