### PR TITLE
harden sdk generation contract, Stabilize SDK generation contract, Do…

### DIFF
--- a/scripts/generate-sdk-ts.mjs
+++ b/scripts/generate-sdk-ts.mjs
@@ -262,6 +262,7 @@ Zero external runtime dependencies; uses the standard Web \`fetch\` API.
 | **Typed error hierarchy** | \`FluxoraApiError\`, \`IdempotencyConflictError\`, \`ValidationError\` |
 | **Client-side validation** | Input guards throw \`ValidationError\` before any network round-trip |
 | **Auth support** | Bearer JWT + static API key |
+| **Deterministic dispatch** | No hidden retries; query params and JSON bodies are sent in caller insertion order |
 
 ---
 
@@ -341,7 +342,7 @@ try {
 POST /api/streams requires an \`Idempotency-Key\` header. The SDK handles this automatically:
 
 - If you omit \`idempotencyKey\`, the SDK auto-generates a UUID v4.
-- If you supply a key, reuse the **same key when retrying** to prevent duplicate creation.
+- The SDK does **not** retry requests internally. If your application retries, supply and reuse the **same key** for every attempt of the same logical create operation.
 - Reusing a key with a **different body** throws \`IdempotencyConflictError\`.
 
 \`\`\`typescript
@@ -356,10 +357,26 @@ const same = await client.createStream(payload, key); // replays cached response
 ## Security notes
 
 - Bearer tokens and API keys are stored in memory only and never logged.
-- The \`Authorization\` header is only added when a credential is present.
+- The \`Authorization\` and \`X-API-Key\` headers are only added when non-empty credentials are present; runtime setters trim surrounding whitespace.
 - Client-side input validation rejects obviously invalid values before network dispatch.
+- Per-request SDK headers override constructor headers. Runtime credentials override any user-supplied \`Authorization\` or \`X-API-Key\` constructor headers.
 - TLS certificate validation is performed by the platform's \`fetch\` implementation.
 - Idempotency key values are never echoed in error bodies or logs (server-side guarantee).
+
+---
+
+## SDK Generation Contract
+
+The TypeScript SDK is generated from \`openapi.yaml\` and its compatibility
+surface is intentionally small:
+
+- Public exports remain \`types\`, \`errors\`, \`idempotency\`, \`pagination\`, and \`client\`.
+- \`FluxoraClient\` methods preserve the current backend envelopes and unwrap only the documented stream convenience shapes.
+- Requests use native \`fetch\` once per SDK method call. Network failures from \`fetch\` are allowed to bubble unchanged.
+- Query parameters omit only \`undefined\` and \`null\` values; \`false\`, \`0\`, and empty strings are serialized.
+- JSON responses are parsed when possible. Empty successful responses resolve to \`{}\`; text error bodies become \`FluxoraApiError\` messages.
+- Request IDs are read from \`X-Request-ID\` first, then response envelope metadata, then nested error objects.
+- Generated output must pass \`pnpm check:sdk:ts\`; drift is treated as a regression.
 
 ---
 
@@ -1151,7 +1168,7 @@ export class StreamPaginator {
   async *autoPaginate(): AsyncGenerator<Stream, void, unknown> {
     while (this.hasMore) {
       const page = await this.nextPage();
-      if (!page || page.length === 0) break;
+      if (!page) break;
       for (const item of page) {
         yield item;
       }
@@ -1175,10 +1192,12 @@ function generateClient() {
  * - All monetary amounts flow as **decimal strings** (never JS numbers).
  * - Idempotency keys are auto-generated for POST /api/streams when omitted.
  * - Cursor-based pagination is encapsulated in \`StreamPaginator\`.
+ * - The SDK performs no hidden retries; callers own retry policy and should
+ *   reuse explicit idempotency keys for retried stream creation attempts.
  *
  * ## Security notes
  * - Bearer tokens and API keys are stored in memory only; never logged.
- * - The \`Authorization\` header is only set when a credential is present.
+ * - Auth headers are only set when non-empty credentials are present.
  * - Client-side validation (empty/missing required params) fires before any
  *   network round-trip, reducing the attack surface for injection.
  * - TLS validation is delegated to the platform's \`fetch\` implementation.
@@ -1257,8 +1276,8 @@ export class FluxoraClient {
 
   constructor(config: FluxoraClientConfig = {}) {
     this.baseUrl = (config.baseUrl ?? 'http://localhost:3000').replace(/\\/+$/, '');
-    this.apiKey = config.apiKey;
-    this.bearerToken = config.bearerToken;
+    this.apiKey = config.apiKey?.trim() || undefined;
+    this.bearerToken = config.bearerToken?.trim() || undefined;
     this.headers = {
       'User-Agent': 'FluxoraTypeScriptSDK/0.1.0',
       Accept: 'application/json',
@@ -1272,7 +1291,7 @@ export class FluxoraClient {
    * @security Token is stored in memory only; never logged.
    */
   public setBearerToken(token: string): void {
-    this.bearerToken = token;
+    this.bearerToken = token.trim() || undefined;
   }
 
   /**
@@ -1280,7 +1299,7 @@ export class FluxoraClient {
    * @security Key is stored in memory only; never logged.
    */
   public setApiKey(apiKey: string): void {
-    this.apiKey = apiKey;
+    this.apiKey = apiKey.trim() || undefined;
   }
 
   // ── Core HTTP dispatcher ───────────────────────────────────────────────────
@@ -1291,6 +1310,10 @@ export class FluxoraClient {
    * On non-2xx responses the method throws:
    * - \`IdempotencyConflictError\` for 409 \`IDEMPOTENCY_CONFLICT\`
    * - \`FluxoraApiError\` for all other non-2xx responses
+   *
+   * The dispatcher intentionally performs exactly one \`fetch\` call. Retry,
+   * timeout, and abort policies belong to the caller or runtime \`fetch\`
+   * implementation so SDK behavior remains deterministic across deploys.
    *
    * @param method  - HTTP verb (GET, POST, DELETE, PATCH, PUT).
    * @param path    - Request path (e.g. \`'/api/streams'\`).

--- a/sdk/typescript/README.md
+++ b/sdk/typescript/README.md
@@ -19,6 +19,7 @@ Zero external runtime dependencies; uses the standard Web `fetch` API.
 | **Typed error hierarchy** | `FluxoraApiError`, `IdempotencyConflictError`, `ValidationError` |
 | **Client-side validation** | Input guards throw `ValidationError` before any network round-trip |
 | **Auth support** | Bearer JWT + static API key |
+| **Deterministic dispatch** | No hidden retries; query params and JSON bodies are sent in caller insertion order |
 
 ---
 
@@ -98,7 +99,7 @@ try {
 POST /api/streams requires an `Idempotency-Key` header. The SDK handles this automatically:
 
 - If you omit `idempotencyKey`, the SDK auto-generates a UUID v4.
-- If you supply a key, reuse the **same key when retrying** to prevent duplicate creation.
+- The SDK does **not** retry requests internally. If your application retries, supply and reuse the **same key** for every attempt of the same logical create operation.
 - Reusing a key with a **different body** throws `IdempotencyConflictError`.
 
 ```typescript
@@ -113,10 +114,26 @@ const same = await client.createStream(payload, key); // replays cached response
 ## Security notes
 
 - Bearer tokens and API keys are stored in memory only and never logged.
-- The `Authorization` header is only added when a credential is present.
+- The `Authorization` and `X-API-Key` headers are only added when non-empty credentials are present; runtime setters trim surrounding whitespace.
 - Client-side input validation rejects obviously invalid values before network dispatch.
+- Per-request SDK headers override constructor headers. Runtime credentials override any user-supplied `Authorization` or `X-API-Key` constructor headers.
 - TLS certificate validation is performed by the platform's `fetch` implementation.
 - Idempotency key values are never echoed in error bodies or logs (server-side guarantee).
+
+---
+
+## SDK Generation Contract
+
+The TypeScript SDK is generated from `openapi.yaml` and its compatibility
+surface is intentionally small:
+
+- Public exports remain `types`, `errors`, `idempotency`, `pagination`, and `client`.
+- `FluxoraClient` methods preserve the current backend envelopes and unwrap only the documented stream convenience shapes.
+- Requests use native `fetch` once per SDK method call. Network failures from `fetch` are allowed to bubble unchanged.
+- Query parameters omit only `undefined` and `null` values; `false`, `0`, and empty strings are serialized.
+- JSON responses are parsed when possible. Empty successful responses resolve to `{}`; text error bodies become `FluxoraApiError` messages.
+- Request IDs are read from `X-Request-ID` first, then response envelope metadata, then nested error objects.
+- Generated output must pass `pnpm check:sdk:ts`; drift is treated as a regression.
 
 ---
 

--- a/sdk/typescript/src/client.ts
+++ b/sdk/typescript/src/client.ts
@@ -9,10 +9,12 @@
  * - All monetary amounts flow as **decimal strings** (never JS numbers).
  * - Idempotency keys are auto-generated for POST /api/streams when omitted.
  * - Cursor-based pagination is encapsulated in `StreamPaginator`.
+ * - The SDK performs no hidden retries; callers own retry policy and should
+ *   reuse explicit idempotency keys for retried stream creation attempts.
  *
  * ## Security notes
  * - Bearer tokens and API keys are stored in memory only; never logged.
- * - The `Authorization` header is only set when a credential is present.
+ * - Auth headers are only set when non-empty credentials are present.
  * - Client-side validation (empty/missing required params) fires before any
  *   network round-trip, reducing the attack surface for injection.
  * - TLS validation is delegated to the platform's `fetch` implementation.
@@ -91,8 +93,8 @@ export class FluxoraClient {
 
   constructor(config: FluxoraClientConfig = {}) {
     this.baseUrl = (config.baseUrl ?? 'http://localhost:3000').replace(/\/+$/, '');
-    this.apiKey = config.apiKey;
-    this.bearerToken = config.bearerToken;
+    this.apiKey = config.apiKey?.trim() || undefined;
+    this.bearerToken = config.bearerToken?.trim() || undefined;
     this.headers = {
       'User-Agent': 'FluxoraTypeScriptSDK/0.1.0',
       Accept: 'application/json',
@@ -106,7 +108,7 @@ export class FluxoraClient {
    * @security Token is stored in memory only; never logged.
    */
   public setBearerToken(token: string): void {
-    this.bearerToken = token;
+    this.bearerToken = token.trim() || undefined;
   }
 
   /**
@@ -114,7 +116,7 @@ export class FluxoraClient {
    * @security Key is stored in memory only; never logged.
    */
   public setApiKey(apiKey: string): void {
-    this.apiKey = apiKey;
+    this.apiKey = apiKey.trim() || undefined;
   }
 
   // ── Core HTTP dispatcher ───────────────────────────────────────────────────
@@ -125,6 +127,10 @@ export class FluxoraClient {
    * On non-2xx responses the method throws:
    * - `IdempotencyConflictError` for 409 `IDEMPOTENCY_CONFLICT`
    * - `FluxoraApiError` for all other non-2xx responses
+   *
+   * The dispatcher intentionally performs exactly one `fetch` call. Retry,
+   * timeout, and abort policies belong to the caller or runtime `fetch`
+   * implementation so SDK behavior remains deterministic across deploys.
    *
    * @param method  - HTTP verb (GET, POST, DELETE, PATCH, PUT).
    * @param path    - Request path (e.g. `'/api/streams'`).

--- a/tests/sdk/typescript.generation.test.ts
+++ b/tests/sdk/typescript.generation.test.ts
@@ -282,6 +282,13 @@ describe('SDK Package Structure & Documentation', () => {
     it('includes a regeneration command', () => {
       expect(readme).toContain('generate:sdk:ts');
     });
+
+    it('documents the SDK generation contract and regression surface', () => {
+      expect(readme).toContain('SDK Generation Contract');
+      expect(readme).toContain('does **not** retry requests internally');
+      expect(readme).toContain('Network failures from `fetch` are allowed to bubble unchanged');
+      expect(readme).toContain('Generated output must pass `pnpm check:sdk:ts`');
+    });
   });
 });
 
@@ -313,6 +320,32 @@ describe('FluxoraClient', () => {
     const c = client as unknown as Record<string, unknown>;
     expect(c['bearerToken']).toBe('jwt-token-abc');
     expect(c['apiKey']).toBe('ak-123');
+  });
+
+  it('trims runtime credentials and treats whitespace-only values as absent', async () => {
+    const capturedHeaders: Record<string, string>[] = [];
+    await withFetchMock(async (_url, init) => {
+      capturedHeaders.push((init?.headers ?? {}) as Record<string, string>);
+      return new Response(JSON.stringify({ status: 'ok' }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }, async () => {
+      const client = new FluxoraClient({
+        baseUrl: 'http://test.local',
+        bearerToken: '  jwt-with-spaces  ',
+        apiKey: '  key-with-spaces  ',
+      });
+      await client.getHealth();
+      client.setBearerToken('   ');
+      client.setApiKey('   ');
+      await client.getHealth();
+    });
+
+    expect(capturedHeaders[0]?.['Authorization']).toBe('Bearer jwt-with-spaces');
+    expect(capturedHeaders[0]?.['X-API-Key']).toBe('key-with-spaces');
+    expect(capturedHeaders[1]?.['Authorization']).toBeUndefined();
+    expect(capturedHeaders[1]?.['X-API-Key']).toBeUndefined();
   });
 
   // 8. Client-side ValidationError guards.
@@ -505,6 +538,125 @@ describe('FluxoraClient', () => {
       await client.getHealth();
     });
     expect(capturedHeaders[0]?.['Authorization']).toBeUndefined();
+  });
+
+  it('runtime credentials override constructor auth headers deterministically', async () => {
+    const capturedHeaders: Record<string, string>[] = [];
+    await withFetchMock(async (_url, init) => {
+      capturedHeaders.push((init?.headers ?? {}) as Record<string, string>);
+      return new Response(JSON.stringify({ status: 'ok' }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }, async () => {
+      const client = new FluxoraClient({
+        baseUrl: 'http://test.local',
+        bearerToken: 'runtime-jwt',
+        apiKey: 'runtime-key',
+        headers: {
+          Authorization: 'Bearer constructor-jwt',
+          'X-API-Key': 'constructor-key',
+        },
+      });
+      await client.getHealth();
+    });
+
+    expect(capturedHeaders[0]?.['Authorization']).toBe('Bearer runtime-jwt');
+    expect(capturedHeaders[0]?.['X-API-Key']).toBe('runtime-key');
+  });
+
+  it('serialises false, 0, and empty-string query params but omits nullish values', async () => {
+    const capturedUrls: string[] = [];
+    await withFetchMock(async (url) => {
+      capturedUrls.push(url as string);
+      return new Response(JSON.stringify({ ok: true }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }, async () => {
+      const client = new FluxoraClient({ baseUrl: 'http://test.local' });
+      await (client as unknown as {
+        request<T>(method: string, path: string, options: { params: Record<string, unknown> }): Promise<T>;
+      }).request('GET', '/probe', {
+        params: {
+          include_total: false,
+          limit: 0,
+          status: '',
+          cursor: null,
+          sender: undefined,
+        },
+      });
+    });
+
+    const url = new URL(capturedUrls[0]);
+    expect(url.searchParams.get('include_total')).toBe('false');
+    expect(url.searchParams.get('limit')).toBe('0');
+    expect(url.searchParams.get('status')).toBe('');
+    expect(url.searchParams.has('cursor')).toBe(false);
+    expect(url.searchParams.has('sender')).toBe(false);
+  });
+
+  it('performs exactly one fetch per SDK call and lets network errors bubble unchanged', async () => {
+    const networkError = new TypeError('fetch failed');
+    const fetchMock = vi.fn(async () => {
+      throw networkError;
+    });
+
+    await withFetchMock(fetchMock, async () => {
+      const client = new FluxoraClient({ baseUrl: 'http://test.local' });
+      await expect(client.getHealth()).rejects.toBe(networkError);
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns an empty object for successful empty response bodies', async () => {
+    await withFetchMock(async () => new Response('', { status: 204 }), async () => {
+      const client = new FluxoraClient({ baseUrl: 'http://test.local' });
+      const result = await (client as unknown as {
+        request<T>(method: string, path: string): Promise<T>;
+      }).request<Record<string, never>>('DELETE', '/empty');
+
+      expect(result).toEqual({});
+    });
+  });
+
+  it('turns text error bodies into FluxoraApiError messages', async () => {
+    await withFetchMock(async () =>
+      new Response('service unavailable', {
+        status: 503,
+        statusText: 'Service Unavailable',
+        headers: { 'x-request-id': 'req-text-body' },
+      }),
+      async () => {
+        const client = new FluxoraClient({ baseUrl: 'http://test.local' });
+        let err: FluxoraApiError | undefined;
+        try { await client.getHealth(); } catch (e) { err = e as FluxoraApiError; }
+
+        expect(err).toBeInstanceOf(FluxoraApiError);
+        expect(err?.code).toBe('HTTP_ERROR');
+        expect(err?.message).toContain('service unavailable');
+        expect(err?.requestId).toBe('req-text-body');
+      },
+    );
+  });
+
+  it('extracts requestId from response metadata when the header is absent', async () => {
+    await withFetchMock(async () =>
+      new Response(
+        JSON.stringify({
+          error: { code: 'RATE_LIMITED', message: 'Too many requests' },
+          meta: { requestId: 'req-from-meta' },
+        }),
+        { status: 429, headers: { 'Content-Type': 'application/json' } },
+      ),
+      async () => {
+        const client = new FluxoraClient({ baseUrl: 'http://test.local' });
+        let err: FluxoraApiError | undefined;
+        try { await client.getHealth(); } catch (e) { err = e as FluxoraApiError; }
+        expect(err?.requestId).toBe('req-from-meta');
+      },
+    );
   });
 });
 


### PR DESCRIPTION
## Summary

- Document the TypeScript SDK generation contract and explicit regression surface.
- Stabilize FluxoraClient edge-case behavior around auth headers, retry ownership, query serialization, response parsing, and observability metadata.
- Add regression coverage for deterministic request dispatch, credential/header precedence, sparse responses, text error bodies, request ID extraction, and generated README contract docs.

## Compatibility

The happy path remains unchanged:
- Existing SDK methods and exports are preserved.
- Backend response envelopes continue to unwrap as before.
- The SDK still performs one native `fetch` call per request and does not introduce hidden retries.
- Stream creation idempotency behavior remains backward compatible.

## Validation

- `node scripts/generate-sdk-ts.mjs --check`

Could not run the focused Vitest suite locally because dependencies are not installed in the workspace.

Closes #1052
Closes #1053
Closes #1054