### PR TITLE
fix(auth): stabilize auth middleware edge cases and add regression tests

### DIFF
--- a/src/lib/apiKey.ts
+++ b/src/lib/apiKey.ts
@@ -257,6 +257,43 @@ export async function isValidApiKey(rawKey: string): Promise<boolean> {
 }
 
 /**
+ * Looks up the full ApiKeyRecord for a given raw key.
+ *
+ * Resolves by prefix (O(log n)), then performs a constant-time hash comparison
+ * to find the matching active record. Returns the record including scopes, or
+ * `undefined` if the key is not found or is inactive.
+ *
+ * Only active keys are returned — revoked keys yield `undefined`.
+ *
+ * @param rawKey - The raw key presented by the caller (e.g. `flx_...`).
+ */
+export async function getApiKeyRecord(rawKey: string): Promise<ApiKeyRecord | undefined> {
+  if (!rawKey || typeof rawKey !== 'string') {
+    return undefined;
+  }
+
+  const prefix = rawKey.slice(0, PREFIX_LENGTH);
+  const candidates = await apiKeyRepository.findActiveByPrefix(prefix);
+
+  for (const candidate of candidates) {
+    if (hashesMatch(hashKey(rawKey, candidate.salt), candidate.keyHash)) {
+      return candidate;
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Alias for {@link getApiKeyRecord} — looks up the full `ApiKeyRecord` for a
+ * given raw key. Exported under a second name so middleware that imports
+ * `findRecordByRawKey` remains source-compatible with the mock used in unit
+ * tests.
+ *
+ * @see getApiKeyRecord
+ */
+export const findRecordByRawKey = getApiKeyRecord;
+
+/**
  * Extracts the API key from common request headers.
  */
 export function getApiKeyFromRequest(

--- a/src/middleware/auth.ts
+++ b/src/middleware/auth.ts
@@ -15,7 +15,7 @@ import { getApiKeyFromRequest, findRecordByRawKey } from '../lib/apiKey.js';
  * If an invalid API key is present, returns 401.
  */
 export async function authenticateApiKey(req: Request, res: Response, next: NextFunction): Promise<void> {
-  const requestId = req.correlationId;
+  const requestId = req.id ?? req.correlationId;
   const rawKey = getApiKeyFromRequest(req.headers);
 
   if (!rawKey) {
@@ -23,7 +23,7 @@ export async function authenticateApiKey(req: Request, res: Response, next: Next
   }
 
   try {
-    const record = await getApiKeyRecord(rawKey);
+    const record = await findRecordByRawKey(rawKey);
     
     if (!record) {
       warn('API key authentication failed — key not found', { requestId });
@@ -176,7 +176,7 @@ export async function authenticate(req: Request, res: Response, next: NextFuncti
 }
 
 export function requireAuth(req: Request, res: Response, next: NextFunction): void {
-  const requestId = req.correlationId;
+  const requestId = req.id ?? req.correlationId;
   if (!req.user) {
     warn('Anonymous access denied to protected route', { path: req.path, requestId });
     res.status(401).json({
@@ -193,7 +193,7 @@ export function requireAuth(req: Request, res: Response, next: NextFunction): vo
 
 export function requirePermission(permission: Permission) {
   return (req: Request, res: Response, next: NextFunction): void => {
-    const requestId = req.correlationId;
+    const requestId = req.id ?? req.correlationId;
     if (!req.user) {
       warn('Permission check failed: no authenticated user', { path: req.path, requestId });
       res.status(401).json({
@@ -223,7 +223,7 @@ export function requirePermission(permission: Permission) {
 
 export function requireScope(...requiredScopes: string[]) {
   return (req: Request, res: Response, next: NextFunction): void => {
-    const requestId = req.correlationId;
+    const requestId = req.id ?? req.correlationId;
     const isApiKeyAuth = (req as any).keyId !== undefined;
     const isJwtAuth = req.user !== undefined;
     if (!isApiKeyAuth && !isJwtAuth) {

--- a/src/middleware/authLockout.ts
+++ b/src/middleware/authLockout.ts
@@ -20,28 +20,34 @@ export async function authLockoutMiddleware(
   const ip = getClientIp(req);
   const address = req.body?.address as string | undefined;
 
-  if (ip && ip !== 'unknown') {
-    const ipLockout = await authAttemptStore.isLockedOut(ip);
-    if (ipLockout > 0) {
-      res.setHeader('Retry-After', String(ipLockout));
-      res.status(429).json({
-        success: false,
-        message: 'Too many failed attempts, try again later',
-      });
-      return;
+  try {
+    if (ip && ip !== 'unknown') {
+      const ipLockout = await authAttemptStore.isLockedOut(ip);
+      if (ipLockout > 0) {
+        res.setHeader('Retry-After', String(ipLockout));
+        res.status(429).json({
+          success: false,
+          message: 'Too many failed attempts, try again later',
+        });
+        return;
+      }
     }
-  }
 
-  if (address) {
-    const addrLockout = await authAttemptStore.isLockedOut(address);
-    if (addrLockout > 0) {
-      res.setHeader('Retry-After', String(addrLockout));
-      res.status(429).json({
-        success: false,
-        message: 'Too many failed attempts, try again later',
-      });
-      return;
+    if (address) {
+      const addrLockout = await authAttemptStore.isLockedOut(address);
+      if (addrLockout > 0) {
+        res.setHeader('Retry-After', String(addrLockout));
+        res.status(429).json({
+          success: false,
+          message: 'Too many failed attempts, try again later',
+        });
+        return;
+      }
     }
+  } catch (err) {
+    // Forward store errors to the Express error handler so they produce a
+    // deterministic 500 response rather than an unhandled rejection.
+    return next(err);
   }
 
   req.authAttemptStore = authAttemptStore;

--- a/tests/middleware/auth.rbac.test.ts
+++ b/tests/middleware/auth.rbac.test.ts
@@ -1,16 +1,57 @@
+/**
+ * RBAC / scope permission middleware integration tests.
+ *
+ * These tests verify that the permission/scope enforcement layer (requirePermission,
+ * requireScope) correctly gates requests based on JWT roles or API key scopes.
+ *
+ * DB layers are mocked so no live database is required.
+ */
+
 import request from 'supertest';
 import jwt from 'jsonwebtoken';
-import { vi } from 'vitest';
+import { vi, describe, it, expect, beforeAll } from 'vitest';
 
+// ── Module-scope mocks (must be hoisted by Vitest) ───────────────────────────
+// The DLQ route calls the real dlqRepository, which needs a live DB.
+// Mock it so the route can return 200 when auth passes.
+vi.mock('../../src/db/repositories/dlqRepository.js', () => ({
+  dlqRepository: {
+    findAll: vi.fn(async () => ({ entries: [], total: 0 })),
+    listSuspendedConsumers: vi.fn(async () => []),
+    findById: vi.fn(async () => undefined),
+    insert: vi.fn(async () => {}),
+    delete: vi.fn(async () => {}),
+    replay: vi.fn(async () => {}),
+    getConsumerSuspension: vi.fn(async () => undefined),
+    recordReplaySuccess: vi.fn(async () => {}),
+    recordReplayFailure: vi.fn(async () => {}),
+    resumeConsumer: vi.fn(async () => {}),
+  },
+}));
+
+vi.mock('../../src/db/repositories/streamRepository.js', () => ({ streamRepository: {} }));
+
+vi.mock('../../src/db/repositories/auditRepository.js', () => ({
+  auditRepository: {
+    findAll: vi.fn(async () => ({ items: [], total: 0, cursor: null })),
+  },
+}));
+
+// ── Imports (after mocks) ────────────────────────────────────────────────────
 import { app } from '../../src/app.js';
 import { generateToken } from '../../src/lib/auth.js';
-import { getConfig } from '../../src/config/env.js';
+import { getConfig, initializeConfig } from '../../src/config/env.js';
+
+// ── Test suite ────────────────────────────────────────────────────────────────
 
 describe('RBAC Permission Middleware', () => {
   const address = 'GCSXAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAUV';
 
   beforeAll(() => {
-    vi.mock('../../src/db/repositories/streamRepository.js', () => ({ streamRepository: {} }));
+    // Config must be initialised before generateToken/verifyToken is called.
+    process.env.NODE_ENV = 'test';
+    process.env.JWT_SECRET = 'a-very-long-secret-key-for-testing-only-12345';
+    initializeConfig();
   });
 
   it('allows operator (has DLQ_LIST) to access DLQ list', async () => {
@@ -19,6 +60,7 @@ describe('RBAC Permission Middleware', () => {
       .get('/admin/dlq')
       .set('Authorization', `Bearer ${token}`);
 
+    // Auth + RBAC allow the request through; the mocked route returns 200.
     expect(res.status).toBe(200);
   });
 
@@ -33,7 +75,7 @@ describe('RBAC Permission Middleware', () => {
 
   it('rejects token missing permissions claim during authentication', async () => {
     const { jwtSecret } = getConfig();
-    // Sign a token without permissions to simulate a malformed token
+    // Sign a token without the `permissions` array — the Zod schema rejects it.
     const raw = jwt.sign({ address, role: 'viewer' } as any, jwtSecret);
     const res = await request(app)
       .get('/api/audit')
@@ -46,12 +88,10 @@ describe('RBAC Permission Middleware', () => {
 describe('Scope Permission Middleware (requireScope)', () => {
   it('returns 401 if authentication is missing entirely', async () => {
     const res = await request(app)
-      .get('/api/streams') // Assuming this route uses requireScope
+      .get('/api/streams')
       .query({ limit: 10 });
-    
-    // An endpoint with requireScope but no auth should fail with 401
-    // (If the route uses authenticateApiKey, it might pass as anonymous if it doesn't fail closed,
-    // but requireScope should catch it now.)
+
+    // requireScope returns 401 when neither JWT user nor API key is present.
     expect(res.status).toBe(401);
   });
 });

--- a/tests/unit/middleware/auth.test.ts
+++ b/tests/unit/middleware/auth.test.ts
@@ -423,3 +423,146 @@ describe('authenticateApiKey (issue #836)', () => {
     expect(next).toHaveBeenCalled();
   });
 });
+
+// ── requireScope edge cases ───────────────────────────────────────────────────
+
+import { requireScope } from '../../../src/middleware/auth.js';
+
+function mockReqForScope(opts: {
+  keyId?: string;
+  keyScopes?: string[];
+  user?: { permissions?: string[] };
+} = {}): Partial<Request> {
+  const req: any = {
+    path: '/test',
+    id: 'req-scope',
+    correlationId: 'req-scope',
+  };
+  if (opts.keyId !== undefined) req.keyId = opts.keyId;
+  if (opts.keyScopes !== undefined) req.keyScopes = opts.keyScopes;
+  if (opts.user !== undefined) req.user = opts.user;
+  return req;
+}
+
+describe('requireScope — unauthenticated principal', () => {
+  it('returns 401 when neither JWT user nor API key is present', () => {
+    const req = mockReqForScope() as Request; // no user, no keyId
+    const res = mockRes() as Response;
+    const next = mockNext();
+
+    requireScope('streams:read')(req, res, next);
+
+    expect(res.statusCode).toBe(401);
+    expect((res as any).jsonBody.error.code).toBe('UNAUTHORIZED');
+    expect(next).not.toHaveBeenCalled();
+  });
+});
+
+describe('requireScope — API key authenticated', () => {
+  it('returns 403 when keyScopes is an empty array', () => {
+    const req = mockReqForScope({ keyId: 'key-1', keyScopes: [] }) as Request;
+    const res = mockRes() as Response;
+    const next = mockNext();
+
+    requireScope('streams:read')(req, res, next);
+
+    expect(res.statusCode).toBe(403);
+    expect((res as any).jsonBody.error.code).toBe('FORBIDDEN');
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it('returns 403 when keyScopes does not include the required scope', () => {
+    const req = mockReqForScope({ keyId: 'key-1', keyScopes: ['streams:read'] }) as Request;
+    const res = mockRes() as Response;
+    const next = mockNext();
+
+    requireScope('streams:write')(req, res, next);
+
+    expect(res.statusCode).toBe(403);
+    expect((res as any).jsonBody.error.code).toBe('FORBIDDEN');
+  });
+
+  it('calls next() when keyScopes includes the required scope', () => {
+    const req = mockReqForScope({ keyId: 'key-1', keyScopes: ['streams:read', 'streams:write'] }) as Request;
+    const res = mockRes() as Response;
+    const next = mockNext();
+
+    requireScope('streams:write')(req, res, next);
+
+    expect(next).toHaveBeenCalled();
+    expect(res.statusCode).toBe(200);
+  });
+
+  it('calls next() when any one of multiple required scopes matches', () => {
+    const req = mockReqForScope({ keyId: 'key-1', keyScopes: ['admin:pause'] }) as Request;
+    const res = mockRes() as Response;
+    const next = mockNext();
+
+    requireScope('streams:write', 'admin:pause')(req, res, next);
+
+    expect(next).toHaveBeenCalled();
+  });
+
+  it('prefers keyScopes over user.permissions when both keyId and user are present', () => {
+    // Both auth methods set: API key takes precedence (isApiKeyAuth checked first)
+    const req = mockReqForScope({
+      keyId: 'key-1',
+      keyScopes: ['streams:read'], // has read
+      user: { permissions: ['streams:write'] }, // has write — should be ignored
+    }) as Request;
+    const res = mockRes() as Response;
+    const next = mockNext();
+
+    requireScope('streams:write')(req, res, next);
+
+    // API key scopes are used; 'streams:write' is not in keyScopes → 403
+    expect(res.statusCode).toBe(403);
+    expect(next).not.toHaveBeenCalled();
+  });
+});
+
+describe('requireScope — JWT authenticated', () => {
+  it('returns 403 when user.permissions is an empty array', () => {
+    const req = mockReqForScope({ user: { permissions: [] } }) as Request;
+    const res = mockRes() as Response;
+    const next = mockNext();
+
+    requireScope('streams:read')(req, res, next);
+
+    expect(res.statusCode).toBe(403);
+    expect((res as any).jsonBody.error.code).toBe('FORBIDDEN');
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it('returns 403 when user.permissions does not include required scope', () => {
+    const req = mockReqForScope({ user: { permissions: ['streams:read'] } }) as Request;
+    const res = mockRes() as Response;
+    const next = mockNext();
+
+    requireScope('streams:write')(req, res, next);
+
+    expect(res.statusCode).toBe(403);
+  });
+
+  it('calls next() when user.permissions includes the required scope', () => {
+    const req = mockReqForScope({ user: { permissions: ['streams:read', 'streams:write'] } }) as Request;
+    const res = mockRes() as Response;
+    const next = mockNext();
+
+    requireScope('streams:write')(req, res, next);
+
+    expect(next).toHaveBeenCalled();
+  });
+
+  it('returns 403 when user has no permissions property (undefined)', () => {
+    // user object exists but permissions is missing (should default to [])
+    const req = mockReqForScope({ user: {} }) as Request;
+    const res = mockRes() as Response;
+    const next = mockNext();
+
+    requireScope('streams:read')(req, res, next);
+
+    expect(res.statusCode).toBe(403);
+    expect(next).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/middleware/authLockout.test.ts
+++ b/tests/unit/middleware/authLockout.test.ts
@@ -1,0 +1,298 @@
+/**
+ * Edge-case unit tests for src/middleware/authLockout.ts.
+ *
+ * The existing integration tests in tests/authLockout.test.ts cover the
+ * happy-path lockout/reset/window/backoff scenarios via a real Express app.
+ * These unit tests lock down the implicit edge cases:
+ *
+ *  1. store=null bypass — when no AuthAttemptStore has been configured,
+ *     authLockoutMiddleware must call next() immediately without any lockout
+ *     check (null-store is a valid "disabled" state, not an error).
+ *
+ *  2. store throws on isLockedOut — the middleware must not swallow the error;
+ *     it must propagate it to next(err) so the error handler can respond.
+ *
+ *  3. IP resolves to 'unknown' — getClientIp() may return 'unknown' for
+ *     requests that have no identifiable remote address. The middleware skips
+ *     the IP lockout check in that case and only checks the body address.
+ *
+ *  4. Missing body address — when req.body.address is absent, only the IP
+ *     check runs (no crash on undefined address lookup).
+ *
+ *  5. Both IP and address locked out — IP check fires first; 429 returned
+ *     before the address check is reached.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import type { Request, Response, NextFunction } from 'express';
+import type { AuthAttemptStore } from '../../../src/redis/authAttemptStore.js';
+
+// ── Mock getClientIp so we control what "IP" the middleware sees ──────────────
+vi.mock('../../../src/ws/connectionLimiter.js', () => ({
+  getClientIp: vi.fn(),
+}));
+
+import { getClientIp } from '../../../src/ws/connectionLimiter.js';
+import {
+  authLockoutMiddleware,
+  setAuthAttemptStore,
+} from '../../../src/middleware/authLockout.js';
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function makeStore(overrides: Partial<AuthAttemptStore> = {}): AuthAttemptStore {
+  return {
+    isLockedOut: vi.fn(async () => 0),
+    recordFailure: vi.fn(async () => {}),
+    recordSuccess: vi.fn(async () => {}),
+    ...overrides,
+  } as unknown as AuthAttemptStore;
+}
+
+function makeReq(opts: { ip?: string; address?: string } = {}): Partial<Request> {
+  return {
+    body: opts.address !== undefined ? { address: opts.address } : {},
+    authAttemptStore: undefined,
+  };
+}
+
+function makeRes(): Partial<Response> {
+  const res: any = {
+    statusCode: 200,
+    _headers: {} as Record<string, string>,
+    status(code: number) { this.statusCode = code; return this; },
+    json(body: any) { this._body = body; return this; },
+    setHeader(name: string, value: string) { this._headers[name] = value; },
+  };
+  return res;
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe('authLockoutMiddleware — store=null bypass', () => {
+  beforeEach(() => {
+    // Ensure no store is registered (simulate "disabled" state).
+    setAuthAttemptStore(null as any);
+    (getClientIp as any).mockReturnValue('1.2.3.4');
+  });
+
+  afterEach(() => {
+    setAuthAttemptStore(null as any);
+    vi.clearAllMocks();
+  });
+
+  it('calls next() immediately without any lockout check when store is null', async () => {
+    const req = makeReq({ address: 'GTEST' });
+    const res = makeRes();
+    const next = vi.fn();
+
+    await authLockoutMiddleware(req as Request, res as Response, next);
+
+    expect(next).toHaveBeenCalledOnce();
+    expect(next).toHaveBeenCalledWith(); // no error argument
+    // IP mock should not matter because isLockedOut is never called
+    expect(getClientIp).not.toHaveBeenCalled();
+  });
+
+  it('does not attach authAttemptStore to req when store is null', async () => {
+    const req = makeReq({ address: 'GTEST' }) as any;
+    const res = makeRes();
+    const next = vi.fn();
+
+    await authLockoutMiddleware(req as Request, res as Response, next);
+
+    // The middleware only attaches store when the store is set
+    expect(req.authAttemptStore).toBeUndefined();
+  });
+});
+
+describe('authLockoutMiddleware — store throws on isLockedOut', () => {
+  afterEach(() => {
+    setAuthAttemptStore(null as any);
+    vi.clearAllMocks();
+  });
+
+  it('propagates the error to next(err) when IP isLockedOut throws', async () => {
+    const boom = new Error('Redis connection refused');
+    const store = makeStore({ isLockedOut: vi.fn(async () => { throw boom; }) });
+    setAuthAttemptStore(store);
+    (getClientIp as any).mockReturnValue('10.0.0.1');
+
+    const req = makeReq({ address: 'GTEST' });
+    const res = makeRes();
+    const next = vi.fn();
+
+    await authLockoutMiddleware(req as Request, res as Response, next);
+
+    expect(next).toHaveBeenCalledWith(boom);
+    expect((res as any).statusCode).toBe(200); // no res.status() call — error forwarded
+  });
+
+  it('propagates the error to next(err) when address isLockedOut throws', async () => {
+    const boom = new Error('Timeout on address lookup');
+    // IP check passes (returns 0), address check throws
+    const store = makeStore({
+      isLockedOut: vi.fn(async (key: string) => {
+        if (key === '10.0.0.1') return 0;
+        throw boom;
+      }),
+    });
+    setAuthAttemptStore(store);
+    (getClientIp as any).mockReturnValue('10.0.0.1');
+
+    const req = makeReq({ address: 'GTEST' });
+    const res = makeRes();
+    const next = vi.fn();
+
+    await authLockoutMiddleware(req as Request, res as Response, next);
+
+    expect(next).toHaveBeenCalledWith(boom);
+  });
+});
+
+describe('authLockoutMiddleware — IP resolves to "unknown"', () => {
+  afterEach(() => {
+    setAuthAttemptStore(null as any);
+    vi.clearAllMocks();
+  });
+
+  it('skips IP lockout check when IP is "unknown" and only checks body address', async () => {
+    const store = makeStore({ isLockedOut: vi.fn(async () => 0) });
+    setAuthAttemptStore(store);
+    (getClientIp as any).mockReturnValue('unknown');
+
+    const req = makeReq({ address: 'GADDR' });
+    const res = makeRes();
+    const next = vi.fn();
+
+    await authLockoutMiddleware(req as Request, res as Response, next);
+
+    expect(next).toHaveBeenCalledOnce();
+    // isLockedOut should have been called for the address but NOT for 'unknown'
+    expect(store.isLockedOut).toHaveBeenCalledWith('GADDR');
+    expect(store.isLockedOut).not.toHaveBeenCalledWith('unknown');
+  });
+
+  it('calls next() when IP is "unknown" and there is no body address', async () => {
+    const store = makeStore({ isLockedOut: vi.fn(async () => 0) });
+    setAuthAttemptStore(store);
+    (getClientIp as any).mockReturnValue('unknown');
+
+    const req = makeReq(); // no address in body
+    const res = makeRes();
+    const next = vi.fn();
+
+    await authLockoutMiddleware(req as Request, res as Response, next);
+
+    expect(next).toHaveBeenCalledOnce();
+    expect(store.isLockedOut).not.toHaveBeenCalled();
+  });
+
+  it('returns 429 when body address is locked out even when IP is "unknown"', async () => {
+    const store = makeStore({ isLockedOut: vi.fn(async () => 60) });
+    setAuthAttemptStore(store);
+    (getClientIp as any).mockReturnValue('unknown');
+
+    const req = makeReq({ address: 'LOCKED_ADDR' });
+    const res = makeRes() as any;
+    const next = vi.fn();
+
+    await authLockoutMiddleware(req as Request, res as Response, next);
+
+    expect(res.statusCode).toBe(429);
+    expect(res._headers['Retry-After']).toBe('60');
+    expect(next).not.toHaveBeenCalled();
+  });
+});
+
+describe('authLockoutMiddleware — missing body address', () => {
+  afterEach(() => {
+    setAuthAttemptStore(null as any);
+    vi.clearAllMocks();
+  });
+
+  it('only checks IP lockout when body.address is absent', async () => {
+    const store = makeStore({ isLockedOut: vi.fn(async () => 0) });
+    setAuthAttemptStore(store);
+    (getClientIp as any).mockReturnValue('5.6.7.8');
+
+    const req = makeReq(); // no address
+    const res = makeRes();
+    const next = vi.fn();
+
+    await authLockoutMiddleware(req as Request, res as Response, next);
+
+    expect(next).toHaveBeenCalledOnce();
+    expect(store.isLockedOut).toHaveBeenCalledWith('5.6.7.8');
+    expect(store.isLockedOut).toHaveBeenCalledTimes(1); // address check skipped
+  });
+
+  it('returns 429 via IP lockout when body.address is absent and IP is locked', async () => {
+    const store = makeStore({ isLockedOut: vi.fn(async () => 120) });
+    setAuthAttemptStore(store);
+    (getClientIp as any).mockReturnValue('5.6.7.8');
+
+    const req = makeReq() as any;
+    const res = makeRes() as any;
+    const next = vi.fn();
+
+    await authLockoutMiddleware(req as Request, res as Response, next);
+
+    expect(res.statusCode).toBe(429);
+    expect(res._headers['Retry-After']).toBe('120');
+    expect(next).not.toHaveBeenCalled();
+  });
+});
+
+describe('authLockoutMiddleware — both IP and address locked', () => {
+  afterEach(() => {
+    setAuthAttemptStore(null as any);
+    vi.clearAllMocks();
+  });
+
+  it('returns 429 based on IP lockout before reaching address check', async () => {
+    // IP locked (60s), address also locked (120s), but IP is checked first.
+    const store = makeStore({
+      isLockedOut: vi.fn(async (key: string) => {
+        if (key === '9.9.9.9') return 60;
+        return 120; // address lockout — should never be reached
+      }),
+    });
+    setAuthAttemptStore(store);
+    (getClientIp as any).mockReturnValue('9.9.9.9');
+
+    const req = makeReq({ address: 'GADDR_ALSO_LOCKED' }) as any;
+    const res = makeRes() as any;
+    const next = vi.fn();
+
+    await authLockoutMiddleware(req as Request, res as Response, next);
+
+    expect(res.statusCode).toBe(429);
+    expect(res._headers['Retry-After']).toBe('60'); // IP lockout value
+    // isLockedOut called once for IP, address check never reached
+    expect(store.isLockedOut).toHaveBeenCalledTimes(1);
+    expect(next).not.toHaveBeenCalled();
+  });
+});
+
+describe('authLockoutMiddleware — attaches store to request', () => {
+  afterEach(() => {
+    setAuthAttemptStore(null as any);
+    vi.clearAllMocks();
+  });
+
+  it('attaches the store to req.authAttemptStore when request is allowed through', async () => {
+    const store = makeStore({ isLockedOut: vi.fn(async () => 0) });
+    setAuthAttemptStore(store);
+    (getClientIp as any).mockReturnValue('1.2.3.4');
+
+    const req = makeReq({ address: 'GTEST' }) as any;
+    const res = makeRes();
+    const next = vi.fn();
+
+    await authLockoutMiddleware(req as Request, res as Response, next);
+
+    expect(req.authAttemptStore).toBe(store);
+    expect(next).toHaveBeenCalledOnce();
+  });
+});

--- a/tests/unit/middleware/tokenAuth.test.ts
+++ b/tests/unit/middleware/tokenAuth.test.ts
@@ -1,0 +1,180 @@
+/**
+ * Edge-case tests for src/middleware/tokenAuth.ts — createBearerTokenAuth.
+ *
+ * Covers the implicit edge-case behaviour that was previously untested:
+ *  1. required=false with no token configured → middleware is a no-op (passes all requests).
+ *  2. required=false with a token configured → auth is enforced.
+ *  3. required=true with no token configured → service-unavailable error (fail-closed).
+ *  4. Empty bearer value in Authorization header (e.g., "Bearer ").
+ *  5. Whitespace-only bearer value (e.g., "Bearer    ").
+ *  6. Missing Authorization header entirely when auth is enforced.
+ *  7. Mismatched bearer token → 401 unauthorized.
+ *  8. Correct bearer token → passes through.
+ *  9. Non-Bearer Authorization scheme → 401 unauthorized.
+ * 10. Token with surrounding whitespace in Authorization header (getBearerToken trims value).
+ */
+
+import { describe, it, expect } from 'vitest';
+import express, { type Request, type Response } from 'express';
+import request from 'supertest';
+import { createBearerTokenAuth } from '../../../src/middleware/tokenAuth.js';
+import { errorHandler } from '../../../src/middleware/errorHandler.js';
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+function buildApp(options: Parameters<typeof createBearerTokenAuth>[0]) {
+  const app = express();
+  app.use(express.json());
+  app.use(createBearerTokenAuth(options));
+  app.get('/protected', (_req: Request, res: Response) => res.json({ ok: true }));
+  app.use(errorHandler);
+  return app;
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe('createBearerTokenAuth — required=false with no token configured', () => {
+  // When required=false and no token is provided, auth is disabled entirely.
+  // Every request must pass regardless of Authorization header.
+
+  it('passes request with no Authorization header', async () => {
+    const app = buildApp({ role: 'partner', required: false });
+    const res = await request(app).get('/protected');
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ ok: true });
+  });
+
+  it('passes request with an Authorization header (auth disabled — header is ignored)', async () => {
+    const app = buildApp({ role: 'partner', required: false });
+    const res = await request(app).get('/protected').set('Authorization', 'Bearer any-value');
+    expect(res.status).toBe(200);
+  });
+
+  it('passes request with a malformed Authorization header when auth is disabled', async () => {
+    const app = buildApp({ role: 'partner', required: false });
+    const res = await request(app).get('/protected').set('Authorization', 'NotBearer xyz');
+    expect(res.status).toBe(200);
+  });
+});
+
+describe('createBearerTokenAuth — required=false with a token configured', () => {
+  // When a token is provided but required=false, auth is still enforced.
+  // (authEnabled = required || Boolean(token) → true when token is set)
+
+  const token = 'my-secret-partner-token';
+
+  it('passes request with the correct bearer token', async () => {
+    const app = buildApp({ role: 'partner', required: false, token });
+    const res = await request(app).get('/protected').set('Authorization', `Bearer ${token}`);
+    expect(res.status).toBe(200);
+  });
+
+  it('returns 401 for missing Authorization header', async () => {
+    const app = buildApp({ role: 'partner', required: false, token });
+    const res = await request(app).get('/protected');
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 401 for wrong bearer token', async () => {
+    const app = buildApp({ role: 'partner', required: false, token });
+    const res = await request(app).get('/protected').set('Authorization', 'Bearer wrong-token');
+    expect(res.status).toBe(401);
+  });
+});
+
+describe('createBearerTokenAuth — required=true with no token configured (fail-closed)', () => {
+  // When required=true but token is absent, the service is misconfigured.
+  // The middleware must fail closed — 503 Service Unavailable, not a silent pass.
+
+  it('returns 503 when token is not configured', async () => {
+    const app = buildApp({ role: 'administrator', required: true });
+    const res = await request(app).get('/protected').set('Authorization', 'Bearer anything');
+    expect(res.status).toBe(503);
+  });
+
+  it('returns 503 even when no Authorization header is present', async () => {
+    const app = buildApp({ role: 'administrator', required: true });
+    const res = await request(app).get('/protected');
+    expect(res.status).toBe(503);
+  });
+});
+
+describe('createBearerTokenAuth — empty / whitespace bearer values', () => {
+  const token = 'real-token-value';
+
+  it('returns 401 for "Bearer " (empty bearer value after split)', async () => {
+    // getBearerToken splits on space — "Bearer " yields value="" which is falsy
+    const app = buildApp({ role: 'partner', required: true, token });
+    const res = await request(app).get('/protected').set('Authorization', 'Bearer ');
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 401 for "Bearer    " (whitespace-only bearer value)', async () => {
+    // trim() turns "   " into "" which is treated as no token
+    const app = buildApp({ role: 'partner', required: true, token });
+    const res = await request(app).get('/protected').set('Authorization', 'Bearer    ');
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 401 for Authorization header with just the scheme and no space', async () => {
+    // "Bearer" with no space → split gives ["Bearer"], no value
+    const app = buildApp({ role: 'partner', required: true, token });
+    const res = await request(app).get('/protected').set('Authorization', 'Bearer');
+    expect(res.status).toBe(401);
+  });
+});
+
+describe('createBearerTokenAuth — non-Bearer Authorization schemes', () => {
+  const token = 'correct-token';
+
+  it('returns 401 for Basic scheme', async () => {
+    const app = buildApp({ role: 'partner', required: true, token });
+    const res = await request(app).get('/protected').set('Authorization', `Basic ${token}`);
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 401 for APIKey scheme', async () => {
+    const app = buildApp({ role: 'partner', required: true, token });
+    const res = await request(app).get('/protected').set('Authorization', `APIKey ${token}`);
+    expect(res.status).toBe(401);
+  });
+});
+
+describe('createBearerTokenAuth — correct token always passes', () => {
+  it('accepts correct token and calls next() for administrator role', async () => {
+    const token = 'admin-secret-token';
+    const app = buildApp({ role: 'administrator', required: true, token });
+    const res = await request(app).get('/protected').set('Authorization', `Bearer ${token}`);
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ ok: true });
+  });
+
+  it('accepts correct token and calls next() for partner role', async () => {
+    const token = 'partner-secret-token';
+    const app = buildApp({ role: 'partner', required: true, token });
+    const res = await request(app).get('/protected').set('Authorization', `Bearer ${token}`);
+    expect(res.status).toBe(200);
+  });
+});
+
+describe('createBearerTokenAuth — token with extra whitespace in Authorization header', () => {
+  it('trims trailing whitespace from bearer value before comparing', async () => {
+    // getBearerToken uses split(' ', 2) and then trim() on the value.
+    // "Bearer correct-token  " should parse to "correct-token" after trim.
+    const token = 'correct-token';
+    const app = buildApp({ role: 'partner', required: true, token });
+    // supertest normalizes headers; inject raw header value via a passthrough middleware
+    const innerApp = express();
+    innerApp.use(express.json());
+    innerApp.use((req: Request, _res: Response, next) => {
+      req.headers['authorization'] = `Bearer ${token}  `; // trailing spaces
+      next();
+    });
+    innerApp.use(createBearerTokenAuth({ role: 'partner', required: true, token }));
+    innerApp.get('/protected', (_req: Request, res: Response) => res.json({ ok: true }));
+    innerApp.use(errorHandler);
+
+    const res = await request(innerApp).get('/protected');
+    expect(res.status).toBe(200);
+  });
+});


### PR DESCRIPTION
closes #1068 
- Fix src/middleware/auth.ts: imported findRecordByRawKey but called getApiKeyRecord (undefined ref) — now consistently calls findRecordByRawKey. Align all requestId resolutions to req.id ?? req.correlationId throughout authenticateApiKey, requireAuth, requirePermission, and requireScope.

- Add getApiKeyRecord + findRecordByRawKey exports to src/lib/apiKey.ts. getApiKeyRecord resolves a full ApiKeyRecord by raw key (prefix lookup + constant-time hash compare). findRecordByRawKey is an exported alias so middleware and its unit-test mocks use the same name.

- Fix src/middleware/authLockout.ts: wrap isLockedOut calls in try/catch and forward errors to next(err) so store failures produce a deterministic 500 instead of an unhandled rejection.

- Fix tests/middleware/auth.rbac.test.ts: move vi.mock calls to module scope (Vitest hoists), add correct dlqRepository mock shape ({entries,total}), add beforeAll with initializeConfig() + JWT_SECRET. All 4 previously- failing tests now pass.

- Add tests/unit/middleware/tokenAuth.test.ts (16 tests): covers required=false with no token (no-op), required=false with token (enforced), required=true with no token (503 fail-closed), empty/whitespace bearer values, non-Bearer schemes, correct token passes.

- Add tests/unit/middleware/authLockout.test.ts (11 tests): covers store=null bypass, store throws forwarded to next(err), IP='unknown' skips IP check, missing body address, both IP+address locked (IP checked first), store attached to req on pass-through.

- Extend tests/unit/middleware/auth.test.ts with requireScope edge cases (10 new tests): unauthenticated 401, empty keyScopes 403, missing scope 403, matching scope passes, any-of-many match, API key takes precedence over JWT when both present, JWT empty permissions 403, JWT missing permissions 403.

Fixes: 4 originally-failing tests. Adds 37 new regression tests. No breaking changes — all existing behavior preserved.