### PR TITLE
fix: remove dead error-handling exports from src/errors.ts (#855)

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -86,5 +86,12 @@ export default [
       '@typescript-eslint/no-explicit-any': 'warn',
     },
   },
+  {
+  files: ['src/**/*.ts'],
+  plugins: { 'unused-exports': unusedExports },
+  rules: {
+    'unused-exports/no-unused-exports': 'error',
+  },
+},
   prettierConfig,
 ];

--- a/src/app.ts
+++ b/src/app.ts
@@ -56,7 +56,8 @@ import { createDeprecationMiddleware } from './middleware/deprecation.js';
 import { routeDeprecations } from './config/deprecations.js';
 import { createRateLimitsRouter } from './routes/rateLimits.js';
 import { getRateLimitConfig } from './config/rateLimits.js';
-import { successResponse, errorResponse } from './utils/response.js';
+import { successResponse } from './utils/response.js';
+import { ApiError } from './errors.js';
 import { docsRouter } from './routes/docs.js';
 import { startVacuumCollector } from './metrics/vacuumCollector.js';
 import { startBackgroundJobs, stopBackgroundJobs } from './jobs/queue.js';
@@ -525,11 +526,8 @@ export function createApp(options: AppOptions = {}): Express {
     );
   });
 
-  app.use((req: Request, res: Response) => {
-    const requestId = req.correlationId;
-    res.status(404).json(
-      errorResponse('NOT_FOUND', 'The requested resource was not found', undefined, requestId),
-    );
+  app.use((_req: Request, _res: Response, next: NextFunction) => {
+    next(new ApiError(404, 'NOT_FOUND', 'The requested resource was not found'));
   });
 
   app.use(errorHandler);

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,6 +1,3 @@
-import { randomUUID } from 'node:crypto';
-import type { Request, Response, NextFunction } from 'express';
-
 export class ApiError extends Error {
   /**
    * HTTP status code returned to the client.
@@ -52,67 +49,4 @@ export function serviceUnavailable(message: string, details?: Record<string, unk
 
 export function unauthorizedError(message: string, details?: Record<string, unknown>): ApiError {
   return new ApiError(401, 'unauthorized', message, details);
-}
-
-export function requestIdMiddleware(req: Request, res: Response, next: NextFunction): void {
-  const requestId = req.header('x-request-id') ?? randomUUID();
-  res.locals['requestId'] = requestId;
-  res.setHeader('x-request-id', requestId);
-  next();
-}
-
-export function notFoundHandler(req: Request, _res: Response, next: NextFunction): void {
-  next(new ApiError(404, 'not_found', `No route matches ${req.method} ${req.originalUrl}`));
-}
-
-function normalizeExpressError(error: unknown): ApiError {
-  const candidate = error as { status?: number; type?: string };
-
-  if (candidate?.type === 'entity.parse.failed') {
-    return new ApiError(400, 'invalid_json', 'Request body must be valid JSON');
-  }
-  if (candidate?.type === 'entity.too.large' || candidate?.status === 413) {
-    return new ApiError(413, 'payload_too_large', 'Request body exceeds the 256 KiB limit');
-  }
-  if (error instanceof ApiError) return error;
-
-  return new ApiError(500, 'internal_error', 'Internal server error', undefined, false);
-}
-
-export function errorHandler(
-  error: unknown,
-  req: Request,
-  res: Response,
-  _next: NextFunction,
-): void {
-  const normalized = normalizeExpressError(error);
-  const requestId = res.locals['requestId'] as string | undefined;
-
-  const log = {
-    requestId,
-    statusCode: normalized.statusCode,
-    code: normalized.code,
-    method: req.method,
-    path: req.originalUrl,
-    message: error instanceof Error ? error.message : normalized.message,
-    details: normalized.details,
-  };
-
-  if (normalized.statusCode >= 500) {
-    console.error('API error', log);
-  } else {
-    console.warn('API error', log);
-  }
-
-  const errorBody: Record<string, unknown> = {
-    code: normalized.code,
-    message: normalized.message,
-    statusCode: normalized.statusCode,
-    requestId,
-  };
-  if (normalized.details !== undefined) {
-    errorBody['details'] = normalized.details;
-  }
-
-  res.status(normalized.statusCode).json({ error: errorBody });
 }

--- a/tests/errors.test.ts
+++ b/tests/errors.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from 'vitest';
+import { ApiError, serviceUnavailable, unauthorizedError } from '../src/errors.js';
+
+describe('src/errors.ts', () => {
+  describe('ApiError', () => {
+    it('constructs with all fields', () => {
+      const err = new ApiError(400, 'TEST_CODE', 'test message', { key: 'value' }, true);
+      expect(err).toBeInstanceOf(Error);
+      expect(err).toBeInstanceOf(ApiError);
+      expect(err.statusCode).toBe(400);
+      expect(err.code).toBe('TEST_CODE');
+      expect(err.message).toBe('test message');
+      expect(err.details).toEqual({ key: 'value' });
+      expect(err.expose).toBe(true);
+    });
+
+    it('defaults expose to true', () => {
+      const err = new ApiError(500, 'INTERNAL', 'oops');
+      expect(err.expose).toBe(true);
+    });
+
+    it('allows expose=false', () => {
+      const err = new ApiError(500, 'INTERNAL', 'oops', undefined, false);
+      expect(err.expose).toBe(false);
+    });
+  });
+
+  describe('serviceUnavailable', () => {
+    it('returns a 503 ApiError', () => {
+      const err = serviceUnavailable('DB is down', { retryAfter: 30 });
+      expect(err).toBeInstanceOf(ApiError);
+      expect(err.statusCode).toBe(503);
+      expect(err.code).toBe('service_unavailable');
+      expect(err.message).toBe('DB is down');
+      expect(err.details).toEqual({ retryAfter: 30 });
+    });
+  });
+
+  describe('unauthorizedError', () => {
+    it('returns a 401 ApiError', () => {
+      const err = unauthorizedError('Invalid token');
+      expect(err).toBeInstanceOf(ApiError);
+      expect(err.statusCode).toBe(401);
+      expect(err.code).toBe('unauthorized');
+      expect(err.message).toBe('Invalid token');
+    });
+  });
+});

--- a/tests/routes/404.test.ts
+++ b/tests/routes/404.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import request from 'supertest';
+import type { Express } from 'express';
+import { createApp } from '../../src/app.js';
+
+describe('404 catch-all handler', () => {
+  let app: Express;
+
+  beforeAll(() => {
+    app = createApp();
+  });
+
+  it('returns structured 404 for unmatched GET routes', async () => {
+    const res = await request(app).get('/this-route-does-not-exist-12345');
+    expect(res.status).toBe(404);
+    expect(res.body).toEqual({
+      success: false,
+      error: {
+        code: 'NOT_FOUND',
+        message: 'The requested resource was not found',
+        requestId: expect.any(String),
+      },
+    });
+  });
+
+  it('returns structured 404 for unmatched POST routes', async () => {
+    const res = await request(app).post('/nonexistent-path');
+    expect(res.status).toBe(404);
+    expect(res.body.error.code).toBe('NOT_FOUND');
+    expect(res.body.error.message).toBe('The requested resource was not found');
+  });
+
+  it('returns structured 404 for unmatched methods on existing paths', async () => {
+    const res = await request(app).patch('/health');
+    expect(res.status).toBe(404);
+    expect(res.body.error.code).toBe('NOT_FOUND');
+  });
+});


### PR DESCRIPTION
Closes #855

## What changed
- **src/errors.ts** — Removed three unused exports (`errorHandler`, `notFoundHandler`, `requestIdMiddleware`) plus the private `normalizeExpressError` helper. The dead `errorHandler` was logging via `console.error`/`console.warn`, bypassing the PII-redacting pipeline (`src/logging/logger.ts` / `src/pii/sanitizer.ts`). Removing it eliminates the landmine.
- **src/app.ts** — Replaced the inline 404 catch-all with an `ApiError` throw so it flows through the live `middleware/errorHandler.ts`. Response format is identical, but 404s now get structured, redacted logging and the `X-Request-ID` header.
- **tests/errors.test.ts** — Covers the three remaining exports (`ApiError`, `serviceUnavailable`, `unauthorizedError`).
- **tests/routes/404.test.ts** — Verifies the consolidated 404 behavior.
- **eslint.config.js** — Added `eslint-plugin-unused-exports` rule to catch dead exports going forward.

## Verification
- `npm run build` passes
- `npm test` passes
- Coverage remains ≥95%