### PR TITLE
feat: add Server-Timing header middleware for backend phase timings

### DIFF
--- a/docs/observability.md
+++ b/docs/observability.md
@@ -67,8 +67,9 @@ Fluxora can return a W3C-compatible `Server-Timing` response header for the stre
 ### How it works
 
 - Middleware creates a request-scoped registry attached to `res.locals` when `SERVER_TIMING_ENABLED=true`.
-- Route handlers record named phases for `db`, `stellar_rpc`, and `serialize` by pushing sanitized values into the registry.
+- Streams route handlers record named phases by pushing sanitized values into the registry. Current streams responses include `db` and `serialize`; paths that make Stellar RPC calls may also record `stellar_rpc`.
 - The final header is emitted once per response and contains only phase names and durations.
+- Responses without recorded phases omit the header, even when the feature is enabled.
 
 ### Security guarantees
 

--- a/src/routes/streams.ts
+++ b/src/routes/streams.ts
@@ -596,12 +596,13 @@ streamsRouter.get(
     );
 
     const serializeStart = process.hrtime.bigint();
-    try {
-      res.json(successResponse(response, requestId));
-    } finally {
-      const durationMs = Number(process.hrtime.bigint() - serializeStart) / 1e6;
-      recordServerTimingPhase(res, 'serialize', durationMs);
-    }
+    const responseEnvelope = successResponse(response, requestId);
+    const serialized = JSON.stringify(responseEnvelope);
+    const durationMs = Number(process.hrtime.bigint() - serializeStart) / 1e6;
+    recordServerTimingPhase(res, 'serialize', durationMs);
+
+    res.type('application/json');
+    res.send(serialized);
   }),
 );
 

--- a/tests/middleware/serverTiming.test.ts
+++ b/tests/middleware/serverTiming.test.ts
@@ -1,7 +1,6 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import express from 'express';
 import request from 'supertest';
-import { createApp } from '../../src/app.js';
 import { serverTimingMiddleware, getServerTimingRegistry, createServerTimingRegistry } from '../../src/middleware/serverTiming.js';
 
 describe('Server Timing middleware', () => {
@@ -56,12 +55,16 @@ describe('Server Timing middleware', () => {
     expect(res.headers['server-timing']).toBe('serialize;dur=3.75');
   });
 
-  it('uses the app middleware stack when mounted globally', async () => {
+  it('keeps the header unset when no phases are recorded', async () => {
     process.env.SERVER_TIMING_ENABLED = 'true';
-    const app = createApp();
+    const app = express();
+    app.use(serverTimingMiddleware());
+    app.get('/empty', (_req, res) => {
+      res.json({ ok: true });
+    });
 
-    const res = await request(app).get('/health');
-    expect(res.headers['server-timing']).toBeDefined();
+    const res = await request(app).get('/empty');
+    expect(res.headers['server-timing']).toBeUndefined();
   });
 
   it('returns a stable snapshot for the current request', () => {

--- a/tests/streams.test.ts
+++ b/tests/streams.test.ts
@@ -51,6 +51,7 @@ import {
 import { errorHandler } from '../src/middleware/errorHandler.js';
 import { requestIdMiddleware } from '../src/errors.js';
 import { correlationIdMiddleware } from '../src/middleware/correlationId.js';
+import { serverTimingMiddleware } from '../src/middleware/serverTiming.js';
 import { generateToken } from '../src/lib/auth.js';
 import { authenticate } from '../src/middleware/auth.js';
 import { initializeConfig } from '../src/config/env.js';
@@ -90,6 +91,7 @@ function createTestApp() {
   const app = express();
   app.use(requestIdMiddleware);
   app.use(correlationIdMiddleware);
+  app.use(serverTimingMiddleware());
   app.use(express.json());
   app.use('/api', requireJsonAccept);
   app.use(authenticate);
@@ -524,6 +526,30 @@ describe('Streams API - Decimal String Serialization', () => {
 
       for (const stream of testStreams) {
         await postStream(app, stream).expect(201);
+      }
+    });
+
+    it('emits a Server-Timing header with db and serialize phases when enabled', async () => {
+      const previous = process.env.SERVER_TIMING_ENABLED;
+      process.env.SERVER_TIMING_ENABLED = 'true';
+
+      try {
+        const response = await request(app)
+          .get('/api/streams')
+          .set('Authorization', `Bearer ${testToken}`)
+          .expect(200);
+
+        expect(response.headers['server-timing']).toBeDefined();
+        expect(response.headers['server-timing']).toContain('db;dur=');
+        expect(response.headers['server-timing']).toContain('serialize;dur=');
+        expect(response.headers['server-timing']).not.toContain('localhost');
+        expect(response.headers['server-timing']).not.toContain('query');
+      } finally {
+        if (previous === undefined) {
+          delete process.env.SERVER_TIMING_ENABLED;
+        } else {
+          process.env.SERVER_TIMING_ENABLED = previous;
+        }
       }
     });
 


### PR DESCRIPTION
Closes #915

## Summary
- Adds Server-Timing coverage for streams responses with request-scoped db/serialize phase timings
- Ensures serialize timing is recorded before headers are emitted
- Documents the feature flag, security guarantees, and header behavior

## Security
- Header contains only sanitized phase names and durations
- No hostnames, query text, URLs, or PII are emitted
- Feature remains disabled unless SERVER_TIMING_ENABLED=true

## Tests
- ./node_modules/.bin/vitest run tests/middleware/serverTiming.test.ts
- ./node_modules/.bin/vitest run tests/streams.test.ts -t "emits a Server-Timing header with db and serialize phases when enabled"