### PR TITLE
feat: fix logger call signature mismatch

### DIFF
--- a/src/metrics/pool.ts
+++ b/src/metrics/pool.ts
@@ -74,7 +74,7 @@ export function syncPoolGauges(
   const active = pool.totalCount - pool.idleCount;
   if (active < 0) {
     dbPoolNegativeActive.inc({ pool: poolName });
-    logger.warn('pg.Pool accounting inconsistency: totalCount < idleCount', {
+    logger.warn('pg.Pool accounting inconsistency: totalCount < idleCount', undefined, {
       pool: poolName,
       totalCount: pool.totalCount,
       idleCount: pool.idleCount,

--- a/src/middleware/deprecation.ts
+++ b/src/middleware/deprecation.ts
@@ -100,7 +100,7 @@ function applyDeprecationHeaders(req: Request, res: Response, entries: Normalize
     }
 
     if (entry.sunset.getTime() <= Date.now()) {
-      logger.warn('deprecated route is past its sunset date', {
+      logger.warn('deprecated route is past its sunset date', req.correlationId as string, {
         event: 'route.sunset.past',
         method: req.method,
         path: req.path,
@@ -108,7 +108,6 @@ function applyDeprecationHeaders(req: Request, res: Response, entries: Normalize
         sunsetDate: entry.sunsetDate,
         sunsetTimestamp: entry.sunset.toISOString(),
         overdueMs: Date.now() - entry.sunset.getTime(),
-        correlationId: req.correlationId,
         userAgent: req.headers['user-agent'] ?? 'unknown',
       });
     }

--- a/src/middleware/idempotency.ts
+++ b/src/middleware/idempotency.ts
@@ -60,7 +60,7 @@ export function createIdempotencyMiddleware(
 
       if (existing) {
         if (existing.requestFingerprint !== incomingHash) {
-          logger.warn('Idempotency conflict detected', {
+          logger.warn('Idempotency conflict detected', req.correlationId as string, {
             idempotencyKeyLength: idempotencyKey.length,
             incomingHash,
             storedHash: existing.requestFingerprint,
@@ -73,9 +73,8 @@ export function createIdempotencyMiddleware(
           });
         }
 
-        logger.info('Replaying idempotent response', { 
+        logger.info('Replaying idempotent response', req.correlationId as string, { 
             idempotencyKeyLength: idempotencyKey.length,
-            requestId: req.correlationId 
         });
         
         res.set('Idempotency-Key', idempotencyKey);
@@ -101,7 +100,7 @@ export function createIdempotencyMiddleware(
             { requestFingerprint: incomingHash, statusCode: res.statusCode, body },
             ttlSeconds,
           ).catch((err) => {
-            logger.error('Failed to store idempotent response', { 
+            logger.error('Failed to store idempotent response', req.correlationId as string, { 
                 error: err instanceof Error ? err.message : String(err) 
             });
           });
@@ -115,7 +114,7 @@ export function createIdempotencyMiddleware(
 
       next();
     } catch (err) {
-      logger.error('Idempotency middleware error', { 
+      logger.error('Idempotency middleware error', req.correlationId as string, { 
           error: err instanceof Error ? err.message : String(err) 
       });
       next();

--- a/src/middleware/pii.ts
+++ b/src/middleware/pii.ts
@@ -32,7 +32,7 @@ export function requestLogger(req: Request, res: Response, next: NextFunction): 
 
   res.on('finish', () => {
     const duration = Date.now() - start;
-    logger.info('http request', {
+    logger.info('http request', req.correlationId as string, {
       method: req.method,
       path: req.path,
       status: res.statusCode,
@@ -51,11 +51,11 @@ export function requestLogger(req: Request, res: Response, next: NextFunction): 
  */
 export function safeErrorHandler(
   err: Error,
-  _req: Request,
+  req: Request,
   res: Response,
   _next: NextFunction,
 ): void {
-  logger.error('unhandled error', {
+  logger.error('unhandled error', req.correlationId as string, {
     error: redactKeysInString(err.message),
     stack: process.env.NODE_ENV === 'production' ? undefined : redactKeysInString(err.stack || ''),
   });

--- a/src/middleware/requestLogger.ts
+++ b/src/middleware/requestLogger.ts
@@ -20,10 +20,9 @@ export function requestLoggerMiddleware(req: Request, res: Response, next: NextF
   const { correlationId } = req;
   const startMs = Date.now();
 
-  logger.info('request received', {
+  logger.info('request received', correlationId as string, {
     method: req.method,
     path: req.path,
-    correlationId,
   });
 
   res.on('finish', () => {
@@ -32,15 +31,14 @@ export function requestLoggerMiddleware(req: Request, res: Response, next: NextF
       path: req.path,
       statusCode: res.statusCode,
       durationMs: Date.now() - startMs,
-      correlationId,
     };
 
     if (res.statusCode >= 500) {
-      logger.error('request failed', meta);
+      logger.error('request failed', correlationId as string, meta);
       return;
     }
 
-    logger.info('request completed', meta);
+    logger.info('request completed', correlationId as string, meta);
   });
 
   next();

--- a/src/redis/client.ts
+++ b/src/redis/client.ts
@@ -78,14 +78,14 @@ function parseHostPorts(raw: string): Array<{ host: string; port: number }> {
 
 /** Attach structured log listeners to any ioredis client (Redis | Cluster). */
 function attachLogListeners(client: Redis | Cluster, mode: string): void {
-  client.on('connect', () => logger.info('redis:connect', { mode }));
-  client.on('ready', () => logger.info('redis:ready', { mode }));
-  client.on('reconnecting', () => logger.warn('redis:reconnecting', { mode }));
+  client.on('connect', () => logger.info('redis:connect', undefined, { mode }));
+  client.on('ready', () => logger.info('redis:ready', undefined, { mode }));
+  client.on('reconnecting', () => logger.warn('redis:reconnecting', undefined, { mode }));
   client.on('error', (err: Error) =>
-    logger.error('redis:error', { mode, error: err.message }),
+    logger.error('redis:error', undefined, { mode, error: err.message }),
   );
-  client.on('close', () => logger.warn('redis:close', { mode }));
-  client.on('end', () => logger.warn('redis:end', { mode }));
+  client.on('close', () => logger.warn('redis:close', undefined, { mode }));
+  client.on('end', () => logger.warn('redis:end', undefined, { mode }));
 }
 
 // ---------------------------------------------------------------------------
@@ -299,7 +299,7 @@ export async function quitAllRedisClients(): Promise<void> {
   await Promise.all(
     clients.map((c) =>
       c.close().catch((err: unknown) => {
-        logger.warn('redis:quit_error', { error: (err as Error).message });
+        logger.warn('redis:quit_error', undefined, { error: (err as Error).message });
       }),
     ),
   );

--- a/src/redis/idempotencyStore.ts
+++ b/src/redis/idempotencyStore.ts
@@ -171,9 +171,8 @@ export class RedisIdempotencyStore<T = unknown> implements IdempotencyStore<T> {
 
       const result = parseAndValidateEnvelope<T>(raw);
       if (result.invalidReason !== undefined) {
-        this.logger.warn('Idempotency store: envelope validation failed — treating as absent', {
+        this.logger.warn('Idempotency store: envelope validation failed — treating as absent', correlationStore.getStore(), {
           operation: 'get',
-          correlationId: correlationStore.getStore(),
           keyLength: key.length,
           reason: result.invalidReason,
         });
@@ -182,9 +181,8 @@ export class RedisIdempotencyStore<T = unknown> implements IdempotencyStore<T> {
       return result.entry;
     } catch (err) {
       this.onStateChange?.(false);
-      this.logger.warn('Idempotency store: Redis get failed — degrading to pass-through', {
+      this.logger.warn('Idempotency store: Redis get failed — degrading to pass-through', correlationStore.getStore(), {
         operation: 'get',
-        correlationId: correlationStore.getStore(),
         keyLength: key.length,
         error: err instanceof Error ? err.message : String(err),
       });
@@ -199,9 +197,8 @@ export class RedisIdempotencyStore<T = unknown> implements IdempotencyStore<T> {
       this.onStateChange?.(true);
     } catch (err) {
       this.onStateChange?.(false);
-      this.logger.warn('Idempotency store: Redis set failed — idempotency not persisted', {
+      this.logger.warn('Idempotency store: Redis set failed — idempotency not persisted', correlationStore.getStore(), {
         operation: 'set',
-        correlationId: correlationStore.getStore(),
         keyLength: key.length,
         error: err instanceof Error ? err.message : String(err),
       });

--- a/tests/logger-call-signature.test.ts
+++ b/tests/logger-call-signature.test.ts
@@ -1,0 +1,333 @@
+/**
+ * Verifies that logger calls across middleware and redis modules use the
+ * correct (message, correlationId, meta) call signature, and that the
+ * structured JSON output carries the correlationId and metadata fields
+ * in the correct positions.
+ *
+ * One representative call site per file is tested.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { EventEmitter } from 'node:events';
+import { logger } from '../src/lib/logger.js';
+
+describe('Logger call-signature correctness', () => {
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+  let infoSpy: ReturnType<typeof vi.spyOn>;
+  let errorSpy: ReturnType<typeof vi.spyOn>;
+  let debugSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    warnSpy = vi.spyOn(logger, 'warn').mockImplementation(() => undefined);
+    infoSpy = vi.spyOn(logger, 'info').mockImplementation(() => undefined);
+    errorSpy = vi.spyOn(logger, 'error').mockImplementation(() => undefined);
+    debugSpy = vi.spyOn(logger, 'debug').mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('logger.warn receives (message, correlationId, meta)', () => {
+    logger.warn('test warning', 'cid-42', { extra: 'data', count: 7 });
+
+    expect(warnSpy).toHaveBeenCalledOnce();
+    const [message, correlationId, meta] = warnSpy.mock.calls[0];
+    expect(message).toBe('test warning');
+    expect(correlationId).toBe('cid-42');
+    expect(meta).toEqual({ extra: 'data', count: 7 });
+  });
+
+  it('logger.info receives (message, correlationId, meta)', () => {
+    logger.info('test info', 'cid-99', { method: 'GET', path: '/foo' });
+
+    expect(infoSpy).toHaveBeenCalledOnce();
+    const [message, correlationId, meta] = infoSpy.mock.calls[0];
+    expect(message).toBe('test info');
+    expect(correlationId).toBe('cid-99');
+    expect(meta).toEqual({ method: 'GET', path: '/foo' });
+  });
+
+  it('logger.error receives (message, correlationId, meta)', () => {
+    logger.error('test error', 'cid-err', { operation: 'set', reason: 'timeout' });
+
+    expect(errorSpy).toHaveBeenCalledOnce();
+    const [message, correlationId, meta] = errorSpy.mock.calls[0];
+    expect(message).toBe('test error');
+    expect(correlationId).toBe('cid-err');
+    expect(meta).toEqual({ operation: 'set', reason: 'timeout' });
+  });
+
+  it('logger.debug receives (message, correlationId, meta)', () => {
+    logger.debug('test debug', 'cid-dbg', { operation: 'dedup', streamId: 's1' });
+
+    expect(debugSpy).toHaveBeenCalledOnce();
+    const [message, correlationId, meta] = debugSpy.mock.calls[0];
+    expect(message).toBe('test debug');
+    expect(correlationId).toBe('cid-dbg');
+    expect(meta).toEqual({ operation: 'dedup', streamId: 's1' });
+  });
+
+  it('logger.info without correlationId passes undefined as second arg', () => {
+    logger.info('no cid passed', undefined, { key: 'value' });
+
+    expect(infoSpy).toHaveBeenCalledOnce();
+    const [message, correlationId, meta] = infoSpy.mock.calls[0];
+    expect(message).toBe('no cid passed');
+    expect(correlationId).toBeUndefined();
+    expect(meta).toEqual({ key: 'value' });
+  });
+
+  it('logger.info with only message passes undefined correlationId and undefined meta', () => {
+    logger.info('minimal');
+
+    expect(infoSpy).toHaveBeenCalledOnce();
+    const [message, correlationId, meta] = infoSpy.mock.calls[0];
+    expect(message).toBe('minimal');
+    expect(correlationId).toBeUndefined();
+    expect(meta).toBeUndefined();
+  });
+});
+
+describe('requestLoggerMiddleware logger call-signature', () => {
+  let infoSpy: ReturnType<typeof vi.spyOn>;
+  let errorSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    infoSpy = vi.spyOn(logger, 'info').mockImplementation(() => undefined);
+    errorSpy = vi.spyOn(logger, 'error').mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('request received: correlationId is second arg, method/path in third', async () => {
+    const { requestLoggerMiddleware } = await import('../src/middleware/requestLogger.js');
+
+    const req = {
+      method: 'POST',
+      path: '/api/streams',
+      correlationId: 'req-logger-test',
+    } as any;
+    const res = new EventEmitter() as any;
+    res.statusCode = 200;
+    const next = vi.fn();
+
+    requestLoggerMiddleware(req, res, next);
+    expect(next).toHaveBeenCalledOnce();
+
+    const [message, cid, meta] = infoSpy.mock.calls[0];
+    expect(message).toBe('request received');
+    expect(cid).toBe('req-logger-test');
+    expect(meta).toEqual({ method: 'POST', path: '/api/streams' });
+  });
+
+  it('request completed: correlationId is second arg, meta is third', async () => {
+    const { requestLoggerMiddleware } = await import('../src/middleware/requestLogger.js');
+
+    const req = {
+      method: 'GET',
+      path: '/health',
+      correlationId: 'cid-complete',
+    } as any;
+    const res = new EventEmitter() as any;
+    res.statusCode = 200;
+
+    requestLoggerMiddleware(req, res, vi.fn());
+    res.emit('finish');
+
+    const [message, cid, meta] = infoSpy.mock.calls[1];
+    expect(message).toBe('request completed');
+    expect(cid).toBe('cid-complete');
+    expect(meta).toMatchObject({ method: 'GET', path: '/health', statusCode: 200 });
+  });
+
+  it('request failed (5xx): correlationId is second arg, meta is third', async () => {
+    const { requestLoggerMiddleware } = await import('../src/middleware/requestLogger.js');
+
+    const req = {
+      method: 'DELETE',
+      path: '/api/resource',
+      correlationId: 'cid-fail',
+    } as any;
+    const res = new EventEmitter() as any;
+    res.statusCode = 500;
+
+    requestLoggerMiddleware(req, res, vi.fn());
+    res.emit('finish');
+
+    const [message, cid, meta] = errorSpy.mock.calls[0];
+    expect(message).toBe('request failed');
+    expect(cid).toBe('cid-fail');
+    expect(meta).toMatchObject({ method: 'DELETE', path: '/api/resource', statusCode: 500 });
+  });
+});
+
+describe('idempotency middleware logger call-signature', () => {
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+  let infoSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    warnSpy = vi.spyOn(logger, 'warn').mockImplementation(() => undefined);
+    infoSpy = vi.spyOn(logger, 'info').mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('idempotency conflict: correlationId is second arg, meta is third', async () => {
+    const { createIdempotencyMiddleware, hashBody } = await import('../src/middleware/idempotency.js');
+    const { InMemoryIdempotencyStore } = await import('../src/redis/idempotencyStore.js');
+
+    const store = new InMemoryIdempotencyStore();
+    const mw = createIdempotencyMiddleware(store, 60);
+
+    const body = { amount: 10 };
+    const req1 = {
+      method: 'POST',
+      headers: { 'idempotency-key': 'conflict-key' },
+      body,
+      correlationId: 'cid-conflict',
+    } as any;
+    const res1: any = {
+      statusCode: 200,
+      set: vi.fn(),
+      json: vi.fn(),
+    };
+
+    await mw(req1, res1, vi.fn());
+    res1.json({ data: { id: 's1' } });
+
+    const req2 = {
+      method: 'POST',
+      headers: { 'idempotency-key': 'conflict-key' },
+      body: { amount: 999 },
+      correlationId: 'cid-conflict-2',
+    } as any;
+    const res2: any = {
+      statusCode: 200,
+      set: vi.fn(),
+      status(code: number) { res2.statusCode = code; return res2; },
+      json: vi.fn(),
+    };
+
+    await mw(req2, res2, vi.fn());
+
+    expect(warnSpy).toHaveBeenCalledOnce();
+    const [message, cid, meta] = warnSpy.mock.calls[0];
+    expect(message).toBe('Idempotency conflict detected');
+    expect(cid).toBe('cid-conflict-2');
+    expect(meta).toMatchObject({
+      idempotencyKeyLength: 'conflict-key'.length,
+      incomingHash: expect.any(String),
+      storedHash: expect.any(String),
+    });
+  });
+
+  it('idempotent replay: correlationId is second arg, meta is third', async () => {
+    const { createIdempotencyMiddleware } = await import('../src/middleware/idempotency.js');
+    const { InMemoryIdempotencyStore } = await import('../src/redis/idempotencyStore.js');
+
+    const store = new InMemoryIdempotencyStore();
+    const mw = createIdempotencyMiddleware(store, 60);
+
+    const body = { amount: 10 };
+    const req1 = {
+      method: 'POST',
+      headers: { 'idempotency-key': 'replay-key' },
+      body,
+      correlationId: 'cid-first',
+    } as any;
+    const res1: any = {
+      statusCode: 200,
+      set: vi.fn(),
+      json: vi.fn(),
+    };
+
+    await mw(req1, res1, vi.fn());
+    res1.json({ data: { id: 's1' } });
+
+    const req2 = {
+      method: 'POST',
+      headers: { 'idempotency-key': 'replay-key' },
+      body,
+      correlationId: 'cid-replay',
+    } as any;
+    const res2: any = {
+      statusCode: 200,
+      set: vi.fn(),
+      json: vi.fn(),
+    };
+
+    await mw(req2, res2, vi.fn());
+
+    expect(infoSpy).toHaveBeenCalledOnce();
+    const [message, cid, meta] = infoSpy.mock.calls[0];
+    expect(message).toBe('Replaying idempotent response');
+    expect(cid).toBe('cid-replay');
+    expect(meta).toMatchObject({ idempotencyKeyLength: 'replay-key'.length });
+  });
+});
+
+describe('pii middleware logger call-signature', () => {
+  let infoSpy: ReturnType<typeof vi.spyOn>;
+  let errorSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    infoSpy = vi.spyOn(logger, 'info').mockImplementation(() => undefined);
+    errorSpy = vi.spyOn(logger, 'error').mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('requestLogger: correlationId is second arg, meta is third', async () => {
+    const { requestLogger } = await import('../src/middleware/pii.js');
+
+    const req = {
+      method: 'GET',
+      path: '/api/data',
+      correlationId: 'cid-pii',
+    } as any;
+    const res = new EventEmitter() as any;
+    res.statusCode = 200;
+
+    requestLogger(req, res, vi.fn());
+    res.emit('finish');
+
+    expect(infoSpy).toHaveBeenCalledOnce();
+    const [message, cid, meta] = infoSpy.mock.calls[0];
+    expect(message).toBe('http request');
+    expect(cid).toBe('cid-pii');
+    expect(meta).toMatchObject({
+      method: 'GET',
+      path: '/api/data',
+      status: 200,
+      durationMs: expect.any(Number),
+    });
+  });
+
+  it('safeErrorHandler: correlationId is second arg, meta is third', async () => {
+    const { safeErrorHandler } = await import('../src/middleware/pii.js');
+
+    const err = new Error('boom');
+    const req = { correlationId: 'cid-err-handler' } as any;
+    const res = {
+      status: vi.fn().mockReturnThis(),
+      json: vi.fn(),
+    } as any;
+
+    safeErrorHandler(err, req, res, vi.fn());
+
+    expect(errorSpy).toHaveBeenCalledOnce();
+    const [message, cid, meta] = errorSpy.mock.calls[0];
+    expect(message).toBe('unhandled error');
+    expect(cid).toBe('cid-err-handler');
+    expect(meta).toMatchObject({
+      error: expect.any(String),
+    });
+  });
+});

--- a/tests/requestLogger.test.ts
+++ b/tests/requestLogger.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { EventEmitter } from 'node:events';
 import { requestLoggerMiddleware } from '../src/middleware/requestLogger.js';
-import { logger, _resetLoggerForTest } from '../src/logging/logger.js';
+import { logger } from '../src/logging/logger.js';
 
 interface MockReq {
   method: string;
@@ -35,7 +35,6 @@ describe('requestLogger middleware', () => {
   let errorSpy: ReturnType<typeof vi.spyOn>;
 
   beforeEach(() => {
-    _resetLoggerForTest();
     infoSpy = vi.spyOn(logger, 'info').mockImplementation(() => undefined);
     errorSpy = vi.spyOn(logger, 'error').mockImplementation(() => undefined);
   });
@@ -72,17 +71,23 @@ describe('requestLogger middleware', () => {
     expect(errorSpy.mock.calls[0][0]).toBe('request failed');
   });
 
-  it('includes correlationId on structured metadata', () => {
+  it('includes correlationId as the second argument and metadata as the third', () => {
     const req = createReq({ correlationId: 'req-abc' });
     const res = createRes(204);
 
     requestLoggerMiddleware(req, res, vi.fn());
     res.emit('finish');
 
-    const receivedMeta = infoSpy.mock.calls[0][1] as Record<string, unknown>;
-    const completedMeta = infoSpy.mock.calls[1][1] as Record<string, unknown>;
-    expect(receivedMeta.correlationId).toBe('req-abc');
-    expect(completedMeta.correlationId).toBe('req-abc');
+    expect(infoSpy).toHaveBeenCalledTimes(2);
+    expect(infoSpy.mock.calls[0][1]).toBe('req-abc');
+    expect(infoSpy.mock.calls[1][1]).toBe('req-abc');
+
+    const receivedMeta = infoSpy.mock.calls[0][2] as Record<string, unknown>;
+    const completedMeta = infoSpy.mock.calls[1][2] as Record<string, unknown>;
+    expect(receivedMeta.method).toBe('GET');
+    expect(receivedMeta.path).toBe('/health');
+    expect(completedMeta.method).toBe('GET');
+    expect(completedMeta.path).toBe('/health');
   });
 
   it('does not include ip or authorization data in emitted metadata', () => {
@@ -92,8 +97,8 @@ describe('requestLogger middleware', () => {
     requestLoggerMiddleware(req, res, vi.fn());
     res.emit('finish');
 
-    const receivedMeta = infoSpy.mock.calls[0][1] as Record<string, unknown>;
-    const completedMeta = infoSpy.mock.calls[1][1] as Record<string, unknown>;
+    const receivedMeta = infoSpy.mock.calls[0][2] as Record<string, unknown>;
+    const completedMeta = infoSpy.mock.calls[1][2] as Record<string, unknown>;
 
     expect(Object.prototype.hasOwnProperty.call(receivedMeta, 'ip')).toBe(false);
     expect(Object.prototype.hasOwnProperty.call(receivedMeta, 'authorization')).toBe(false);
@@ -112,7 +117,7 @@ describe('requestLogger middleware', () => {
     requestLoggerMiddleware(req, res, vi.fn());
     res.emit('finish');
 
-    const completedMeta = infoSpy.mock.calls[1][1] as Record<string, unknown>;
+    const completedMeta = infoSpy.mock.calls[1][2] as Record<string, unknown>;
     expect(completedMeta.statusCode).toBe(201);
     expect(completedMeta.durationMs).toBe(45);
 


### PR DESCRIPTION
# Fix: Logger call-signature mismatch across middleware and redis modules

## Problem

The structured logger's object API (`src/lib/logger.ts`) has the signature:

```typescript
logger.X(message: string, correlationId?: string, meta?: Record<string, unknown>)
```

Multiple files were passing a metadata object directly as the second argument (where `correlationId: string` is expected), causing a type mismatch (`TS2345`). At runtime, the metadata was silently dropped or coerced to `"[object Object]"` in the correlationId slot, meaning:

- Structured metadata (operation names, error details, status codes) was **lost** from log output
- Correlation IDs were **not attached** to these log lines, breaking request tracing
- Security-relevant logs (idempotency conflicts, PII-safe error logging) were missing context needed for incident forensics

## Changes

### Core fixes — 6 files (13 call sites per issue)

| File | Sites | Fix |
|------|-------|-----|
| `src/middleware/idempotency.ts` | 4 | Pass `req.correlationId` as second arg |
| `src/middleware/requestLogger.ts` | 3 | Extract `correlationId` from meta, pass as second arg |
| `src/middleware/deprecation.ts` | 1 | Remove `correlationId` from meta, pass as second arg |
| `src/middleware/pii.ts` | 2 | Pass `req.correlationId` as second arg; rename `_req` → `req` |
| `src/redis/idempotencyStore.ts` | 3 | Extract `correlationStore.getStore()` as second arg |
| `src/redis/dedup.ts` | 0 | Already correct — passes `undefined` explicitly |

### Additional discoveries — 2 more files with same bug

Found by project-wide grep for remaining `logger.X(message, {object})` patterns:

| File | Sites | Fix |
|------|-------|-----|
| `src/redis/client.ts` | 7 | Redis event listeners: pass `undefined` (no request context) |
| `src/metrics/pool.ts` | 1 | Pool gauge logging: pass `undefined` (no request context) |

### Tests

- **`tests/logger-call-signature.test.ts`** — New test file with 13 tests verifying the correct `(message, correlationId, meta)` call signature across logger object, `requestLoggerMiddleware`, `idempotency` middleware, and `pii` middleware
- **`tests/requestLogger.test.ts`** — Updated existing assertions to match the new call signature (correlationId now at spy index `[1]`, meta at `[2]`)

## Verification

```
$ pnpm run typecheck   # zero new errors (2 pre-existing syntax errors in unrelated files)
$ pnpm vitest run tests/logger-call-signature.test.ts tests/requestLogger.test.ts
  ✓ 18/18 tests passed
```

## CI note

No CI pipeline enforces `tsc --noEmit` as a merge gate. The type errors were masked by two pre-existing syntax errors in `src/webhooks/dispatcher.ts` and `tests/integration/broadcast-auth.test.ts` that cause tsc to bail early. A separate effort should fix those and add a CI step running `pnpm run typecheck`.

Closes #882 