### PR TITLE
fix(jobs): harden job queue dead-letter handling (#1056)

### DIFF
--- a/src/jobs/queue.ts
+++ b/src/jobs/queue.ts
@@ -267,6 +267,38 @@ export class JobQueue {
 }
 
 /**
+ * Default retry configuration used for built-in background jobs.
+ *
+ * These constants are intentionally exported so callers and tests can
+ * reference the same values without duplicating magic numbers.
+ *
+ * @internal
+ */
+export const DEFAULT_RETRY_LIMIT = 3;
+export const DEFAULT_RETRY_DELAY = 30;   // seconds
+export const DEFAULT_RETRY_BACKOFF = true;
+export const DEFAULT_EXPIRE_SECONDS = 900; // 15 minutes
+
+/**
+ * Constant used for the dead‑letter queue name.
+ *
+ * pg‑boss routes jobs that exceed their retry limit to this queue.
+ */
+export const DEAD_LETTER_QUEUE = 'job_dead_letter_queue';
+
+/**
+ * Maximum byte-length for persisted `error_message` in job_dead_letter.
+ * Prevents oversized error strings from blowing the TEXT column budget.
+ */
+const DLQ_MAX_ERROR_BYTES = 2048;
+
+/**
+ * Maximum byte-length for the serialised `payload` stored in job_dead_letter.
+ * pg JSONB can hold large documents, but we cap this to avoid runaway rows.
+ */
+const DLQ_MAX_PAYLOAD_BYTES = 65536; // 64 KiB
+
+/**
  * Singleton accessor for the JobQueue.
  *
  * The singleton is set during application startup via `setJobQueue`.
@@ -286,8 +318,16 @@ export function setJobQueue(queue: JobQueue | null): void {
  *
  * Keeps the existing signature so callers in `src/app.ts` continue to work.
  * Should be called once at startup with the application's Postgres pool.
+ *
+ * @throws {Error} If `pool` is null or undefined — callers must supply a valid pool.
  */
 export function startBackgroundJobs(pool: Pool): void {
+  // Guard: a missing pool is a programming error that would cause a silent crash
+  // inside the DLQ handler when pool.query is eventually called.
+  if (pool == null) {
+    throw new Error('startBackgroundJobs requires a valid PostgreSQL pool');
+  }
+
   if (_jobQueue) {
     logger.warn('Background jobs already started, skipping duplicate init');
     return;
@@ -313,18 +353,51 @@ export function startBackgroundJobs(pool: Pool): void {
   queue.register(
     DEAD_LETTER_QUEUE,
     async (ctx) => {
-      const payload = ctx.data as any;
-      const originalJobName = payload?.name || 'unknown';
-      const originalJobId = payload?.id || 'unknown';
+      const payload = ctx.data as Record<string, unknown> | null | undefined;
+      const originalJobName =
+        (typeof payload?.name === 'string' && payload.name) ? payload.name : 'unknown';
+      const originalJobId =
+        (typeof payload?.id === 'string' && payload.id) ? payload.id : 'unknown';
       const originalPayload = payload?.data ?? null;
+
+      // Build error message from pg-boss `output` field, then truncate to
+      // DLQ_MAX_ERROR_BYTES so oversized error strings don't blow the column.
       let errorMessage = 'Unknown error';
-      if (payload?.output) {
-        if (typeof payload.output === 'string') errorMessage = payload.output;
-        else if (payload.output.message) errorMessage = payload.output.message;
-        else errorMessage = JSON.stringify(payload.output);
+      const output = payload?.output;
+      if (output !== undefined && output !== null) {
+        if (typeof output === 'string') {
+          errorMessage = output;
+        } else if (
+          typeof output === 'object' &&
+          'message' in output &&
+          typeof (output as Record<string, unknown>).message === 'string'
+        ) {
+          errorMessage = (output as Record<string, unknown>).message as string;
+        } else {
+          errorMessage = JSON.stringify(output);
+        }
       }
-      
-      const retryCount = payload?.retrycount || payload?.retryCount || 0;
+      // Truncate oversized error messages before persisting.
+      if (errorMessage.length > DLQ_MAX_ERROR_BYTES) {
+        errorMessage = errorMessage.slice(0, DLQ_MAX_ERROR_BYTES);
+      }
+
+      // retrycount is the pg-boss canonical casing; also handle camelCase.
+      const rawRetry =
+        (payload?.retrycount as number | undefined) ??
+        (payload?.retryCount as number | undefined) ??
+        0;
+      // Cap at 0 minimum so a corrupt/negative value never writes a nonsensical row.
+      const retryCount = Math.max(0, Number.isFinite(rawRetry) ? rawRetry : 0);
+
+      // Truncate oversized payloads before serialising into JSONB.
+      let persistedPayload = originalPayload;
+      if (persistedPayload !== null) {
+        const serialised = JSON.stringify(persistedPayload);
+        if (serialised.length > DLQ_MAX_PAYLOAD_BYTES) {
+          persistedPayload = { _truncated: true, _originalSize: serialised.length };
+        }
+      }
 
       logger.error('Job permanently failed and moved to DLQ', undefined, {
         jobName: originalJobName,
@@ -332,17 +405,28 @@ export function startBackgroundJobs(pool: Pool): void {
         error: errorMessage,
       });
 
-      await pool.query(
-        `INSERT INTO job_dead_letter (job_name, job_id, payload, error_message, retry_count)
-         VALUES ($1, $2, $3, $4, $5)`,
-        [
-          originalJobName,
-          originalJobId,
-          originalPayload,
-          errorMessage,
-          retryCount,
-        ]
-      );
+      // Re-throw on DB failure so pg-boss can retry the DLQ entry itself.
+      // Without this, a transient DB outage would silently swallow the record.
+      try {
+        await pool.query(
+          `INSERT INTO job_dead_letter (job_name, job_id, payload, error_message, retry_count)
+           VALUES ($1, $2, $3, $4, $5)`,
+          [
+            originalJobName,
+            originalJobId,
+            persistedPayload,
+            errorMessage,
+            retryCount,
+          ]
+        );
+      } catch (dbErr) {
+        logger.error('Failed to persist DLQ entry — rethrowing for pg-boss retry', undefined, {
+          jobName: originalJobName,
+          jobId: originalJobId,
+          error: dbErr instanceof Error ? dbErr.message : String(dbErr),
+        });
+        throw dbErr;
+      }
     }
   );
 
@@ -397,10 +481,3 @@ export async function stopBackgroundJobs(): Promise<void> {
     setJobQueue(null);
   }
 }
-
-/**
- * Constant used for the dead‑letter queue name.
- *
- * pg‑boss routes jobs that exceed their retry limit to this queue.
- */
-export const DEAD_LETTER_QUEUE = 'job_dead_letter_queue';

--- a/tests/jobs/queue.test.ts
+++ b/tests/jobs/queue.test.ts
@@ -310,31 +310,50 @@ describe('startBackgroundJobs', () => {
     vi.restoreAllMocks();
   });
 
-  it('registers partition-maintenance and job_dead_letter_queue handlers', async () => {
+  // ── Helper: extract DLQ handler from spied register calls ──────────────
+
+  async function extractDlqHandler() {
     const mod = await import('../../src/jobs/queue.js');
-    
-    // We mock Pool
     const mockPool = {
       query: vi.fn().mockResolvedValue({ rowCount: 1 }),
     } as any;
 
-    // Spy on register, start, schedule, send
+    const registerSpy = vi.spyOn(mod.JobQueue.prototype, 'register');
+    vi.spyOn(mod.JobQueue.prototype, 'start').mockResolvedValue(undefined);
+    vi.spyOn(mod.JobQueue.prototype, 'schedule').mockResolvedValue(undefined);
+    vi.spyOn(mod.JobQueue.prototype, 'send').mockResolvedValue(null);
+
+    mod.startBackgroundJobs(mockPool);
+
+    const dlqCall = registerSpy.mock.calls.find(c => c[0] === 'job_dead_letter_queue');
+    const dlqHandler = dlqCall![1];
+    return { dlqHandler, mockPool };
+  }
+
+  // ── Happy path ──────────────────────────────────────────────────────────
+
+  it('registers partition-maintenance and job_dead_letter_queue handlers', async () => {
+    const mod = await import('../../src/jobs/queue.js');
+    const mockPool = {
+      query: vi.fn().mockResolvedValue({ rowCount: 1 }),
+    } as any;
+
     const registerSpy = vi.spyOn(mod.JobQueue.prototype, 'register');
     const startSpy = vi.spyOn(mod.JobQueue.prototype, 'start').mockResolvedValue(undefined);
     vi.spyOn(mod.JobQueue.prototype, 'schedule').mockResolvedValue(undefined);
     vi.spyOn(mod.JobQueue.prototype, 'send').mockResolvedValue(null);
-    
+
     mod.startBackgroundJobs(mockPool);
 
     expect(registerSpy).toHaveBeenCalledWith('partition-maintenance', expect.any(Function), expect.any(Object));
     expect(registerSpy).toHaveBeenCalledWith('job_dead_letter_queue', expect.any(Function));
     expect(startSpy).toHaveBeenCalled();
+  });
 
-    // Verify DLQ handler behavior
-    const dlqCall = registerSpy.mock.calls.find(c => c[0] === 'job_dead_letter_queue');
-    const dlqHandler = dlqCall![1];
+  it('DLQ handler inserts a well-formed row for a standard failure', async () => {
+    const { dlqHandler, mockPool } = await extractDlqHandler();
 
-    const dlqCtx = {
+    await dlqHandler({
       id: 'dlq-id',
       name: 'job_dead_letter_queue',
       data: {
@@ -343,14 +362,279 @@ describe('startBackgroundJobs', () => {
         data: { foo: 'bar' },
         output: 'Some error occurred',
         retryCount: 3,
-      }
-    };
-
-    await dlqHandler(dlqCtx as any);
+      },
+    } as any);
 
     expect(mockPool.query).toHaveBeenCalledWith(
       expect.stringContaining('INSERT INTO job_dead_letter'),
-      ['original-job', 'orig-123', { foo: 'bar' }, 'Some error occurred', 3]
+      ['original-job', 'orig-123', { foo: 'bar' }, 'Some error occurred', 3],
     );
+  });
+
+  it('DLQ handler reads retrycount (lowercase pg-boss casing)', async () => {
+    const { dlqHandler, mockPool } = await extractDlqHandler();
+
+    await dlqHandler({
+      id: 'x',
+      name: 'job_dead_letter_queue',
+      data: { name: 'job-a', id: 'jid', data: null, output: 'err', retrycount: 5 },
+    } as any);
+
+    const args = mockPool.query.mock.calls[0][1];
+    expect(args[4]).toBe(5); // retry_count column
+  });
+
+  // ── Edge: null / undefined payload ─────────────────────────────────────
+
+  it('DLQ handler tolerates completely null ctx.data', async () => {
+    const { dlqHandler, mockPool } = await extractDlqHandler();
+
+    await dlqHandler({ id: 'x', name: 'job_dead_letter_queue', data: null } as any);
+
+    const args = mockPool.query.mock.calls[0][1];
+    expect(args[0]).toBe('unknown');  // job_name
+    expect(args[1]).toBe('unknown');  // job_id
+    expect(args[2]).toBeNull();       // payload
+    expect(args[3]).toBe('Unknown error'); // error_message
+    expect(args[4]).toBe(0);          // retry_count
+  });
+
+  it('DLQ handler tolerates undefined ctx.data', async () => {
+    const { dlqHandler, mockPool } = await extractDlqHandler();
+
+    await dlqHandler({ id: 'x', name: 'job_dead_letter_queue', data: undefined } as any);
+
+    const args = mockPool.query.mock.calls[0][1];
+    expect(args[0]).toBe('unknown');
+    expect(args[1]).toBe('unknown');
+    expect(args[2]).toBeNull();
+    expect(args[3]).toBe('Unknown error');
+    expect(args[4]).toBe(0);
+  });
+
+  it('DLQ handler uses "unknown" for missing job name or id', async () => {
+    const { dlqHandler, mockPool } = await extractDlqHandler();
+
+    await dlqHandler({
+      id: 'x', name: 'job_dead_letter_queue',
+      data: { output: 'err' }, // no name/id/data fields
+    } as any);
+
+    const args = mockPool.query.mock.calls[0][1];
+    expect(args[0]).toBe('unknown');
+    expect(args[1]).toBe('unknown');
+  });
+
+  // ── Edge: oversized error_message ──────────────────────────────────────
+
+  it('DLQ handler truncates error_message that exceeds DLQ_MAX_ERROR_BYTES', async () => {
+    const { dlqHandler, mockPool } = await extractDlqHandler();
+    const hugeError = 'E'.repeat(10_000);
+
+    await dlqHandler({
+      id: 'x', name: 'job_dead_letter_queue',
+      data: { name: 'job', id: 'jid', data: null, output: hugeError },
+    } as any);
+
+    const args = mockPool.query.mock.calls[0][1];
+    // error_message must be capped at 2048 characters
+    expect(args[3].length).toBeLessThanOrEqual(2048);
+    expect(args[3]).toBe(hugeError.slice(0, 2048));
+  });
+
+  it('DLQ handler extracts error from output.message object', async () => {
+    const { dlqHandler, mockPool } = await extractDlqHandler();
+
+    await dlqHandler({
+      id: 'x', name: 'job_dead_letter_queue',
+      data: { name: 'job', id: 'jid', data: null, output: { message: 'db constraint' } },
+    } as any);
+
+    const args = mockPool.query.mock.calls[0][1];
+    expect(args[3]).toBe('db constraint');
+  });
+
+  it('DLQ handler JSON-stringifies unknown output objects', async () => {
+    const { dlqHandler, mockPool } = await extractDlqHandler();
+
+    await dlqHandler({
+      id: 'x', name: 'job_dead_letter_queue',
+      data: { name: 'job', id: 'jid', data: null, output: { code: 42, detail: 'boom' } },
+    } as any);
+
+    const args = mockPool.query.mock.calls[0][1];
+    expect(args[3]).toBe('{"code":42,"detail":"boom"}');
+  });
+
+  // ── Edge: negative / NaN retryCount ────────────────────────────────────
+
+  it('DLQ handler clamps negative retryCount to 0', async () => {
+    const { dlqHandler, mockPool } = await extractDlqHandler();
+
+    await dlqHandler({
+      id: 'x', name: 'job_dead_letter_queue',
+      data: { name: 'job', id: 'jid', data: null, output: 'err', retryCount: -5 },
+    } as any);
+
+    const args = mockPool.query.mock.calls[0][1];
+    expect(args[4]).toBe(0);
+  });
+
+  it('DLQ handler clamps NaN retryCount to 0', async () => {
+    const { dlqHandler, mockPool } = await extractDlqHandler();
+
+    await dlqHandler({
+      id: 'x', name: 'job_dead_letter_queue',
+      data: { name: 'job', id: 'jid', data: null, output: 'err', retryCount: NaN },
+    } as any);
+
+    const args = mockPool.query.mock.calls[0][1];
+    expect(args[4]).toBe(0);
+  });
+
+  // ── Edge: oversized payload ─────────────────────────────────────────────
+
+  it('DLQ handler replaces oversized payload with a truncation sentinel', async () => {
+    const { dlqHandler, mockPool } = await extractDlqHandler();
+    const bigPayload = { data: 'X'.repeat(100_000) };
+
+    await dlqHandler({
+      id: 'x', name: 'job_dead_letter_queue',
+      data: { name: 'job', id: 'jid', data: bigPayload, output: 'err', retryCount: 0 },
+    } as any);
+
+    const args = mockPool.query.mock.calls[0][1];
+    // Original 100k payload should be replaced with a sentinel object
+    expect(args[2]).toHaveProperty('_truncated', true);
+    expect(args[2]).toHaveProperty('_originalSize');
+    expect((args[2] as any)._originalSize).toBeGreaterThan(65536);
+  });
+
+  it('DLQ handler preserves a small payload without modification', async () => {
+    const { dlqHandler, mockPool } = await extractDlqHandler();
+    const smallPayload = { contractId: 'abc', amount: 100 };
+
+    await dlqHandler({
+      id: 'x', name: 'job_dead_letter_queue',
+      data: { name: 'job', id: 'jid', data: smallPayload, output: 'err', retryCount: 0 },
+    } as any);
+
+    const args = mockPool.query.mock.calls[0][1];
+    expect(args[2]).toEqual(smallPayload);
+  });
+
+  // ── Edge: DB failure re-throw ───────────────────────────────────────────
+
+  it('DLQ handler re-throws DB errors so pg-boss can retry the DLQ entry', async () => {
+    const mod = await import('../../src/jobs/queue.js');
+    const dbError = new Error('connection refused');
+    const mockPool = {
+      query: vi.fn().mockRejectedValue(dbError),
+    } as any;
+
+    const registerSpy = vi.spyOn(mod.JobQueue.prototype, 'register');
+    vi.spyOn(mod.JobQueue.prototype, 'start').mockResolvedValue(undefined);
+    vi.spyOn(mod.JobQueue.prototype, 'schedule').mockResolvedValue(undefined);
+    vi.spyOn(mod.JobQueue.prototype, 'send').mockResolvedValue(null);
+
+    mod.startBackgroundJobs(mockPool);
+
+    const dlqCall = registerSpy.mock.calls.find(c => c[0] === 'job_dead_letter_queue');
+    const dlqHandler = dlqCall![1];
+
+    await expect(
+      dlqHandler({
+        id: 'x', name: 'job_dead_letter_queue',
+        data: { name: 'job', id: 'jid', data: null, output: 'err', retryCount: 0 },
+      } as any),
+    ).rejects.toThrow('connection refused');
+  });
+
+  // ── Edge: null pool guard ───────────────────────────────────────────────
+
+  it('throws synchronously when pool is null', async () => {
+    const mod = await import('../../src/jobs/queue.js');
+    expect(() => mod.startBackgroundJobs(null as any)).toThrow(
+      'startBackgroundJobs requires a valid PostgreSQL pool',
+    );
+  });
+
+  it('throws synchronously when pool is undefined', async () => {
+    const mod = await import('../../src/jobs/queue.js');
+    expect(() => mod.startBackgroundJobs(undefined as any)).toThrow(
+      'startBackgroundJobs requires a valid PostgreSQL pool',
+    );
+  });
+
+  // ── Edge: duplicate startup guard ──────────────────────────────────────
+
+  it('no-ops on second call when queue is already set (duplicate init guard)', async () => {
+    const mod = await import('../../src/jobs/queue.js');
+    const mockPool = { query: vi.fn().mockResolvedValue({ rowCount: 1 }) } as any;
+
+    const registerSpy = vi.spyOn(mod.JobQueue.prototype, 'register');
+    vi.spyOn(mod.JobQueue.prototype, 'start').mockResolvedValue(undefined);
+    vi.spyOn(mod.JobQueue.prototype, 'schedule').mockResolvedValue(undefined);
+    vi.spyOn(mod.JobQueue.prototype, 'send').mockResolvedValue(null);
+
+    mod.startBackgroundJobs(mockPool);
+    const callsAfterFirst = registerSpy.mock.calls.length;
+
+    // Second call must not register or start anything new
+    mod.startBackgroundJobs(mockPool);
+    expect(registerSpy.mock.calls.length).toBe(callsAfterFirst);
+  });
+
+  // ── Exported constants ──────────────────────────────────────────────────
+
+  it('exports DEFAULT_RETRY_LIMIT as a positive integer', async () => {
+    const mod = await import('../../src/jobs/queue.js');
+    expect(typeof mod.DEFAULT_RETRY_LIMIT).toBe('number');
+    expect(mod.DEFAULT_RETRY_LIMIT).toBeGreaterThan(0);
+  });
+
+  it('exports DEFAULT_RETRY_DELAY as a positive number', async () => {
+    const mod = await import('../../src/jobs/queue.js');
+    expect(typeof mod.DEFAULT_RETRY_DELAY).toBe('number');
+    expect(mod.DEFAULT_RETRY_DELAY).toBeGreaterThan(0);
+  });
+
+  it('exports DEFAULT_RETRY_BACKOFF as boolean', async () => {
+    const mod = await import('../../src/jobs/queue.js');
+    expect(typeof mod.DEFAULT_RETRY_BACKOFF).toBe('boolean');
+  });
+
+  it('exports DEFAULT_EXPIRE_SECONDS as a positive number', async () => {
+    const mod = await import('../../src/jobs/queue.js');
+    expect(typeof mod.DEFAULT_EXPIRE_SECONDS).toBe('number');
+    expect(mod.DEFAULT_EXPIRE_SECONDS).toBeGreaterThan(0);
+  });
+
+  it('exports DEAD_LETTER_QUEUE as a non-empty string', async () => {
+    const mod = await import('../../src/jobs/queue.js');
+    expect(typeof mod.DEAD_LETTER_QUEUE).toBe('string');
+    expect(mod.DEAD_LETTER_QUEUE.length).toBeGreaterThan(0);
+  });
+
+  it('partition-maintenance job is registered with DEAD_LETTER_QUEUE routing', async () => {
+    const mod = await import('../../src/jobs/queue.js');
+    const mockPool = { query: vi.fn().mockResolvedValue({ rowCount: 1 }) } as any;
+
+    const registerSpy = vi.spyOn(mod.JobQueue.prototype, 'register');
+    vi.spyOn(mod.JobQueue.prototype, 'start').mockResolvedValue(undefined);
+    vi.spyOn(mod.JobQueue.prototype, 'schedule').mockResolvedValue(undefined);
+    vi.spyOn(mod.JobQueue.prototype, 'send').mockResolvedValue(null);
+
+    mod.startBackgroundJobs(mockPool);
+
+    const pmCall = registerSpy.mock.calls.find(c => c[0] === 'partition-maintenance');
+    expect(pmCall).toBeDefined();
+    expect(pmCall![2]).toMatchObject({
+      retryLimit: mod.DEFAULT_RETRY_LIMIT,
+      retryDelay: mod.DEFAULT_RETRY_DELAY,
+      retryBackoff: mod.DEFAULT_RETRY_BACKOFF,
+      expireInSeconds: mod.DEFAULT_EXPIRE_SECONDS,
+      deadLetter: mod.DEAD_LETTER_QUEUE,
+    });
   });
 });


### PR DESCRIPTION
closes #1056 
- Add missing DEFAULT_RETRY_LIMIT/DELAY/BACKOFF/EXPIRE_SECONDS constants that were referenced but never defined (caused ReferenceError at runtime)
- Move DEAD_LETTER_QUEUE constant next to related constants; remove duplicate
- Harden DLQ handler:
  - Replace any-typed payload with type-safe Record<string,unknown> reads
  - Truncate error_message to 2048 bytes before INSERT
  - Truncate oversized payloads (>64 KiB) to a sentinel object
  - Clamp retryCount to Math.max(0, ...) so negative/NaN values are safe
  - Re-throw DB INSERT errors so pg-boss retries the DLQ entry on outage
- Guard startBackgroundJobs against null/undefined pool argument
- Expand tests from 22 to 44: null payload, oversized error truncation, negative retryCount clamping, DB failure re-throw, null pool guard, duplicate init guard, output.message extraction, payload sentinel