### PR TITLE
fix(jobs): stabilize job queue dead-letter handling (#1057)

### DIFF
--- a/src/jobs/queue.ts
+++ b/src/jobs/queue.ts
@@ -7,6 +7,67 @@ import type {
 import { logger } from '../lib/logger.js';
 import { resolvePoolConfig } from '../db/pool.js';
 import { runPartitionMaintenance } from './partitionMaintenance.js';
+import { jobDlqEntriesTotal } from '../metrics/businessMetrics.js';
+
+// ── Retry / expiry defaults ───────────────────────────────────────────────────
+//
+// Exported so callers (and tests) can reference the canonical values without
+// repeating magic numbers.  All are intentionally conservative to bound blast
+// radius on runaway workers.
+
+/**
+ * Maximum number of retry attempts before a job is moved to the dead‑letter
+ * queue.  Three attempts ≈ a brief transient failure without hammering the DB.
+ */
+export const DEFAULT_RETRY_LIMIT = 3;
+
+/**
+ * Base retry delay in seconds (used as the fixed interval when backoff is
+ * disabled, or as the seed when exponential backoff is enabled).
+ */
+export const DEFAULT_RETRY_DELAY = 30;
+
+/**
+ * Whether to apply exponential backoff between retry attempts.
+ * `true` ⇒ each attempt waits 2^n × `retryDelay` seconds.
+ */
+export const DEFAULT_RETRY_BACKOFF = true;
+
+/**
+ * Maximum time in seconds a job may remain in the `active` state before
+ * pg‑boss automatically moves it back to `failed`.  15 minutes is generous
+ * for the maintenance workload and protects against hung workers.
+ */
+export const DEFAULT_EXPIRE_SECONDS = 900; // 15 minutes
+
+// ── Internal types ────────────────────────────────────────────────────────────
+
+/**
+ * Shape of the data payload that pg‑boss attaches to a job when it routes it
+ * to the dead‑letter queue.  The fields come directly from pg‑boss internals;
+ * all are optional because pg‑boss does not guarantee their presence.
+ *
+ * @internal
+ */
+interface DlqJobPayload {
+  /** Original job name as registered with pg‑boss. */
+  name?: unknown;
+  /** Original job ID (UUID). */
+  id?: unknown;
+  /** Application‑level data the job was created with. */
+  data?: unknown;
+  /**
+   * Error output captured when the job exceeded its retry limit.
+   * May be a plain string, an `{ message: string }` object, or arbitrary JSON.
+   */
+  output?: unknown;
+  /**
+   * pg‑boss stores the retry count as `retrycount` (lowercase) in older
+   * versions and `retryCount` (camelCase) in newer ones.  We normalise both.
+   */
+  retrycount?: unknown;
+  retryCount?: unknown;
+}
 
 /**
  * JobHandlerContext – context passed to job handlers.
@@ -313,37 +374,75 @@ export function startBackgroundJobs(pool: Pool): void {
   queue.register(
     DEAD_LETTER_QUEUE,
     async (ctx) => {
-      const payload = ctx.data as any;
-      const originalJobName = payload?.name || 'unknown';
-      const originalJobId = payload?.id || 'unknown';
-      const originalPayload = payload?.data ?? null;
-      let errorMessage = 'Unknown error';
-      if (payload?.output) {
-        if (typeof payload.output === 'string') errorMessage = payload.output;
-        else if (payload.output.message) errorMessage = payload.output.message;
-        else errorMessage = JSON.stringify(payload.output);
-      }
-      
-      const retryCount = payload?.retrycount || payload?.retryCount || 0;
+      // pg-boss delivers the original job's metadata as ctx.data when routing
+      // to a dead-letter queue.  We use the DlqJobPayload interface to make
+      // the extraction explicit and type-safe rather than casting to `any`.
+      const payload: DlqJobPayload =
+        ctx.data !== null && typeof ctx.data === 'object'
+          ? (ctx.data as DlqJobPayload)
+          : {};
 
-      logger.error('Job permanently failed and moved to DLQ', undefined, {
+      // Use nullish coalescing (??) so that an explicit empty-string value
+      // from pg-boss is preserved rather than being coerced to 'unknown' the
+      // way the || operator would behave.
+      const originalJobName =
+        typeof payload.name === 'string' && payload.name !== '' ? payload.name : 'unknown';
+      const originalJobId =
+        typeof payload.id === 'string' && payload.id !== '' ? payload.id : 'unknown';
+      const originalPayload = payload.data ?? null;
+
+      let errorMessage = 'Unknown error';
+      if (payload.output !== undefined && payload.output !== null) {
+        if (typeof payload.output === 'string') {
+          errorMessage = payload.output;
+        } else if (
+          typeof payload.output === 'object' &&
+          'message' in payload.output &&
+          typeof (payload.output as Record<string, unknown>).message === 'string'
+        ) {
+          errorMessage = (payload.output as Record<string, unknown>).message as string;
+        } else {
+          errorMessage = JSON.stringify(payload.output);
+        }
+      }
+
+      // Normalise retrycount / retryCount: both keys must be coerced to a
+      // number, and we default to 0 only when both are absent or non-numeric.
+      // We use ?? (not ||) so that a legitimate value of 0 is not discarded.
+      const rawRetry = payload.retrycount ?? payload.retryCount;
+      const retryCount =
+        typeof rawRetry === 'number' && Number.isFinite(rawRetry) ? rawRetry : 0;
+
+      logger.error('Job permanently failed and moved to DLQ', ctx.id, {
         jobName: originalJobName,
         jobId: originalJobId,
+        retryCount,
         error: errorMessage,
       });
 
-      await pool.query(
-        `INSERT INTO job_dead_letter (job_name, job_id, payload, error_message, retry_count)
-         VALUES ($1, $2, $3, $4, $5)`,
-        [
-          originalJobName,
-          originalJobId,
-          originalPayload,
-          errorMessage,
-          retryCount,
-        ]
-      );
-    }
+      // Increment the observable counter so on-call can alert on DLQ growth.
+      jobDlqEntriesTotal.inc({ job_name: originalJobName });
+
+      // Persist to job_dead_letter.  Wrap in try/catch so that a transient DB
+      // failure does NOT cause pg-boss to requeue this DLQ entry (which would
+      // create a confusing retry loop on a terminal event).
+      try {
+        await pool.query(
+          `INSERT INTO job_dead_letter (job_name, job_id, payload, error_message, retry_count)
+           VALUES ($1, $2, $3, $4, $5)`,
+          [originalJobName, originalJobId, originalPayload, errorMessage, retryCount],
+        );
+      } catch (insertErr) {
+        // Log but do not re-throw: the job is terminally failed.  A failed
+        // DLQ insert is surfaced via the error log and the metric above; the
+        // pg-boss job itself will still be marked as completed (not retried).
+        logger.error('Failed to persist DLQ entry to job_dead_letter', ctx.id, {
+          jobName: originalJobName,
+          jobId: originalJobId,
+          error: insertErr instanceof Error ? insertErr.message : String(insertErr),
+        });
+      }
+    },
   );
 
   queue.start().catch((err: Error) => {

--- a/src/metrics/businessMetrics.ts
+++ b/src/metrics/businessMetrics.ts
@@ -339,6 +339,26 @@ export const adminReindexJobDurationSeconds =
     registers: [registry],
   });
 
+/**
+ * Counter for jobs that have been permanently routed to the dead-letter queue.
+ *
+ * Each increment represents one terminal job failure that was persisted to
+ * `job_dead_letter`.  Labelled by `job_name` so operators can see which
+ * specific job types are failing most frequently without requiring a DB query.
+ *
+ * @security
+ * - Label cardinality is bounded: job_name values come from developer-controlled
+ *   `register()` call sites, not from user input.
+ */
+export const jobDlqEntriesTotal =
+  (registry.getSingleMetric('fluxora_job_dlq_entries_total') as Counter<'job_name'>) ||
+  new Counter({
+    name: 'fluxora_job_dlq_entries_total',
+    help: 'Total number of jobs permanently moved to the dead-letter queue, labelled by job name',
+    labelNames: ['job_name'] as const,
+    registers: [registry],
+  });
+
 /** Clean helper to de-register metrics between test runs. */
 export function deRegisterBusinessMetrics(): void {
   registry.removeSingleMetric('fluxora_auth_jwt_verify_duration_seconds');
@@ -360,5 +380,6 @@ export function deRegisterBusinessMetrics(): void {
   registry.removeSingleMetric('fluxora_admin_reindex_job_duration_seconds');
   registry.removeSingleMetric('fluxora_longpoll_active_connections');
   registry.removeSingleMetric('fluxora_longpoll_connections_rejected_total');
+  registry.removeSingleMetric('fluxora_job_dlq_entries_total');
 }
 

--- a/tests/jobs/queue.test.ts
+++ b/tests/jobs/queue.test.ts
@@ -310,32 +310,110 @@ describe('startBackgroundJobs', () => {
     vi.restoreAllMocks();
   });
 
+  // ── helpers ──────────────────────────────────────────────────────────────
+
+  /** Boot startBackgroundJobs and extract the raw DLQ handler function. */
+  async function getDlqHandler(mockPool: { query: ReturnType<typeof vi.fn> }) {
+    const mod = await import('../../src/jobs/queue.js');
+    const registerSpy = vi.spyOn(mod.JobQueue.prototype, 'register');
+    vi.spyOn(mod.JobQueue.prototype, 'start').mockResolvedValue(undefined);
+    vi.spyOn(mod.JobQueue.prototype, 'schedule').mockResolvedValue(undefined);
+    vi.spyOn(mod.JobQueue.prototype, 'send').mockResolvedValue(null);
+    mod.startBackgroundJobs(mockPool as never);
+    const call = registerSpy.mock.calls.find((c) => c[0] === 'job_dead_letter_queue');
+    return call![1];
+  }
+
+  // ── exported constants ────────────────────────────────────────────────────
+
+  it('exports DEFAULT_RETRY_LIMIT as a positive integer', async () => {
+    const { DEFAULT_RETRY_LIMIT } = await import('../../src/jobs/queue.js');
+    expect(typeof DEFAULT_RETRY_LIMIT).toBe('number');
+    expect(DEFAULT_RETRY_LIMIT).toBeGreaterThan(0);
+    expect(Number.isInteger(DEFAULT_RETRY_LIMIT)).toBe(true);
+  });
+
+  it('exports DEFAULT_RETRY_DELAY as a positive integer', async () => {
+    const { DEFAULT_RETRY_DELAY } = await import('../../src/jobs/queue.js');
+    expect(typeof DEFAULT_RETRY_DELAY).toBe('number');
+    expect(DEFAULT_RETRY_DELAY).toBeGreaterThan(0);
+  });
+
+  it('exports DEFAULT_RETRY_BACKOFF as a boolean', async () => {
+    const { DEFAULT_RETRY_BACKOFF } = await import('../../src/jobs/queue.js');
+    expect(typeof DEFAULT_RETRY_BACKOFF).toBe('boolean');
+  });
+
+  it('exports DEFAULT_EXPIRE_SECONDS as a positive integer', async () => {
+    const { DEFAULT_EXPIRE_SECONDS } = await import('../../src/jobs/queue.js');
+    expect(typeof DEFAULT_EXPIRE_SECONDS).toBe('number');
+    expect(DEFAULT_EXPIRE_SECONDS).toBeGreaterThan(0);
+  });
+
+  // ── handler registration ─────────────────────────────────────────────────
+
   it('registers partition-maintenance and job_dead_letter_queue handlers', async () => {
     const mod = await import('../../src/jobs/queue.js');
-    
-    // We mock Pool
-    const mockPool = {
-      query: vi.fn().mockResolvedValue({ rowCount: 1 }),
-    } as any;
-
-    // Spy on register, start, schedule, send
+    const mockPool = { query: vi.fn().mockResolvedValue({ rowCount: 1 }) };
     const registerSpy = vi.spyOn(mod.JobQueue.prototype, 'register');
     const startSpy = vi.spyOn(mod.JobQueue.prototype, 'start').mockResolvedValue(undefined);
     vi.spyOn(mod.JobQueue.prototype, 'schedule').mockResolvedValue(undefined);
     vi.spyOn(mod.JobQueue.prototype, 'send').mockResolvedValue(null);
-    
-    mod.startBackgroundJobs(mockPool);
 
-    expect(registerSpy).toHaveBeenCalledWith('partition-maintenance', expect.any(Function), expect.any(Object));
+    mod.startBackgroundJobs(mockPool as never);
+
+    expect(registerSpy).toHaveBeenCalledWith(
+      'partition-maintenance',
+      expect.any(Function),
+      expect.any(Object),
+    );
     expect(registerSpy).toHaveBeenCalledWith('job_dead_letter_queue', expect.any(Function));
     expect(startSpy).toHaveBeenCalled();
+  });
 
-    // Verify DLQ handler behavior
-    const dlqCall = registerSpy.mock.calls.find(c => c[0] === 'job_dead_letter_queue');
-    const dlqHandler = dlqCall![1];
+  it('registers partition-maintenance with the exported default constants', async () => {
+    const mod = await import('../../src/jobs/queue.js');
+    const mockPool = { query: vi.fn().mockResolvedValue({ rowCount: 1 }) };
+    const registerSpy = vi.spyOn(mod.JobQueue.prototype, 'register');
+    vi.spyOn(mod.JobQueue.prototype, 'start').mockResolvedValue(undefined);
+    vi.spyOn(mod.JobQueue.prototype, 'schedule').mockResolvedValue(undefined);
+    vi.spyOn(mod.JobQueue.prototype, 'send').mockResolvedValue(null);
 
-    const dlqCtx = {
-      id: 'dlq-id',
+    mod.startBackgroundJobs(mockPool as never);
+
+    const pmCall = registerSpy.mock.calls.find((c) => c[0] === 'partition-maintenance');
+    expect(pmCall![2]).toMatchObject({
+      retryLimit: mod.DEFAULT_RETRY_LIMIT,
+      retryDelay: mod.DEFAULT_RETRY_DELAY,
+      retryBackoff: mod.DEFAULT_RETRY_BACKOFF,
+      expireInSeconds: mod.DEFAULT_EXPIRE_SECONDS,
+      deadLetter: mod.DEAD_LETTER_QUEUE,
+    });
+  });
+
+  it('is idempotent — calling startBackgroundJobs twice skips the second call', async () => {
+    const mod = await import('../../src/jobs/queue.js');
+    const mockPool = { query: vi.fn().mockResolvedValue({ rowCount: 1 }) };
+    const registerSpy = vi.spyOn(mod.JobQueue.prototype, 'register');
+    vi.spyOn(mod.JobQueue.prototype, 'start').mockResolvedValue(undefined);
+    vi.spyOn(mod.JobQueue.prototype, 'schedule').mockResolvedValue(undefined);
+    vi.spyOn(mod.JobQueue.prototype, 'send').mockResolvedValue(null);
+
+    mod.startBackgroundJobs(mockPool as never);
+    const countAfterFirst = registerSpy.mock.calls.length;
+    mod.startBackgroundJobs(mockPool as never);
+    // No additional register calls on second invocation
+    expect(registerSpy.mock.calls.length).toBe(countAfterFirst);
+  });
+
+  // ── DLQ handler: happy path ───────────────────────────────────────────────
+
+  it('DLQ handler: persists a well-formed payload to job_dead_letter', async () => {
+    const mockPool = { query: vi.fn().mockResolvedValue({ rowCount: 1 }) };
+    const dlqHandler = await getDlqHandler(mockPool);
+
+    await dlqHandler({
+      id: 'dlq-ctx-id',
       name: 'job_dead_letter_queue',
       data: {
         name: 'original-job',
@@ -343,14 +421,217 @@ describe('startBackgroundJobs', () => {
         data: { foo: 'bar' },
         output: 'Some error occurred',
         retryCount: 3,
-      }
-    };
-
-    await dlqHandler(dlqCtx as any);
+      },
+    } as never);
 
     expect(mockPool.query).toHaveBeenCalledWith(
       expect.stringContaining('INSERT INTO job_dead_letter'),
-      ['original-job', 'orig-123', { foo: 'bar' }, 'Some error occurred', 3]
+      ['original-job', 'orig-123', { foo: 'bar' }, 'Some error occurred', 3],
     );
+  });
+
+  it('DLQ handler: extracts error from output.message when output is an object', async () => {
+    const mockPool = { query: vi.fn().mockResolvedValue({ rowCount: 1 }) };
+    const dlqHandler = await getDlqHandler(mockPool);
+
+    await dlqHandler({
+      id: 'dlq-ctx-id',
+      name: 'job_dead_letter_queue',
+      data: {
+        name: 'some-job',
+        id: 'job-456',
+        output: { message: 'DB connection refused' },
+        retryCount: 2,
+      },
+    } as never);
+
+    expect(mockPool.query).toHaveBeenCalledWith(
+      expect.stringContaining('INSERT INTO job_dead_letter'),
+      ['some-job', 'job-456', null, 'DB connection refused', 2],
+    );
+  });
+
+  it('DLQ handler: JSON-stringifies unknown output shapes', async () => {
+    const mockPool = { query: vi.fn().mockResolvedValue({ rowCount: 1 }) };
+    const dlqHandler = await getDlqHandler(mockPool);
+
+    await dlqHandler({
+      id: 'dlq-ctx-id',
+      name: 'job_dead_letter_queue',
+      data: {
+        name: 'some-job',
+        id: 'job-789',
+        output: { code: 500, detail: 'oops' },
+        retryCount: 1,
+      },
+    } as never);
+
+    const [, params] = mockPool.query.mock.calls[0] as [string, unknown[]];
+    expect(params[3]).toBe(JSON.stringify({ code: 500, detail: 'oops' }));
+  });
+
+  // ── DLQ handler: retryCount edge cases ───────────────────────────────────
+
+  it('DLQ handler: preserves retryCount of 0 (does not treat falsy 0 as missing)', async () => {
+    const mockPool = { query: vi.fn().mockResolvedValue({ rowCount: 1 }) };
+    const dlqHandler = await getDlqHandler(mockPool);
+
+    await dlqHandler({
+      id: 'dlq-ctx-id',
+      name: 'job_dead_letter_queue',
+      data: { name: 'j', id: 'id-1', retryCount: 0 },
+    } as never);
+
+    const [, params] = mockPool.query.mock.calls[0] as [string, unknown[]];
+    expect(params[4]).toBe(0);
+  });
+
+  it('DLQ handler: reads retrycount (lowercase) when retryCount is absent', async () => {
+    const mockPool = { query: vi.fn().mockResolvedValue({ rowCount: 1 }) };
+    const dlqHandler = await getDlqHandler(mockPool);
+
+    await dlqHandler({
+      id: 'dlq-ctx-id',
+      name: 'job_dead_letter_queue',
+      data: { name: 'j', id: 'id-2', retrycount: 5 },
+    } as never);
+
+    const [, params] = mockPool.query.mock.calls[0] as [string, unknown[]];
+    expect(params[4]).toBe(5);
+  });
+
+  it('DLQ handler: defaults retryCount to 0 when both keys are absent', async () => {
+    const mockPool = { query: vi.fn().mockResolvedValue({ rowCount: 1 }) };
+    const dlqHandler = await getDlqHandler(mockPool);
+
+    await dlqHandler({
+      id: 'dlq-ctx-id',
+      name: 'job_dead_letter_queue',
+      data: { name: 'j', id: 'id-3' },
+    } as never);
+
+    const [, params] = mockPool.query.mock.calls[0] as [string, unknown[]];
+    expect(params[4]).toBe(0);
+  });
+
+  // ── DLQ handler: missing / null / non-string name/id ─────────────────────
+
+  it('DLQ handler: falls back to "unknown" for missing job name', async () => {
+    const mockPool = { query: vi.fn().mockResolvedValue({ rowCount: 1 }) };
+    const dlqHandler = await getDlqHandler(mockPool);
+
+    await dlqHandler({
+      id: 'dlq-ctx-id',
+      name: 'job_dead_letter_queue',
+      data: { id: 'some-id' },
+    } as never);
+
+    const [, params] = mockPool.query.mock.calls[0] as [string, unknown[]];
+    expect(params[0]).toBe('unknown');
+  });
+
+  it('DLQ handler: falls back to "unknown" for missing job id', async () => {
+    const mockPool = { query: vi.fn().mockResolvedValue({ rowCount: 1 }) };
+    const dlqHandler = await getDlqHandler(mockPool);
+
+    await dlqHandler({
+      id: 'dlq-ctx-id',
+      name: 'job_dead_letter_queue',
+      data: { name: 'some-job' },
+    } as never);
+
+    const [, params] = mockPool.query.mock.calls[0] as [string, unknown[]];
+    expect(params[1]).toBe('unknown');
+  });
+
+  it('DLQ handler: handles null ctx.data without throwing', async () => {
+    const mockPool = { query: vi.fn().mockResolvedValue({ rowCount: 1 }) };
+    const dlqHandler = await getDlqHandler(mockPool);
+
+    await expect(
+      dlqHandler({ id: 'dlq-ctx-id', name: 'job_dead_letter_queue', data: null } as never),
+    ).resolves.toBeUndefined();
+
+    const [, params] = mockPool.query.mock.calls[0] as [string, unknown[]];
+    expect(params[0]).toBe('unknown');
+    expect(params[1]).toBe('unknown');
+    expect(params[4]).toBe(0);
+  });
+
+  it('DLQ handler: handles non-object ctx.data without throwing', async () => {
+    const mockPool = { query: vi.fn().mockResolvedValue({ rowCount: 1 }) };
+    const dlqHandler = await getDlqHandler(mockPool);
+
+    await expect(
+      dlqHandler({ id: 'dlq-ctx-id', name: 'job_dead_letter_queue', data: 'bad' } as never),
+    ).resolves.toBeUndefined();
+
+    expect(mockPool.query).toHaveBeenCalled();
+  });
+
+  // ── DLQ handler: DB insert failure resilience ─────────────────────────────
+
+  it('DLQ handler: does NOT re-throw when the DB insert fails', async () => {
+    const mockPool = { query: vi.fn().mockRejectedValue(new Error('connection lost')) };
+    const dlqHandler = await getDlqHandler(mockPool);
+
+    // Must resolve, not reject — pg-boss must not retry a terminal DLQ job
+    await expect(
+      dlqHandler({
+        id: 'dlq-ctx-id',
+        name: 'job_dead_letter_queue',
+        data: { name: 'j', id: 'id-x', retryCount: 1, output: 'err' },
+      } as never),
+    ).resolves.toBeUndefined();
+  });
+
+  it('DLQ handler: still increments the metric even when the DB insert fails', async () => {
+    const { jobDlqEntriesTotal } = await import('../../src/metrics/businessMetrics.js');
+    const incSpy = vi.spyOn(jobDlqEntriesTotal, 'inc');
+
+    const mockPool = { query: vi.fn().mockRejectedValue(new Error('timeout')) };
+    const dlqHandler = await getDlqHandler(mockPool);
+
+    await dlqHandler({
+      id: 'dlq-ctx-id',
+      name: 'job_dead_letter_queue',
+      data: { name: 'failing-job', id: 'id-y', retryCount: 2, output: 'timeout' },
+    } as never);
+
+    expect(incSpy).toHaveBeenCalledWith({ job_name: 'failing-job' });
+  });
+
+  // ── DLQ handler: observability ────────────────────────────────────────────
+
+  it('DLQ handler: increments jobDlqEntriesTotal with the correct job_name label', async () => {
+    const { jobDlqEntriesTotal } = await import('../../src/metrics/businessMetrics.js');
+    const incSpy = vi.spyOn(jobDlqEntriesTotal, 'inc');
+
+    const mockPool = { query: vi.fn().mockResolvedValue({ rowCount: 1 }) };
+    const dlqHandler = await getDlqHandler(mockPool);
+
+    await dlqHandler({
+      id: 'dlq-ctx-id',
+      name: 'job_dead_letter_queue',
+      data: { name: 'partition-maintenance', id: 'pm-1', retryCount: 3, output: 'disk full' },
+    } as never);
+
+    expect(incSpy).toHaveBeenCalledWith({ job_name: 'partition-maintenance' });
+  });
+
+  it('DLQ handler: uses "unknown" as job_name label when name is absent', async () => {
+    const { jobDlqEntriesTotal } = await import('../../src/metrics/businessMetrics.js');
+    const incSpy = vi.spyOn(jobDlqEntriesTotal, 'inc');
+
+    const mockPool = { query: vi.fn().mockResolvedValue({ rowCount: 1 }) };
+    const dlqHandler = await getDlqHandler(mockPool);
+
+    await dlqHandler({
+      id: 'dlq-ctx-id',
+      name: 'job_dead_letter_queue',
+      data: { id: 'no-name-job' },
+    } as never);
+
+    expect(incSpy).toHaveBeenCalledWith({ job_name: 'unknown' });
   });
 });


### PR DESCRIPTION
closes #1057 
- Define missing DEFAULT_RETRY_LIMIT/DELAY/BACKOFF/EXPIRE_SECONDS constants (were referenced but never declared — ReferenceError at runtime)
- Replace 'as any' DLQ payload cast with typed DlqJobPayload interface
- Fix retryCount extraction: use ?? not || so a legitimate 0 is not discarded
- Wrap DB insert in try/catch so a transient insert failure does not cause pg-boss to re-enqueue a terminal DLQ job
- Forward ctx.id as correlationId to the DLQ error log entry
- Add jobDlqEntriesTotal Counter (labelled by job_name) to businessMetrics so DLQ growth is observable without a DB query
- Expand tests from 1 broad case to 21 targeted tests covering payload shapes, retryCount edge cases, null/non-object data, DB insert failure resilience, and metric emission