### PR TITLE
docs(csrf): document enforcement path and add edge-case tests for emp…

### DIFF
--- a/docs/security.md
+++ b/docs/security.md
@@ -54,3 +54,32 @@ To protect browser-originated clients (such as dashboard applications) against C
 4. **Error Handling**:
    Requests failing CSRF validation return an HTTP `403 Forbidden` JSON envelope with code `FORBIDDEN` and a message specifying whether the CSRF token was missing or mismatched.
 
+### CSRF enforcement behavior (browser-facing requests)
+
+This section spells out the precise enforcement path and important edge-cases to make behaviour explicit for developers and to define the regression surface for tests.
+
+- **When CSRF is enforced**:
+   - The middleware enforces CSRF only for mutating HTTP methods: `POST`, `PUT`, `PATCH`, `DELETE`.
+   - Enforcement applies only to requests that appear to be cookie-session authenticated (i.e., an ambient `Cookie` header is present and no Authorization or API-key credentials are supplied).
+
+- **Non-enforcement (bypass) rules**:
+   - Any non-blank `Authorization` header (e.g., `Bearer <token>`) bypasses CSRF enforcement.
+   - Presence of `X-API-Key` header bypasses CSRF enforcement.
+   - Presence of `x-api-key` query parameter bypasses CSRF enforcement.
+   - Safe methods (`GET`, `HEAD`, `OPTIONS`) bypass CSRF enforcement regardless of authentication method.
+
+- **Token requirements when enforced**:
+   - Both a `fluxora_csrf` cookie and an `X-CSRF-Token` header must be present for cookie-authenticated mutating requests.
+   - The cookie value is URI-decoded when parsed; the header value is used as supplied (case-insensitive header name lookup is performed).
+   - Empty strings for either token are treated as missing and will cause a 403 response.
+   - If the header is provided as an array (can occur in some frameworks), the first element is used.
+
+- **Comparison semantics**:
+   - Tokens are compared in constant time by HMAC-ing each input and then using `timingSafeEqual` on the digests. This removes timing side-channels associated with variable-length inputs.
+
+- **Error contract (regression surface)**:
+   - 403 responses must use the existing JSON envelope with `error.code === 'FORBIDDEN'`.
+   - Error messages will indicate whether the failure was due to a missing token or a mismatch, and may include `requestId` when available on the request object.
+
+Include the tests under `tests/middleware/csrf.test.ts` to cover the above edge-cases so behavior remains explicit and regression-safe.
+

--- a/tests/middleware/csrf.test.ts
+++ b/tests/middleware/csrf.test.ts
@@ -547,6 +547,28 @@ describe('csrfMiddleware integration — token format edge cases', () => {
     expect(res.status).toBe(403);
     expect(res.body.error.message).toContain('CSRF token mismatch');
   });
+
+  it('blocks when X-CSRF-Token header is present but empty string', async () => {
+    const token = generateCsrfToken();
+    const res = await request(app)
+      .post('/api/streams')
+      .set('Cookie', `session=abc; ${CSRF_COOKIE_NAME}=${token}`)
+      .set('X-CSRF-Token', '')
+      .send({});
+    expect(res.status).toBe(403);
+    expect(res.body.error.message).toContain('CSRF token missing');
+  });
+
+  it('blocks when fluxora_csrf cookie value is empty string', async () => {
+    const headerToken = generateCsrfToken();
+    const res = await request(app)
+      .post('/api/streams')
+      .set('Cookie', `session=abc; ${CSRF_COOKIE_NAME}=`)
+      .set('X-CSRF-Token', headerToken)
+      .send({});
+    expect(res.status).toBe(403);
+    expect(res.body.error.message).toContain('CSRF token missing');
+  });
 });
 
 describe('csrfMiddleware integration — correlationId in error responses', () => {


### PR DESCRIPTION
CLOSES #1046

What I changed

[security.md](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html): Added a clear "CSRF enforcement behavior (browser-facing requests)" section that spells out enforcement rules, bypass rules, token requirements, comparison semantics, and the regression surface.
[csrf.test.ts](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html): Added tests asserting that empty header or empty cookie values are treated as missing tokens and result in 403 FORBIDDEN responses.