### PR TITLE
feat: add Toxiproxy chaos tests to CI workflow (Closes #944)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,6 +110,42 @@ jobs:
         run: pnpm audit --audit-level=moderate
         continue-on-error: true
 
+  chaos:
+    name: Chaos tests (Toxiproxy)
+    runs-on: ubuntu-latest
+    needs: [test]
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20.x'
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Start chaos stack
+        run: docker compose --profile chaos up -d --wait
+
+      - name: Run chaos tests
+        env:
+          CHAOS_ENABLED: "true"
+          TOXI_URL: "http://localhost:8474"
+          CHAOS_PG_PROXY_URL: "postgresql://chaos_user:chaos_password@localhost:5433/chaos_db"
+          CHAOS_REDIS_PROXY_URL: "redis://:chaos_password@localhost:6380"
+        run: pnpm test tests/incidents/toxiproxy.chaos.test.ts
+
+      - name: Tear down chaos stack
+        if: always()
+        run: docker compose --profile chaos down -v
+
   docker:
     name: Docker Build
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Overview

This PR adds the Toxiproxy chaos test job to the CI pipeline, completing the CI integration described in the chaos-toxiproxy runbook (`docs/runbooks/chaos-toxiproxy.md`).

## Related Issue

Closes #944

## Changes

### CI Integration

* **[MODIFY]** `.github/workflows/ci.yml`
  * Add a dedicated `chaos` job that runs after the `test` job passes
  * Starts the Toxiproxy chaos stack via `docker compose --profile chaos up -d --wait`
  * Runs the full `toxiproxy.chaos.test.ts` suite with `CHAOS_ENABLED=true`
  * Tears down the chaos stack on completion with `if: always()` to ensure cleanup

### What This Enables

The chaos test suite (`tests/incidents/toxiproxy.chaos.test.ts`) with 38 automated tests (33 network-level scenarios + 5 unit tests) now runs automatically in CI on every push and PR. This ensures:

* Postgres and Redis fault injection scenarios (latency, timeout, bandwidth throttle, TCP reset) are validated in CI
* Health aggregation rules (unhealthy > degraded > healthy) are verified
* Pool error propagation under chaos conditions is tested
* Security assertions (credentials never leak in health error messages) are enforced

### Existing Implementation

The core chaos engineering implementation was already merged in PR #774:
* `tests/incidents/toxiproxy.chaos.test.ts` - 38 automated tests
* `docs/runbooks/chaos-toxiproxy.md` - Operations runbook
* `docker-compose.yml` - Chaos profile with Toxiproxy
* `toxiproxy.config.json` - Proxy seed configuration

This PR adds the missing CI integration to ensure these tests run automatically.

## Verification Results

```
pnpm test tests/incidents/toxiproxy.chaos.test.ts
✅ 5/5 unit tests passed (33 chaos tests skipped - requires CHAOS_ENABLED=true + docker stack)
✅ No lint errors in chaos-related files
✅ No type errors in chaos-related files
```

| Acceptance Criteria | Status |
| --- | --- |
| Toxiproxy scenarios are scripted and runnable in CI | ✅ CI job added with docker compose orchestration |
| Tests are runnable via `pnpm test` | ✅ Tests run with CHAOS_ENABLED=true, skipped by default |
| Runbook documents expected health transitions | ✅ Complete runbook with 7 fault scenarios |
| Security: credentials never leak | ✅ Assertions verify sanitiseErrorMessage works |
| CI integration documented in runbook | ✅ CI job matches runbook's recommended configuration |

## Security Notes

* All chaos test credentials are test-only values matching docker-compose.yml
* The Toxiproxy management API (8474) is bound to 127.0.0.1 only
* Chaos tests run in an isolated `chaos_db` / `chaos-redis` - never touch default instances
* Tests are skipped by default (`CHAOS_ENABLED=true` required)