### PR TITLE
check phase commit:

### DIFF
--- a/docs/security.md
+++ b/docs/security.md
@@ -44,11 +44,11 @@ To protect browser-originated clients (such as dashboard applications) against C
    - **Cookie-Authenticated Sessions**: Requests that rely on ambient browser cookies (and do not supply Bearer or API-key credentials) MUST present both the `fluxora_csrf` cookie and matching `X-CSRF-Token` header.
 
 3. **Constant-Time Token Comparison**:
-   Token comparison is executed in constant time using Node.js `crypto.timingSafeEqual` with byte-length matching (identical to `src/webhooks/signature.ts`) to prevent timing side-channel attacks:
+   Token comparison is executed in constant time using the same HMAC-SHA256 approach as `src/webhooks/signature.ts`. Both inputs are HMAC-hashed before comparison with `crypto.timingSafeEqual` to eliminate timing side-channels from variable-length inputs:
    ```ts
-   const bufA = Buffer.from(cookieToken, 'utf8');
-   const bufB = Buffer.from(headerToken, 'utf8');
-   const isValid = bufA.length === bufB.length && timingSafeEqual(bufA, bufB);
+   const hashA = createHmac('sha256', key).update(cookieToken).digest('hex');
+   const hashB = createHmac('sha256', key).update(headerToken).digest('hex');
+   const isValid = timingSafeEqual(Buffer.from(hashA, 'utf8'), Buffer.from(hashB, 'utf8'));
    ```
 
 4. **Error Handling**:

--- a/src/middleware/csrf.ts
+++ b/src/middleware/csrf.ts
@@ -1,5 +1,5 @@
 import type { Request, Response, NextFunction } from 'express';
-import { timingSafeEqual, randomBytes } from 'node:crypto';
+import { createHmac, timingSafeEqual, randomBytes } from 'node:crypto';
 import { errorResponse } from '../utils/response.js';
 import { ApiErrorCode } from './errorHandler.js';
 import { getApiKeyFromRequest } from '../lib/apiKey.js';
@@ -9,6 +9,14 @@ export const CSRF_COOKIE_NAME = 'fluxora_csrf';
 
 /** Header name expected on mutating browser-originated requests containing the CSRF token. */
 export const CSRF_HEADER_NAME = 'x-csrf-token';
+
+/**
+ * Fixed HMAC key used for constant-time CSRF token comparison.
+ * Matches the pattern in `src/webhooks/signature.ts` where both inputs are
+ * HMAC-hashed before comparison to eliminate timing side-channels from
+ * variable-length inputs.
+ */
+const CSRF_COMPARE_KEY = 'fluxora-csrf-compare';
 
 /**
  * Helper function to parse raw Cookie header string into a record of key-value pairs.
@@ -79,23 +87,19 @@ export function isCookieAuthenticated(req: Request): boolean {
 
 /**
  * Compares two CSRF token strings in constant time to protect against timing attacks.
- * Uses Node.js `crypto.timingSafeEqual` with byte-length pre-verification.
- * Matches the constant-time verification pattern used in `src/webhooks/signature.ts`.
+ * Both inputs are HMAC-SHA256-hashed before comparison using `crypto.timingSafeEqual`,
+ * matching the constant-time verification pattern used in `src/webhooks/signature.ts`.
+ * This eliminates timing side-channels from variable-length inputs.
  *
  * @param tokenA - First CSRF token string (e.g. from cookie)
  * @param tokenB - Second CSRF token string (e.g. from header)
- * @returns true if tokens are identical byte-for-byte in constant time, false otherwise
+ * @returns true if tokens are identical in constant time, false otherwise
  */
 export function safeCompareCsrfTokens(tokenA?: string, tokenB?: string): boolean {
   if (!tokenA || !tokenB) return false;
-  const bufA = Buffer.from(tokenA, 'utf8');
-  const bufB = Buffer.from(tokenB, 'utf8');
-
-  if (bufA.length !== bufB.length) {
-    return false;
-  }
-
-  return timingSafeEqual(bufA, bufB);
+  const hashA = createHmac('sha256', CSRF_COMPARE_KEY).update(tokenA).digest('hex');
+  const hashB = createHmac('sha256', CSRF_COMPARE_KEY).update(tokenB).digest('hex');
+  return timingSafeEqual(Buffer.from(hashA, 'utf8'), Buffer.from(hashB, 'utf8'));
 }
 
 /**


### PR DESCRIPTION
Updates the CSRF token comparison in `safeCompareCsrfTokens` to use the **same** HMAC-SHA256 constant-time approach already used in `src/webhooks/signature.ts`.

### What changed

- **`src/middleware/csrf.ts`**: Both CSRF token inputs are now HMAC-hashed with `createHmac('sha256', key)` before being compared with `crypto.timingSafeEqual`. This eliminates the timing side-channel that a byte-length pre-check can leak, and mirrors the `constantTimeCompare` function in `src/webhooks/signature.ts` exactly.
- **`docs/security.md`**: Updated the code documentation to reflect the HMAC-based approach.

### Why

The previous implementation did a `bufA.length !== bufB.length` early return before `timingSafeEqual`, which could leak token length information. By hashing both inputs first (always producing 64-char hex strings), the comparison is truly constant-time end-to-end — consistent with the rest of the codebase.

### Security

- CSRF checks still apply **only** to cookie-authenticated requests (Bearer JWT and API-Key bypass as before)
- Safe methods (GET, HEAD, OPTIONS) still bypass
- Token comparison is now fully aligned with `src/webhooks/signature.ts`

closes #736 