### PR TITLE
Enhance database operations documentation and improve partition management logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,12 +141,13 @@ Response:
 }
 ```
 
-### Partition Management
+### Scripted Database Operations & Partition Management
 
-The `contract_events` table is range-partitioned by `happened_at` to prevent unbounded growth.
-Partitions are rotated and dropped automatically based on a configurable retention policy.
-- An ops script `dropOldPartitions` in `src/scripts/db-ops.ts` is available to detach and drop partitions older than a specified number of days.
-- By default, it runs in a `dryRun` mode. To actually drop data, invoke it with `dryRun = false`.
+Scripted database backup, restore, and partition retention operations are managed via `src/scripts/db-ops.ts`.
+- `backupDatabase` / `restoreDatabase`: Support local custom-format dumps as well as zero-disk S3 streaming.
+- `dropOldPartitions`: Detaches and drops range partitions older than a specified threshold. Runs in `dryRun = true` mode by default.
+
+For complete details on operator ergonomics, security controls, credential protection, and region resolution, see [docs/database.md](docs/database.md#scripted-database-operations--operator-ergonomics).
 
 ## 🧪 Testing
 

--- a/docs/database.md
+++ b/docs/database.md
@@ -606,3 +606,118 @@ pnpm run migrate
 ### Tests
 
 Unit tests for the queue are in `tests/jobs/queue.test.ts`. They mock pg-boss using `vi.mock()` to test the `JobQueue` class independently of a real database.
+
+---
+
+## Scripted Database Operations & Operator Ergonomics
+
+### Overview & Architecture
+
+Script-based database operations reside in [`src/scripts/db-ops.ts`](../src/scripts/db-ops.ts). This module provides production-grade wrappers around PostgreSQL utilities (`pg_dump` and `pg_restore`) as well as SQL partition cleanup utilities (`dropOldPartitions`).
+
+The design prioritizes zero-disk footprint (streaming dumps directly to/from S3), strict shell injection safety, credential isolation, and fail-safe operator defaults.
+
+```
+                  ┌──────────────────────────────────────────────┐
+                  │              src/scripts/db-ops.ts           │
+                  └──────┬───────────────────────────────┬───────┘
+                         │                               │
+             ┌───────────▼───────────┐       ┌───────────▼───────────┐
+             │    backupDatabase     │       │    restoreDatabase    │
+             └─────┬───────────┬─────┘       └─────┬───────────┬─────┘
+                   │           │                   │           │
+           (Local) │           │ (S3 Stream)  (Local)│           │ (S3 Stream)
+                   ▼           ▼                   ▼           ▼
+             execFile       spawn               execFile     spawn
+            "pg_dump"     "pg_dump"            "pg_restore" "pg_restore"
+             └─► Disk      └─► S3 Upload         ▲           ▲
+                                                 │           │
+                                                Disk       S3 Stream
+```
+
+### Core Operations Reference
+
+#### 1. `backupDatabase(databaseUrl, outputPath, s3Target?)`
+
+Generates a custom-format PostgreSQL database backup (`--format=custom`).
+
+- **Local Mode** (`s3Target` omitted): Executes `pg_dump` via `execFile`, writing output directly to `outputPath`.
+- **S3 Streaming Mode** (`s3Target` provided): Spawns `pg_dump` stdout stream piped into a `PassThrough` stream to AWS S3 using `@aws-sdk/lib-storage` `Upload`. The dump streams directly to S3 without creating temporary files on the local filesystem.
+- **Return Type**: `Promise<DbOperationResult>` where:
+  ```typescript
+  export interface DbOperationResult {
+    success: boolean;
+    message: string;
+    /** Raw stderr / error detail — never contains connection passwords or AWS keys */
+    error?: string;
+  }
+  ```
+
+#### 2. `restoreDatabase(databaseUrl, inputPath, s3Source?)`
+
+Restores a custom-format PostgreSQL database dump using `pg_restore`.
+
+- **Local Mode** (`s3Source` omitted): Executes `pg_restore` via `execFile` from `inputPath`.
+- **S3 Streaming Mode** (`s3Source` provided): Downloads object body via S3 `GetObjectCommand` and streams `response.Body` directly into `pg_restore` standard input (`stdin`).
+- **Flags Used**:
+  - `--clean`: Drops database objects before restoring them.
+  - `--no-owner`: Skips restoration of original object ownership, enabling portable restores across environments with different database roles.
+  - `--no-password`: Prevents prompt hanging when credentials are missing or invalid.
+
+> [!WARNING]
+> `--clean` drops existing database tables/objects before recreating them. Ensure active database connections are closed or quieted before invoking `restoreDatabase` in production.
+
+#### 3. `dropOldPartitions(pool, parentTable, olderThanDays, dryRun = true)`
+
+Performs retention-based partition pruning for range-partitioned tables such as `contract_events`.
+
+- **Bound Extraction**: Queries `pg_inherits` and `pg_class`, extracting upper bound date strings using `/TO \('([^']+)'\)/` from `pg_get_expr(c.relpartbound, c.oid)`.
+- **Default Partition Handling**: Automatically skips the `DEFAULT` partition (`partition_bound === 'DEFAULT'`).
+- **Dry-Run Safety**: Defaults `dryRun = true`. Operators must explicitly pass `dryRun = false` to execute `DROP TABLE IF EXISTS`.
+
+### Security & Credential Protection
+
+1. **Input Validation**:
+   - Connection strings: Validated against `^postgre(?:s|sql):\/\/` before spawning subprocesses. Rejects empty strings, whitespace, and non-postgres schemes (`mysql://`, `redis://`, etc.).
+   - File paths: Validated to reject empty strings and shell control characters (`[\0`$|;&<>]`).
+2. **Subprocess Isolation**:
+   - Uses Node.js `execFile` (array form) and `spawn` with explicit argument vectors.
+   - Arguments are never concatenated into a shell string, eliminating shell injection vectors.
+3. **Password & Credential Masking**:
+   - `DATABASE_URL` credentials and AWS secrets are consumed strictly from environment variables or argument inputs.
+   - Raw database passwords are never printed to console or leaked inside `DbOperationResult.error` strings during error conditions.
+4. **AWS Credential Isolation**:
+   - Uses AWS SDK v3 environment provider chain (`AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_SESSION_TOKEN`).
+   - S3 credentials are never logged or stored in job results.
+
+### Decimal-String Serialization Guarantee
+
+Financial and numerical fields in Fluxora (e.g. event stream amounts, token balances) are stored as decimal strings in database `TEXT` or `NUMERIC` columns.
+
+The `db-ops` module processes backup and restore operations purely as binary/text byte streams. No JSON coercion or numeric parsing is applied to table records, guaranteeing zero loss of precision for monetary values.
+
+### Operator Ergonomics & Safety Controls
+
+| Ergonomic Control | Behavior | Benefit |
+|---|---|---|
+| **Default Dry Run** | `dropOldPartitions` defaults `dryRun = true` | Prevents accidental data deletion if invoked without arguments |
+| **Lazy AWS SDK Loading** | Dynamic `import('@aws-sdk/client-s3')` and `import('@aws-sdk/lib-storage')` | `db-ops.ts` runs in local-only mode even when `@aws-sdk` packages are not installed |
+| **AWS Region Resolution** | `s3Target.region` ➔ `AWS_REGION` ➔ `AWS_DEFAULT_REGION` ➔ `'us-east-1'` | Flexible environment configuration across AWS ECS, Lambda, and local environments |
+| **Whitespace Normalization** | Trims leading/trailing whitespace from `databaseUrl`, `outputPath`, and `inputPath` | Prevents spurious validation failures from whitespace in config files or CLI input |
+| **Clean Output Interface** | `DbOperationResult` standardizes `{ success, message, error }` | Simplifies caller code, logging, and error handling |
+
+### Regression Surface & Edge-Case Matrix
+
+| Component / Function | Input / Condition | Expected Behavior | Failure Mode / Mitigation |
+|---|---|---|---|
+| `backupDatabase` | Empty or whitespace `databaseUrl` | Returns `{ success: false, message: 'DATABASE_URL is required...' }` | Fast failure before subprocess creation |
+| `backupDatabase` | Non-postgres scheme (`mysql://`) | Returns `{ success: false, message: 'DATABASE_URL must be a valid PostgreSQL...' }` | Fast failure before subprocess creation |
+| `backupDatabase` | File path with `;` or `` ` `` | Returns `{ success: false, message: 'Output path contains invalid characters.' }` | Rejection of unsafe path inputs |
+| `backupDatabase` | Local mode, `pg_dump` fails | Returns `{ success: false, message: 'Backup failed', error: <stderr> }` | Error captured without password leakage |
+| `backupDatabase` | S3 mode, AWS SDK missing | Throws Error: `'AWS SDK v3 is not installed...'` | Clear diagnostic message asking user to install SDK |
+| `backupDatabase` | S3 mode, `pg_dump` non-zero exit | Returns `{ success: false, message: 'Backup failed', error: <stderr> }` | S3 upload discarded, error reported |
+| `restoreDatabase` | S3 mode, S3 object body null/empty | Returns `{ success: false, message: 'Restore failed', error: 'S3 object ... returned an empty body' }` | Prevents hanging `pg_restore` on empty input |
+| `dropOldPartitions` | Table has `DEFAULT` partition | `DEFAULT` partition is skipped; never dropped | Prevents dropping catch-all partition |
+| `dropOldPartitions` | Unparseable partition bound | Partition is skipped without throwing | Log/continue without breaking retention task |
+| `dropOldPartitions` | `dryRun = true` | Returns list of partition names in `droppedPartitions`; no `DROP TABLE` query issued | Safe audit before execution |
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -48,6 +48,7 @@
         "@typescript-eslint/eslint-plugin": "^8.59.0",
         "@typescript-eslint/parser": "^8.59.0",
         "@vitest/coverage-v8": "^3.2.6",
+        "aws-sdk-client-mock": "^4.1.0",
         "eslint": "^10.2.1",
         "eslint-config-prettier": "^10.1.8",
         "fast-check": "^4.8.0",
@@ -3868,6 +3869,47 @@
       "hasInstallScript": true,
       "license": "Apache-2.0"
     },
+    "node_modules/@sinonjs/commons": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-3.0.1.tgz",
+      "integrity": "sha512-K3mCHKQ9sVh8o1C9cxkwxaOmXoAMlDxC1mYyHrjqOWEcBjYr76t96zL2zlj5dUGZ3HSw240X1qgH3Mjf1yJWpQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "type-detect": "4.0.8"
+      }
+    },
+    "node_modules/@sinonjs/fake-timers": {
+      "version": "11.2.2",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-11.2.2.tgz",
+      "integrity": "sha512-G2piCSxQ7oWOxwGSAyFHfPIsyeJGXYtc6mFbnFA+kRXkiEnTl8c/8jul2S329iFBnDI9HGoeWWAZvuvOkZccgw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@sinonjs/commons": "^3.0.0"
+      }
+    },
+    "node_modules/@sinonjs/samsam": {
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-8.0.3.tgz",
+      "integrity": "sha512-hw6HbX+GyVZzmaYNh82Ecj1vdGZrqVIn/keDTg63IgAwiQPO+xCz99uG6Woqgb4tM0mUiFENKZ4cqd7IX94AXQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@sinonjs/commons": "^3.0.1",
+        "type-detect": "^4.1.0"
+      }
+    },
+    "node_modules/@sinonjs/samsam/node_modules/type-detect": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.1.0.tgz",
+      "integrity": "sha512-Acylog8/luQ8L7il+geoSxhEkazvkslg7PSNKOX59mbB9cOveP5aq9h74Y7YU8yDpJwetzQQrfIwtf4Wp4LKcw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/@types/body-parser": {
       "version": "1.19.6",
       "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.6.tgz",
@@ -4080,6 +4122,23 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@types/shimmer/-/shimmer-1.2.0.tgz",
       "integrity": "sha512-UE7oxhQLLd9gub6JKIAhDq06T0F6FnztwMNRvYgjeQSBeMc1ZG/tA47EwfduvkuQS8apbkM/lpLpWsaCeYsXVg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/sinon": {
+      "version": "17.0.4",
+      "resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-17.0.4.tgz",
+      "integrity": "sha512-RHnIrhfPO3+tJT0s7cFaXGZvsL4bbR3/k7z3P312qMS4JaS2Tk+KiwiLx1S0rQ56ERj00u1/BtdyVd0FY+Pdew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/sinonjs__fake-timers": "*"
+      }
+    },
+    "node_modules/@types/sinonjs__fake-timers": {
+      "version": "15.0.1",
+      "resolved": "https://registry.npmjs.org/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-15.0.1.tgz",
+      "integrity": "sha512-Ko2tjWJq8oozHzHV+reuvS5KYIRAokHnGbDwGh/J64LntgpbuylF74ipEL24HCyRjf9FOlBiBHWBR1RlVKsI1w==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/superagent": {
@@ -4629,6 +4688,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/aws-sdk-client-mock": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk-client-mock/-/aws-sdk-client-mock-4.1.0.tgz",
+      "integrity": "sha512-h/tOYTkXEsAcV3//6C1/7U4ifSpKyJvb6auveAepqqNJl6TdZaPFEtKjBQNf8UxQdDP850knB2i/whq4zlsxJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/sinon": "^17.0.3",
+        "sinon": "^18.0.1",
+        "tslib": "^2.1.0"
+      }
+    },
     "node_modules/balanced-match": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
@@ -5009,6 +5080,16 @@
       "dependencies": {
         "asap": "^2.0.0",
         "wrappy": "1"
+      }
+    },
+    "node_modules/diff": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-5.2.2.tgz",
+      "integrity": "sha512-vtcDfH3TOjP8UekytvnHH1o1P4FcUdt4eQ1Y+Abap1tk/OB2MWQvcwS2ClCd1zuIhc3JKOx6p3kod8Vfys3E+A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
       }
     },
     "node_modules/dotenv": {
@@ -6351,6 +6432,13 @@
         "npm": ">=6"
       }
     },
+    "node_modules/just-extend": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-6.2.0.tgz",
+      "integrity": "sha512-cYofQu2Xpom82S6qD778jBDpwvvy39s1l/hrYij2u9AMdQcGRpaBu6kY4mVhuno5kJVi1DAz4aiphA2WI1/OAw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/jwa": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
@@ -6664,6 +6752,40 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/nise": {
+      "version": "6.1.5",
+      "resolved": "https://registry.npmjs.org/nise/-/nise-6.1.5.tgz",
+      "integrity": "sha512-SnRDPDBjxZZoU2n0+gzzLtSvo1OZo7j6jnbXsoh3AFxEGhaFU7ZF0TmefuKERq79wxR2U+MPn7ArW+Tl+clC3A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@sinonjs/commons": "^3.0.1",
+        "@sinonjs/fake-timers": "^15.1.1",
+        "just-extend": "^6.2.0",
+        "path-to-regexp": "^8.3.0"
+      }
+    },
+    "node_modules/nise/node_modules/@sinonjs/fake-timers": {
+      "version": "15.4.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-15.4.0.tgz",
+      "integrity": "sha512-DsG+8/LscQIQg68J6Ef3dv10u6nVyetYn923s3/sus5eaGfTo1of5WMZSLf0UJc9KDuKPilPH0UDJCjvNbDNCA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@sinonjs/commons": "^3.0.1"
+      }
+    },
+    "node_modules/nise/node_modules/path-to-regexp": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/node-pg-migrate": {
@@ -7583,6 +7705,25 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/sinon": {
+      "version": "18.0.1",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-18.0.1.tgz",
+      "integrity": "sha512-a2N2TDY1uGviajJ6r4D1CyRAkzE9NNVlYOV1wX5xQDuAk0ONgzgRl0EjCQuRCPxOwp13ghsMwt9Gdldujs39qw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@sinonjs/commons": "^3.0.1",
+        "@sinonjs/fake-timers": "11.2.2",
+        "@sinonjs/samsam": "^8.0.0",
+        "diff": "^5.2.0",
+        "nise": "^6.0.0",
+        "supports-color": "^7"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/sinon"
+      }
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -7850,12 +7991,6 @@
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
       "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
-      "dev": true
-    },
-    "node_modules/tinyexec": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
-      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
       "dev": true,
       "license": "MIT"
     },
@@ -7944,6 +8079,13 @@
         "typescript": ">=4.8.4"
       }
     },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD"
+    },
     "node_modules/tsx": {
       "version": "4.22.4",
       "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.22.4.tgz",
@@ -7974,6 +8116,16 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/type-detect": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/type-fest": {

--- a/src/scripts/db-ops.ts
+++ b/src/scripts/db-ops.ts
@@ -441,7 +441,7 @@ export async function dropOldPartitions(
     const pName = row.partition_name;
     const pBound = row.partition_bound;
     
-    if (pBound === 'DEFAULT') continue;
+    if (!pBound || pBound === 'DEFAULT') continue;
     
     // Bounds typically look like: FOR VALUES FROM ('2023-01-01 00:00:00+00') TO ('2023-02-01 00:00:00+00')
     // Note: literal parentheses in pg_get_expr output — no backslash escaping needed.

--- a/tests/db-ops.test.ts
+++ b/tests/db-ops.test.ts
@@ -268,6 +268,82 @@ describe('backupDatabase', () => {
     expect(result.message).toBe('Backup failed')
     expect(result.error).toContain('S3 upload failed')
   })
+
+  it('resolves AWS region according to priority hierarchy (target.region > AWS_REGION > AWS_DEFAULT_REGION > us-east-1)', async () => {
+    const { S3Client } = await import('@aws-sdk/client-s3') as { S3Client: MockInstance }
+
+    const originalRegion = process.env.AWS_REGION
+    const originalDefaultRegion = process.env.AWS_DEFAULT_REGION
+
+    try {
+      // 1. Explicit target region takes top priority
+      process.env.AWS_REGION = 'eu-west-1'
+      process.env.AWS_DEFAULT_REGION = 'ap-southeast-1'
+
+      const fakeChild1 = makeFakeChild(0)
+      ;(childProcess.spawn as unknown as MockInstance).mockReturnValue(fakeChild1)
+
+      await backupDatabase(VALID_URL, '', { bucket: 'b1', key: 'k1', region: 'ca-central-1' })
+      expect(S3Client).toHaveBeenLastCalledWith({ region: 'ca-central-1' })
+
+      // 2. AWS_REGION env var takes second priority when target region is omitted
+      const fakeChild2 = makeFakeChild(0)
+      ;(childProcess.spawn as unknown as MockInstance).mockReturnValue(fakeChild2)
+
+      await backupDatabase(VALID_URL, '', { bucket: 'b1', key: 'k1' })
+      expect(S3Client).toHaveBeenLastCalledWith({ region: 'eu-west-1' })
+
+      // 3. AWS_DEFAULT_REGION env var takes third priority
+      delete process.env.AWS_REGION
+      const fakeChild3 = makeFakeChild(0)
+      ;(childProcess.spawn as unknown as MockInstance).mockReturnValue(fakeChild3)
+
+      await backupDatabase(VALID_URL, '', { bucket: 'b1', key: 'k1' })
+      expect(S3Client).toHaveBeenLastCalledWith({ region: 'ap-southeast-1' })
+
+      // 4. Default fallback is 'us-east-1'
+      delete process.env.AWS_DEFAULT_REGION
+      const fakeChild4 = makeFakeChild(0)
+      ;(childProcess.spawn as unknown as MockInstance).mockReturnValue(fakeChild4)
+
+      await backupDatabase(VALID_URL, '', { bucket: 'b1', key: 'k1' })
+      expect(S3Client).toHaveBeenLastCalledWith({ region: 'us-east-1' })
+    } finally {
+      process.env.AWS_REGION = originalRegion
+      process.env.AWS_DEFAULT_REGION = originalDefaultRegion
+    }
+  })
+
+  it('handles child process error event (e.g. pg_dump ENOENT)', async () => {
+    const stdout = new PassThrough()
+    const stderr = new PassThrough()
+    const stdin = new PassThrough()
+    stdout.end()
+
+    const fakeChild: Record<string, unknown> = {
+      stdout,
+      stderr,
+      stdin,
+      on: vi.fn((event: string, cb: (err: Error) => void) => {
+        if (event === 'error') {
+          Promise.resolve().then(() => {
+            cb(new Error('spawn pg_dump ENOENT'))
+          })
+        }
+        return fakeChild
+      }),
+    }
+    ;(childProcess.spawn as unknown as MockInstance).mockReturnValue(fakeChild)
+
+    const result = await backupDatabase(VALID_URL, '', {
+      bucket: 'my-backups',
+      key: 'fluxora/enoent.dump',
+    })
+
+    expect(result.success).toBe(false)
+    expect(result.message).toBe('Backup failed')
+    expect(result.error).toContain('spawn pg_dump ENOENT')
+  })
 })
 
 // ── restoreDatabase ───────────────────────────────────────────────────────────
@@ -507,5 +583,40 @@ describe('dropOldPartitions', () => {
     // The first query gets the partitions, but DROP TABLE is never called
     expect(fakePool.query).toHaveBeenCalledTimes(1);
     expect(fakePool.query).toHaveBeenCalledWith(expect.stringContaining('SELECT'), ['contract_events']);
+  })
+
+  it('defaults dryRun to true when omitted', async () => {
+    const fakePool = {
+      query: vi.fn().mockResolvedValue({
+        rows: [
+          { partition_name: 'contract_events_old', partition_bound: "FOR VALUES FROM ('2020-01-01 00:00:00+00') TO ('2020-02-01 00:00:00+00')" }
+        ]
+      })
+    } as unknown as import('pg').Pool;
+
+    // Call without dryRun argument
+    const result = await dropOldPartitions(fakePool, 'contract_events', 30);
+    
+    expect(result.droppedPartitions).toContain('contract_events_old');
+    expect(result.message).toContain('[DRY RUN]');
+    expect(fakePool.query).toHaveBeenCalledTimes(1);
+  })
+
+  it('handles null or missing partition_bound values gracefully without throwing', async () => {
+    const fakePool = {
+      query: vi.fn().mockResolvedValue({
+        rows: [
+          { partition_name: 'contract_events_null', partition_bound: null },
+          { partition_name: 'contract_events_empty', partition_bound: '' },
+          { partition_name: 'contract_events_old', partition_bound: "FOR VALUES FROM ('2020-01-01 00:00:00+00') TO ('2020-02-01 00:00:00+00')" }
+        ]
+      })
+    } as unknown as import('pg').Pool;
+
+    const result = await dropOldPartitions(fakePool, 'contract_events', 30, true);
+    
+    expect(result.droppedPartitions).toContain('contract_events_old');
+    expect(result.droppedPartitions).not.toContain('contract_events_null');
+    expect(result.droppedPartitions).not.toContain('contract_events_empty');
   })
 })


### PR DESCRIPTION
### **Document script-based db ops**

Closes #1097

### **Changes Made**
- Updated README.md to reflect new scripted database operations and partition management features.
- Expanded database.md with detailed descriptions of backup, restore, and partition cleanup operations.
- Modified db-ops.ts to handle null or missing partition bounds gracefully.
- Added tests for AWS region resolution and error handling in db-ops.test.ts.