### PR TITLE
test: harden admin route permission edge cases (#1075)

### DIFF
--- a/tests/routes/admin.auth.test.ts
+++ b/tests/routes/admin.auth.test.ts
@@ -1,0 +1,481 @@
+/**
+ * tests/routes/admin.auth.test.ts
+ *
+ * Dedicated hardening suite for the `requireAdminAuth` guard as applied
+ * to the main adminRouter.
+ *
+ * Covered edge-cases
+ * ------------------
+ *
+ * ADMIN_API_KEY environment variable
+ *   • Unset → every protected route returns 503 (fail-closed)
+ *
+ * Authorization header format
+ *   • Missing header            → 401
+ *   • Wrong scheme (Basic)      → 401
+ *   • Two-part Bearer but empty token ("Bearer ") → 401
+ *   • Non-Bearer two-word prefix → 401
+ *   • Oversized header (>8192 B) → 401  (DoS guard)
+ *
+ * Static key comparison
+ *   • Correct static key        → passes (200/202/etc.)
+ *   • Wrong static key          → 403
+ *   • Key that is one char shorter than correct → 403  (length side-channel)
+ *   • Key that is one char longer  → 403
+ *
+ * JWT fallback path (when static key doesn't match)
+ *   • JWT with role=admin                    → passes
+ *   • JWT with role=data-protection-officer  → passes
+ *   • JWT with role=operator                 → 403
+ *   • JWT with role=viewer                   → 403
+ *   • Expired JWT                            → 403
+ *   • Structurally invalid JWT (random string) → 403
+ *   • JWT signed with wrong secret            → 403
+ *
+ * Public (unauthenticated) endpoint
+ *   • GET /api/admin/status/read-only is accessible without any credentials
+ *   • GET /api/admin/status/read-only still works when ADMIN_API_KEY is unset
+ *
+ * Persistence / service errors on protected routes
+ *   • PUT /api/admin/pause throws AdminStatePersistenceError → 503
+ *   • POST /api/admin/reindex when already running           → 409
+ *
+ * Audit trail
+ *   • Successful auth records an in-memory audit event (PAUSE_FLAGS_UPDATED)
+ *
+ * Response shape
+ *   • Auth failures must use the { error: string } shape (not success envelope)
+ *   • Protected success responses use { success: true, data, meta } envelope
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import request from 'supertest';
+import jwt from 'jsonwebtoken';
+import { app } from '../../src/app.js';
+import { _resetForTest } from '../../src/state/adminState.js';
+import { _resetAuditLog } from '../../src/lib/auditLog.js';
+import { initializeConfig } from '../../src/config/env.js';
+import { generateToken } from '../../src/lib/auth.js';
+
+// ── Constants ─────────────────────────────────────────────────────────────────
+
+const ADMIN_KEY = 'test-admin-key-for-auth-suite';
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function authed(req: request.Test): request.Test {
+  return req.set('Authorization', `Bearer ${ADMIN_KEY}`);
+}
+
+function withToken(req: request.Test, token: string): request.Test {
+  return req.set('Authorization', `Bearer ${token}`);
+}
+
+// ── Setup / teardown ──────────────────────────────────────────────────────────
+
+let prevAdminKey: string | undefined;
+let prevJwtSecret: string | undefined;
+
+beforeEach(() => {
+  prevAdminKey = process.env.ADMIN_API_KEY;
+  prevJwtSecret = process.env.JWT_SECRET;
+
+  process.env.ADMIN_API_KEY = ADMIN_KEY;
+  // Use a stable secret for deterministic JWT generation in tests.
+  process.env.JWT_SECRET = 'test-jwt-secret-for-admin-auth-suite';
+
+  _resetForTest();
+  _resetAuditLog();
+  initializeConfig();
+});
+
+afterEach(() => {
+  if (prevAdminKey === undefined) delete process.env.ADMIN_API_KEY;
+  else process.env.ADMIN_API_KEY = prevAdminKey;
+
+  if (prevJwtSecret === undefined) delete process.env.JWT_SECRET;
+  else process.env.JWT_SECRET = prevJwtSecret;
+
+  vi.restoreAllMocks();
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 1. ADMIN_API_KEY unset
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('ADMIN_API_KEY unset → fail-closed', () => {
+  beforeEach(() => {
+    delete process.env.ADMIN_API_KEY;
+  });
+
+  it('GET /api/admin/status returns 503', async () => {
+    const res = await request(app)
+      .get('/api/admin/status')
+      .set('Authorization', `Bearer ${ADMIN_KEY}`);
+    expect(res.status).toBe(503);
+    expect(res.body.error).toMatch(/not configured/i);
+  });
+
+  it('PUT /api/admin/pause returns 503', async () => {
+    const res = await request(app)
+      .put('/api/admin/pause')
+      .set('Authorization', `Bearer ${ADMIN_KEY}`)
+      .send({ streamCreation: true });
+    expect(res.status).toBe(503);
+  });
+
+  it('POST /api/admin/reindex returns 503', async () => {
+    const res = await request(app)
+      .post('/api/admin/reindex')
+      .set('Authorization', `Bearer ${ADMIN_KEY}`);
+    expect(res.status).toBe(503);
+  });
+
+  it('GET /api/admin/status/read-only still returns 200 (public endpoint bypasses auth)', async () => {
+    const res = await request(app).get('/api/admin/status/read-only');
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 2. Authorization header format errors
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('Authorization header format errors → 401', () => {
+  it('missing Authorization header', async () => {
+    const res = await request(app).get('/api/admin/status');
+    expect(res.status).toBe(401);
+    expect(res.body).toHaveProperty('error');
+  });
+
+  it('wrong scheme: Basic', async () => {
+    const res = await request(app)
+      .get('/api/admin/status')
+      .set('Authorization', `Basic ${ADMIN_KEY}`);
+    expect(res.status).toBe(401);
+  });
+
+  it('non-Bearer two-word prefix (Token scheme)', async () => {
+    const res = await request(app)
+      .get('/api/admin/status')
+      .set('Authorization', `Token ${ADMIN_KEY}`);
+    expect(res.status).toBe(401);
+  });
+
+  it('empty bearer token: "Bearer " with no token value', async () => {
+    const res = await request(app)
+      .get('/api/admin/status')
+      .set('Authorization', 'Bearer ');
+    expect(res.status).toBe(401);
+  });
+
+  it('oversized Authorization header (>8192 bytes) → 401 DoS guard', async () => {
+    // 8193-byte header — one byte over the MAX_AUTHORIZATION_HEADER_LENGTH limit
+    const oversized = `Bearer ${'x'.repeat(8186)}`;
+    const res = await request(app)
+      .get('/api/admin/status')
+      .set('Authorization', oversized);
+    expect(res.status).toBe(401);
+    expect(res.body.error).toMatch(/too large/i);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 3. Static key comparison
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('Static key comparison', () => {
+  it('correct static key → 200', async () => {
+    const res = await authed(request(app).get('/api/admin/status'));
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+  });
+
+  it('wrong static key → 403', async () => {
+    const res = await request(app)
+      .get('/api/admin/status')
+      .set('Authorization', 'Bearer wrong-key');
+    expect(res.status).toBe(403);
+    expect(res.body.error).toMatch(/invalid/i);
+  });
+
+  it('key that is one character shorter than correct → 403 (no timing leak)', async () => {
+    const shorterKey = ADMIN_KEY.slice(0, -1);
+    const res = await request(app)
+      .get('/api/admin/status')
+      .set('Authorization', `Bearer ${shorterKey}`);
+    expect(res.status).toBe(403);
+  });
+
+  it('key that is one character longer than correct → 403 (no timing leak)', async () => {
+    const longerKey = ADMIN_KEY + 'X';
+    const res = await request(app)
+      .get('/api/admin/status')
+      .set('Authorization', `Bearer ${longerKey}`);
+    expect(res.status).toBe(403);
+  });
+
+  it('empty string key → 401 (missing token)', async () => {
+    const res = await request(app)
+      .get('/api/admin/status')
+      .set('Authorization', 'Bearer');
+    // Single-word header without space — header has no token part
+    expect(res.status).toBe(401);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 4. JWT fallback path
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('JWT fallback: role-based access control', () => {
+  it('JWT with role=admin → 200', async () => {
+    const token = generateToken({ address: 'addr-admin', role: 'admin' });
+    const res = await withToken(request(app).get('/api/admin/status'), token);
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+  });
+
+  it('JWT with role=data-protection-officer → 200', async () => {
+    const token = generateToken({
+      address: 'addr-dpo',
+      role: 'data-protection-officer',
+    });
+    const res = await withToken(request(app).get('/api/admin/status'), token);
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+  });
+
+  it('JWT with role=operator → 403', async () => {
+    const token = generateToken({ address: 'addr-operator', role: 'operator' });
+    const res = await withToken(request(app).get('/api/admin/status'), token);
+    expect(res.status).toBe(403);
+  });
+
+  it('JWT with role=viewer → 403', async () => {
+    const token = generateToken({ address: 'addr-viewer', role: 'viewer' });
+    const res = await withToken(request(app).get('/api/admin/status'), token);
+    expect(res.status).toBe(403);
+  });
+
+  it('expired JWT → 403', async () => {
+    // Sign a token that expired 1 second ago
+    const secret = process.env.JWT_SECRET!;
+    const expired = jwt.sign(
+      { address: 'addr-expired', role: 'admin' },
+      secret,
+      { expiresIn: -1 },
+    );
+    const res = await withToken(request(app).get('/api/admin/status'), expired);
+    expect(res.status).toBe(403);
+  });
+
+  it('structurally invalid JWT (random string) → 403', async () => {
+    const res = await request(app)
+      .get('/api/admin/status')
+      .set('Authorization', 'Bearer not.a.valid.jwt.at.all');
+    expect(res.status).toBe(403);
+  });
+
+  it('JWT signed with wrong secret → 403', async () => {
+    const badToken = jwt.sign({ address: 'addr-admin', role: 'admin' }, 'wrong-secret');
+    const res = await withToken(request(app).get('/api/admin/status'), badToken);
+    expect(res.status).toBe(403);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 5. Public endpoint (no auth required)
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('GET /api/admin/status/read-only — public, no auth required', () => {
+  it('returns 200 with no Authorization header', async () => {
+    const res = await request(app).get('/api/admin/status/read-only');
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+  });
+
+  it('returns pause flags in data envelope', async () => {
+    const res = await request(app).get('/api/admin/status/read-only');
+    expect(res.body.data.pauseFlags).toEqual({ streamCreation: false, ingestion: false });
+  });
+
+  it('response includes meta.timestamp', async () => {
+    const res = await request(app).get('/api/admin/status/read-only');
+    expect(res.body.meta).toHaveProperty('timestamp');
+    expect(typeof res.body.meta.timestamp).toBe('string');
+  });
+
+  it('accessible even with an invalid Bearer token (auth guard is skipped)', async () => {
+    const res = await request(app)
+      .get('/api/admin/status/read-only')
+      .set('Authorization', 'Bearer completely-wrong');
+    // Auth guard is NOT applied to this endpoint, so an invalid token is ignored
+    expect(res.status).toBe(200);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 6. Persistence / service error paths
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('PUT /api/admin/pause — persistence error → 503', () => {
+  it('returns 503 when setPauseFlags throws AdminStatePersistenceError', async () => {
+    const adminStateModule = await import('../../src/state/adminState.js');
+    const { AdminStatePersistenceError } = adminStateModule;
+    const spy = vi.spyOn(adminStateModule, 'setPauseFlags').mockRejectedValue(
+      new AdminStatePersistenceError('disk full'),
+    );
+
+    const res = await authed(
+      request(app).put('/api/admin/pause').send({ streamCreation: true }),
+    );
+
+    expect(res.status).toBe(503);
+    expect(res.body.success).toBe(false);
+    expect(res.body.error.code).toBe('PERSISTENCE_ERROR');
+    expect(res.body.error.message).toMatch(/persist/i);
+
+    spy.mockRestore();
+  });
+});
+
+describe('POST /api/admin/reindex — conflict when already running', () => {
+  it('returns 409 when a reindex is already in progress', async () => {
+    // Trigger first reindex
+    await authed(request(app).post('/api/admin/reindex'));
+    // Attempt a second one immediately
+    const res = await authed(request(app).post('/api/admin/reindex'));
+    expect(res.status).toBe(409);
+    expect(res.body.success).toBe(false);
+    expect(res.body.error.code).toBe('CONFLICT');
+    expect(res.body.error.message).toMatch(/already in progress/i);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 7. Audit trail
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('Audit trail — successful admin mutations', () => {
+  // These tests spy on `recordAuditEvent` rather than reading back from
+  // `getAuditEntries()` so they work correctly even when another test file
+  // in the same Vitest worker has replaced the auditLog module with a
+  // module-scope vi.mock (e.g. admin.apiKeys.test.ts).
+
+  it('PUT /api/admin/pause calls recordAuditEvent with PAUSE_FLAGS_UPDATED', async () => {
+    const auditModule = await import('../../src/lib/auditLog.js');
+    const spy = vi.spyOn(auditModule, 'recordAuditEvent');
+
+    await authed(
+      request(app).put('/api/admin/pause').send({ streamCreation: true }),
+    );
+
+    expect(spy).toHaveBeenCalledWith(
+      'PAUSE_FLAGS_UPDATED',
+      'pauseFlags',
+      'system',
+      expect.anything(),  // correlationId
+      expect.objectContaining({ updated: expect.any(Object) }),
+    );
+  });
+
+  it('POST /api/admin/reindex calls recordAuditEvent with REINDEX_TRIGGERED', async () => {
+    const auditModule = await import('../../src/lib/auditLog.js');
+    const spy = vi.spyOn(auditModule, 'recordAuditEvent');
+
+    await authed(request(app).post('/api/admin/reindex'));
+
+    expect(spy).toHaveBeenCalledWith(
+      'REINDEX_TRIGGERED',
+      'reindex',
+      'system',
+      expect.anything(),  // correlationId
+      expect.any(Object),
+    );
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 8. Response shape contract
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('Response shape contract', () => {
+  it('401 responses use { error: string } shape — not the success envelope', async () => {
+    const res = await request(app).get('/api/admin/status');
+    expect(res.status).toBe(401);
+    expect(res.body).toHaveProperty('error');
+    expect(res.body).not.toHaveProperty('success');
+    expect(res.body).not.toHaveProperty('data');
+  });
+
+  it('403 responses use { error: string } shape', async () => {
+    const res = await request(app)
+      .get('/api/admin/status')
+      .set('Authorization', 'Bearer bad-key');
+    expect(res.status).toBe(403);
+    expect(res.body).toHaveProperty('error');
+    expect(res.body).not.toHaveProperty('success');
+  });
+
+  it('503 (unconfigured) responses use { error: string } shape', async () => {
+    delete process.env.ADMIN_API_KEY;
+    const res = await request(app)
+      .get('/api/admin/status')
+      .set('Authorization', `Bearer ${ADMIN_KEY}`);
+    expect(res.status).toBe(503);
+    expect(res.body).toHaveProperty('error');
+    expect(res.body).not.toHaveProperty('success');
+  });
+
+  it('successful protected responses use the success envelope shape', async () => {
+    const res = await authed(request(app).get('/api/admin/status'));
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({
+      success: true,
+      data: expect.any(Object),
+      meta: expect.objectContaining({ timestamp: expect.any(String) }),
+    });
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 9. Guard applied consistently across all protected routes
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('Guard applied consistently — every protected route rejects without credentials', () => {
+  const protectedRoutes: Array<[string, string]> = [
+    ['GET',    '/api/admin/status'],
+    ['GET',    '/api/admin/pause'],
+    ['PUT',    '/api/admin/pause'],
+    ['GET',    '/api/admin/reindex'],
+    ['POST',   '/api/admin/reindex'],
+    ['POST',   '/api/admin/indexer/stall/clear'],
+    ['GET',    '/api/admin/deprecations'],
+    ['GET',    '/api/admin/ban-store/status'],
+    ['POST',   '/api/admin/ws/disconnect'],
+    ['GET',    '/api/admin/api-keys'],
+    ['POST',   '/api/admin/api-keys'],
+    ['GET',    '/api/admin/restore'],
+    ['POST',   '/api/admin/streams/bulk-actions'],
+  ];
+
+  for (const [method, path] of protectedRoutes) {
+    it(`${method} ${path} → 401 when Authorization header is absent`, async () => {
+      const req = (request(app) as any)[method.toLowerCase()](path);
+      const res = await (method === 'PUT' || method === 'POST'
+        ? req.send({})
+        : req);
+      expect(res.status).toBe(401);
+    });
+
+    it(`${method} ${path} → 403 when wrong Bearer token is supplied`, async () => {
+      const req = (request(app) as any)[method.toLowerCase()](path);
+      const withAuth = req.set('Authorization', 'Bearer totally-wrong-key');
+      const res = await (method === 'PUT' || method === 'POST'
+        ? withAuth.send({})
+        : withAuth);
+      expect(res.status).toBe(403);
+    });
+  }
+});

--- a/tests/routes/admin.banStore.test.ts
+++ b/tests/routes/admin.banStore.test.ts
@@ -1,0 +1,263 @@
+/**
+ * tests/routes/admin.banStore.test.ts
+ *
+ * Hardening suite for GET /api/admin/ban-store/status.
+ *
+ * Coverage
+ * --------
+ *
+ * Auth gate
+ *   • Missing Authorization header          → 401
+ *   • Wrong Bearer token                    → 403
+ *   • ADMIN_API_KEY unset                   → 503
+ *   • Valid static key                      → passes
+ *   • JWT with role=admin                   → passes
+ *
+ * Happy path — global store NOT initialized
+ *   • Returns 200 with { available: false, usingFallback: false }
+ *
+ * Happy path — global store initialized and healthy
+ *   • Returns 200 with { available: true, usingFallback: false }
+ *
+ * Happy path — global store in fallback mode
+ *   • Returns 200 with { available: true, usingFallback: true }
+ *
+ * Error paths
+ *   • getHybridBanStoreStatus throws          → 503 with SERVICE_UNAVAILABLE
+ *   • getHybridBanStoreStatus is not-a-function → graceful 200 fallback
+ *
+ * Response envelope
+ *   • Success response wraps in { success: true, data, meta }
+ *   • Error response wraps in { success: false, error: { code, message } }
+ *   • meta.timestamp is a valid ISO-8601 string
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import request from 'supertest';
+import { app } from '../../src/app.js';
+import { _resetForTest } from '../../src/state/adminState.js';
+import { initializeConfig } from '../../src/config/env.js';
+import { generateToken } from '../../src/lib/auth.js';
+
+// ── Constants ─────────────────────────────────────────────────────────────────
+
+const ADMIN_KEY = 'test-admin-key-for-ban-store';
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function authed(req: request.Test): request.Test {
+  return req.set('Authorization', `Bearer ${ADMIN_KEY}`);
+}
+
+// ── Setup / teardown ──────────────────────────────────────────────────────────
+
+let prevAdminKey: string | undefined;
+let prevJwtSecret: string | undefined;
+
+beforeEach(() => {
+  prevAdminKey = process.env.ADMIN_API_KEY;
+  prevJwtSecret = process.env.JWT_SECRET;
+
+  process.env.ADMIN_API_KEY = ADMIN_KEY;
+  process.env.JWT_SECRET = 'test-jwt-secret-for-ban-store';
+
+  _resetForTest();
+  initializeConfig();
+  vi.clearAllMocks();
+});
+
+afterEach(() => {
+  if (prevAdminKey === undefined) delete process.env.ADMIN_API_KEY;
+  else process.env.ADMIN_API_KEY = prevAdminKey;
+
+  if (prevJwtSecret === undefined) delete process.env.JWT_SECRET;
+  else process.env.JWT_SECRET = prevJwtSecret;
+
+  vi.restoreAllMocks();
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 1. Auth gate
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('GET /api/admin/ban-store/status — auth gate', () => {
+  it('returns 401 when Authorization header is absent', async () => {
+    const res = await request(app).get('/api/admin/ban-store/status');
+    expect(res.status).toBe(401);
+    expect(res.body).toHaveProperty('error');
+  });
+
+  it('returns 403 when wrong Bearer token is supplied', async () => {
+    const res = await request(app)
+      .get('/api/admin/ban-store/status')
+      .set('Authorization', 'Bearer wrong-key');
+    expect(res.status).toBe(403);
+    expect(res.body).toHaveProperty('error');
+  });
+
+  it('returns 503 when ADMIN_API_KEY is unset (fail-closed)', async () => {
+    delete process.env.ADMIN_API_KEY;
+    const res = await request(app)
+      .get('/api/admin/ban-store/status')
+      .set('Authorization', `Bearer ${ADMIN_KEY}`);
+    expect(res.status).toBe(503);
+    expect(res.body.error).toMatch(/not configured/i);
+  });
+
+  it('passes with correct static key', async () => {
+    const res = await authed(request(app).get('/api/admin/ban-store/status'));
+    expect(res.status).toBe(200);
+  });
+
+  it('passes with JWT role=admin', async () => {
+    const token = generateToken({ address: 'addr-admin', role: 'admin' });
+    const res = await request(app)
+      .get('/api/admin/ban-store/status')
+      .set('Authorization', `Bearer ${token}`);
+    expect(res.status).toBe(200);
+  });
+
+  it('returns 403 with JWT role=operator (insufficient privilege)', async () => {
+    const token = generateToken({ address: 'addr-operator', role: 'operator' });
+    const res = await request(app)
+      .get('/api/admin/ban-store/status')
+      .set('Authorization', `Bearer ${token}`);
+    expect(res.status).toBe(403);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 2. Happy path — store status variants
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('GET /api/admin/ban-store/status — happy path', () => {
+  it('returns available:false when global store is not initialised', async () => {
+    // By default in tests the global HybridBanStore is NOT set, so the
+    // function returns { usingFallback: false, available: false }.
+    vi.spyOn(
+      await import('../../src/redis/banStore.js'),
+      'getHybridBanStoreStatus',
+    ).mockReturnValue({ usingFallback: false, available: false });
+
+    const res = await authed(request(app).get('/api/admin/ban-store/status'));
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(res.body.data.banStore.available).toBe(false);
+    expect(res.body.data.banStore.usingFallback).toBe(false);
+  });
+
+  it('returns available:true, usingFallback:false when store is healthy', async () => {
+    vi.spyOn(
+      await import('../../src/redis/banStore.js'),
+      'getHybridBanStoreStatus',
+    ).mockReturnValue({ usingFallback: false, available: true });
+
+    const res = await authed(request(app).get('/api/admin/ban-store/status'));
+    expect(res.status).toBe(200);
+    expect(res.body.data.banStore.available).toBe(true);
+    expect(res.body.data.banStore.usingFallback).toBe(false);
+  });
+
+  it('returns available:true, usingFallback:true when store is in fallback mode', async () => {
+    vi.spyOn(
+      await import('../../src/redis/banStore.js'),
+      'getHybridBanStoreStatus',
+    ).mockReturnValue({ usingFallback: true, available: true });
+
+    const res = await authed(request(app).get('/api/admin/ban-store/status'));
+    expect(res.status).toBe(200);
+    expect(res.body.data.banStore.available).toBe(true);
+    expect(res.body.data.banStore.usingFallback).toBe(true);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 3. Error paths
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('GET /api/admin/ban-store/status — error paths', () => {
+  it('returns 503 when getHybridBanStoreStatus throws', async () => {
+    vi.spyOn(
+      await import('../../src/redis/banStore.js'),
+      'getHybridBanStoreStatus',
+    ).mockImplementation(() => {
+      throw new Error('Redis connection lost');
+    });
+
+    const res = await authed(request(app).get('/api/admin/ban-store/status'));
+    expect(res.status).toBe(503);
+    expect(res.body.success).toBe(false);
+    expect(res.body.error.code).toBe('SERVICE_UNAVAILABLE');
+  });
+
+  it('503 error message reflects the underlying error, not an internal stack trace', async () => {
+    vi.spyOn(
+      await import('../../src/redis/banStore.js'),
+      'getHybridBanStoreStatus',
+    ).mockImplementation(() => {
+      throw new Error('Redis connection lost');
+    });
+
+    const res = await authed(request(app).get('/api/admin/ban-store/status'));
+    const body = JSON.stringify(res.body);
+    // Must surface the message but not expose internals
+    expect(res.body.error.message).toBe('Redis connection lost');
+    expect(body).not.toMatch(/node_modules/);
+    expect(body).not.toMatch(/at Object\./);
+  });
+
+  it('returns 200 with available:false when getHybridBanStoreStatus is not a function (graceful fallback)', async () => {
+    // The route has a typeof guard: if not a function it falls back gracefully.
+    vi.spyOn(
+      await import('../../src/redis/banStore.js'),
+      'getHybridBanStoreStatus',
+    ).mockReturnValue(undefined as any);
+
+    // When the mock returns undefined, the route's typeof check treats it as
+    // not-a-function (the real function always returns an object). In practice
+    // the route guards this with `typeof getHybridBanStoreStatus === 'function'`.
+    // We test that a non-throwing, non-function result doesn't crash the handler.
+    // The route falls back to { available: false, reason: '...' }.
+    const res = await authed(request(app).get('/api/admin/ban-store/status'));
+    // Should not crash (not 500)
+    expect(res.status).not.toBe(500);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 4. Response envelope shape
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('GET /api/admin/ban-store/status — response envelope shape', () => {
+  it('wraps success in { success: true, data: { banStore }, meta: { timestamp } }', async () => {
+    const res = await authed(request(app).get('/api/admin/ban-store/status'));
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({
+      success: true,
+      data: { banStore: expect.any(Object) },
+      meta: { timestamp: expect.any(String) },
+    });
+    expect(new Date(res.body.meta.timestamp).getTime()).toBeGreaterThan(0);
+  });
+
+  it('data.banStore always contains available and usingFallback fields', async () => {
+    const res = await authed(request(app).get('/api/admin/ban-store/status'));
+    expect(typeof res.body.data.banStore.available).toBe('boolean');
+    expect(typeof res.body.data.banStore.usingFallback).toBe('boolean');
+  });
+
+  it('error envelope uses { success: false, error: { code, message } }', async () => {
+    vi.spyOn(
+      await import('../../src/redis/banStore.js'),
+      'getHybridBanStoreStatus',
+    ).mockImplementation(() => { throw new Error('boom'); });
+
+    const res = await authed(request(app).get('/api/admin/ban-store/status'));
+    expect(res.body).toMatchObject({
+      success: false,
+      error: {
+        code: 'SERVICE_UNAVAILABLE',
+        message: expect.any(String),
+      },
+    });
+  });
+});

--- a/tests/routes/admin.wsDisconnect.test.ts
+++ b/tests/routes/admin.wsDisconnect.test.ts
@@ -1,0 +1,382 @@
+/**
+ * tests/routes/admin.wsDisconnect.test.ts
+ *
+ * Hardening suite for POST /api/admin/ws/disconnect.
+ *
+ * Coverage
+ * --------
+ *
+ * Auth gate
+ *   • Missing Authorization header          → 401
+ *   • Wrong Bearer token                    → 403
+ *   • ADMIN_API_KEY unset                   → 503
+ *   • Valid static key                      → passes
+ *   • JWT with role=admin                   → passes
+ *   • JWT with role=operator                → 403 (insufficient privilege)
+ *
+ * Input validation
+ *   • stream_id field missing entirely      → 400
+ *   • stream_id is null                     → 400
+ *   • stream_id is a number                 → 400
+ *   • stream_id is a boolean                → 400
+ *   • stream_id is an empty string ""       → 400
+ *   • stream_id is whitespace only ("  ")   → 400
+ *   • Validation errors use VALIDATION_ERROR code
+ *
+ * Hub not initialised
+ *   • When getStreamHub returns null        → 503 with SERVICE_UNAVAILABLE
+ *
+ * Audit persistence failure
+ *   • When recordAuditEventToDb rejects     → 503 with PERSISTENCE_ERROR
+ *   • disconnectedCount is still present in 503 error details
+ *
+ * Happy path
+ *   • Returns 200 with success envelope containing stream_id, disconnectedCount, message
+ *   • disconnectedCount matches the number of sockets closed by hub
+ *   • Works when hub has no subscribers for the given stream_id (disconnectedCount: 0)
+ *   • Emits ADMIN_WS_DISCONNECT audit entry via recordAuditEventToDb
+ *
+ * Response envelope
+ *   • Success uses { success: true, data, meta }
+ *   • Errors use { success: false, error: { code, message } }
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import request from 'supertest';
+import { app } from '../../src/app.js';
+import { _resetForTest } from '../../src/state/adminState.js';
+import { _resetAuditLog } from '../../src/lib/auditLog.js';
+import { initializeConfig } from '../../src/config/env.js';
+import { generateToken } from '../../src/lib/auth.js';
+
+// ── Constants ─────────────────────────────────────────────────────────────────
+
+const ADMIN_KEY = 'test-admin-key-for-ws-disconnect';
+const STREAM_ID = 'stream-abc-123';
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function authed(req: request.Test): request.Test {
+  return req.set('Authorization', `Bearer ${ADMIN_KEY}`);
+}
+
+function postDisconnect(body: Record<string, unknown>): request.Test {
+  return authed(request(app).post('/api/admin/ws/disconnect').send(body));
+}
+
+// ── Setup / teardown ──────────────────────────────────────────────────────────
+
+let prevAdminKey: string | undefined;
+let prevJwtSecret: string | undefined;
+
+beforeEach(() => {
+  prevAdminKey = process.env.ADMIN_API_KEY;
+  prevJwtSecret = process.env.JWT_SECRET;
+
+  process.env.ADMIN_API_KEY = ADMIN_KEY;
+  process.env.JWT_SECRET = 'test-jwt-secret-for-ws-disconnect';
+
+  _resetForTest();
+  _resetAuditLog();
+  initializeConfig();
+  vi.clearAllMocks();
+});
+
+afterEach(() => {
+  if (prevAdminKey === undefined) delete process.env.ADMIN_API_KEY;
+  else process.env.ADMIN_API_KEY = prevAdminKey;
+
+  if (prevJwtSecret === undefined) delete process.env.JWT_SECRET;
+  else process.env.JWT_SECRET = prevJwtSecret;
+
+  vi.restoreAllMocks();
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 1. Auth gate
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('POST /api/admin/ws/disconnect — auth gate', () => {
+  it('returns 401 when Authorization header is absent', async () => {
+    const res = await request(app)
+      .post('/api/admin/ws/disconnect')
+      .send({ stream_id: STREAM_ID });
+    expect(res.status).toBe(401);
+    expect(res.body).toHaveProperty('error');
+  });
+
+  it('returns 403 when wrong Bearer token is supplied', async () => {
+    const res = await request(app)
+      .post('/api/admin/ws/disconnect')
+      .set('Authorization', 'Bearer wrong-key')
+      .send({ stream_id: STREAM_ID });
+    expect(res.status).toBe(403);
+    expect(res.body).toHaveProperty('error');
+  });
+
+  it('returns 503 when ADMIN_API_KEY is unset (fail-closed)', async () => {
+    delete process.env.ADMIN_API_KEY;
+    const res = await request(app)
+      .post('/api/admin/ws/disconnect')
+      .set('Authorization', `Bearer ${ADMIN_KEY}`)
+      .send({ stream_id: STREAM_ID });
+    expect(res.status).toBe(503);
+    expect(res.body.error).toMatch(/not configured/i);
+  });
+
+  it('passes with correct static key', async () => {
+    // Hub not initialised → 503 SERVICE_UNAVAILABLE (not an auth error)
+    const res = await postDisconnect({ stream_id: STREAM_ID });
+    expect(res.status).not.toBe(401);
+    expect(res.status).not.toBe(403);
+  });
+
+  it('passes with JWT role=admin', async () => {
+    const token = generateToken({ address: 'addr-admin', role: 'admin' });
+    const res = await request(app)
+      .post('/api/admin/ws/disconnect')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ stream_id: STREAM_ID });
+    // Should reach the endpoint (not blocked by auth). Hub may or may not be
+    // initialised — but either 200 or 503 means auth passed.
+    expect([200, 503]).toContain(res.status);
+  });
+
+  it('returns 403 with JWT role=operator (insufficient privilege)', async () => {
+    const token = generateToken({ address: 'addr-operator', role: 'operator' });
+    const res = await request(app)
+      .post('/api/admin/ws/disconnect')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ stream_id: STREAM_ID });
+    expect(res.status).toBe(403);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 2. Input validation
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('POST /api/admin/ws/disconnect — input validation', () => {
+  it('returns 400 when stream_id is missing from body', async () => {
+    const res = await postDisconnect({});
+    expect(res.status).toBe(400);
+    expect(res.body.success).toBe(false);
+    expect(res.body.error.code).toBe('VALIDATION_ERROR');
+    expect(res.body.error.message).toMatch(/stream_id/i);
+  });
+
+  it('returns 400 when stream_id is null', async () => {
+    const res = await postDisconnect({ stream_id: null });
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe('VALIDATION_ERROR');
+  });
+
+  it('returns 400 when stream_id is a number', async () => {
+    const res = await postDisconnect({ stream_id: 42 });
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe('VALIDATION_ERROR');
+  });
+
+  it('returns 400 when stream_id is a boolean', async () => {
+    const res = await postDisconnect({ stream_id: true });
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe('VALIDATION_ERROR');
+  });
+
+  it('returns 400 when stream_id is an empty string', async () => {
+    const res = await postDisconnect({ stream_id: '' });
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe('VALIDATION_ERROR');
+    expect(res.body.error.message).toMatch(/stream_id/i);
+  });
+
+  it('returns 400 when stream_id is whitespace only', async () => {
+    const res = await postDisconnect({ stream_id: '   ' });
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe('VALIDATION_ERROR');
+  });
+
+  it('returns 400 when stream_id is an object', async () => {
+    const res = await postDisconnect({ stream_id: { id: 'stream-1' } });
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe('VALIDATION_ERROR');
+  });
+
+  it('validation error response uses success envelope format', async () => {
+    const res = await postDisconnect({});
+    expect(res.body).toMatchObject({
+      success: false,
+      error: {
+        code: 'VALIDATION_ERROR',
+        message: expect.any(String),
+      },
+    });
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 3. Hub not initialised → 503
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('POST /api/admin/ws/disconnect — hub not initialised', () => {
+  it('returns 503 with SERVICE_UNAVAILABLE when getStreamHub returns null', async () => {
+    // In the test environment the StreamHub singleton is not created,
+    // so getStreamHub() already returns null.
+    const res = await postDisconnect({ stream_id: STREAM_ID });
+    expect(res.status).toBe(503);
+    expect(res.body.success).toBe(false);
+    expect(res.body.error.code).toBe('SERVICE_UNAVAILABLE');
+    expect(res.body.error.message).toMatch(/hub.*not initialized|not initialized.*hub/i);
+  });
+
+  it('503 response does not leak stack traces or internal paths', async () => {
+    const res = await postDisconnect({ stream_id: STREAM_ID });
+    const body = JSON.stringify(res.body);
+    expect(body).not.toMatch(/Error:/);
+    expect(body).not.toMatch(/at Object\./);
+    expect(body).not.toMatch(/node_modules/);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 4. Happy path — hub mock present
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('POST /api/admin/ws/disconnect — happy path (mocked hub)', () => {
+  beforeEach(async () => {
+    // Provide a mock hub that reports 3 disconnected sockets.
+    const hubModule = await import('../../src/ws/hub.js');
+    vi.spyOn(hubModule, 'getStreamHub').mockReturnValue({
+      disconnectByStreamId: vi.fn().mockReturnValue(3),
+    } as any);
+
+    // Stub out the DB audit write so tests don't need a live Postgres pool.
+    const auditModule = await import('../../src/lib/auditLog.js');
+    vi.spyOn(auditModule, 'recordAuditEventToDb').mockResolvedValue({
+      seq: 1,
+      timestamp: new Date().toISOString(),
+      action: 'ADMIN_WS_DISCONNECT',
+      resourceType: 'stream',
+      resourceId: STREAM_ID,
+    });
+  });
+
+  it('returns 200 with success envelope on valid request', async () => {
+    const res = await postDisconnect({ stream_id: STREAM_ID });
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(res.body.data).toHaveProperty('message');
+    expect(res.body.data).toHaveProperty('stream_id', STREAM_ID);
+    expect(res.body.data).toHaveProperty('disconnectedCount', 3);
+  });
+
+  it('trims leading/trailing whitespace from stream_id before processing', async () => {
+    const res = await postDisconnect({ stream_id: `  ${STREAM_ID}  ` });
+    expect(res.status).toBe(200);
+    expect(res.body.data.stream_id).toBe(STREAM_ID);
+  });
+
+  it('response includes meta.timestamp', async () => {
+    const res = await postDisconnect({ stream_id: STREAM_ID });
+    expect(res.body.meta).toHaveProperty('timestamp');
+    expect(typeof res.body.meta.timestamp).toBe('string');
+    expect(new Date(res.body.meta.timestamp).getTime()).toBeGreaterThan(0);
+  });
+
+  it('calls disconnectByStreamId with the exact (trimmed) stream_id', async () => {
+    const hubModule = await import('../../src/ws/hub.js');
+    const mockHub = hubModule.getStreamHub()!;
+
+    await postDisconnect({ stream_id: `  ${STREAM_ID}  ` });
+
+    expect((mockHub as any).disconnectByStreamId).toHaveBeenCalledWith(STREAM_ID);
+  });
+
+  it('works when hub has no subscribers (disconnectedCount: 0)', async () => {
+    const hubModule = await import('../../src/ws/hub.js');
+    vi.spyOn(hubModule, 'getStreamHub').mockReturnValue({
+      disconnectByStreamId: vi.fn().mockReturnValue(0),
+    } as any);
+
+    const res = await postDisconnect({ stream_id: STREAM_ID });
+    expect(res.status).toBe(200);
+    expect(res.body.data.disconnectedCount).toBe(0);
+  });
+
+  it('calls recordAuditEventToDb with ADMIN_WS_DISCONNECT and correct payload', async () => {
+    const auditModule = await import('../../src/lib/auditLog.js');
+
+    await postDisconnect({ stream_id: STREAM_ID });
+
+    expect(auditModule.recordAuditEventToDb).toHaveBeenCalledWith(
+      'ADMIN_WS_DISCONNECT',
+      'stream',
+      STREAM_ID,
+      expect.any(String), // correlationId
+      expect.objectContaining({
+        disconnectedCount: 3,
+        closeCode: 4000,
+        closeReason: 'admin-forced-disconnect',
+      }),
+    );
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 5. Audit persistence failure → 503
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('POST /api/admin/ws/disconnect — audit persistence failure', () => {
+  beforeEach(async () => {
+    const hubModule = await import('../../src/ws/hub.js');
+    vi.spyOn(hubModule, 'getStreamHub').mockReturnValue({
+      disconnectByStreamId: vi.fn().mockReturnValue(2),
+    } as any);
+
+    const auditModule = await import('../../src/lib/auditLog.js');
+    vi.spyOn(auditModule, 'recordAuditEventToDb').mockRejectedValue(
+      new Error('DB write failed'),
+    );
+  });
+
+  it('returns 503 with PERSISTENCE_ERROR when audit write fails', async () => {
+    const res = await postDisconnect({ stream_id: STREAM_ID });
+    expect(res.status).toBe(503);
+    expect(res.body.success).toBe(false);
+    expect(res.body.error.code).toBe('PERSISTENCE_ERROR');
+  });
+
+  it('includes disconnectedCount in the 503 error details', async () => {
+    const res = await postDisconnect({ stream_id: STREAM_ID });
+    expect(res.status).toBe(503);
+    // The route attaches disconnectedCount to details even on persistence failure
+    expect(res.body.error.details).toMatchObject({ disconnectedCount: 2 });
+  });
+
+  it('503 error message mentions audit persistence', async () => {
+    const res = await postDisconnect({ stream_id: STREAM_ID });
+    expect(res.body.error.message).toMatch(/audit|persist/i);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 6. Response envelope shape
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('POST /api/admin/ws/disconnect — response envelope shape', () => {
+  it('400 validation error uses { success: false, error: { code, message } }', async () => {
+    const res = await postDisconnect({ stream_id: null });
+    expect(res.body).toMatchObject({
+      success: false,
+      error: { code: 'VALIDATION_ERROR', message: expect.any(String) },
+    });
+  });
+
+  it('503 hub-unavailable uses { success: false, error: { code, message } }', async () => {
+    const res = await postDisconnect({ stream_id: STREAM_ID });
+    // Hub not initialised in this describe scope
+    expect(res.body).toMatchObject({
+      success: false,
+      error: { code: 'SERVICE_UNAVAILABLE', message: expect.any(String) },
+    });
+  });
+});


### PR DESCRIPTION
closes #1075
Add three dedicated test suites covering previously untested authorization and guard behavior across admin endpoints.

tests/routes/admin.auth.test.ts
- requireAdminAuth: ADMIN_API_KEY unset returns 503 fail-closed
- Header format errors: missing, wrong scheme, oversized DoS guard
- Static key: correct passes, wrong/shorter/longer all return 403
- JWT fallback: admin and data-protection-officer pass; operator, viewer, expired, invalid, and wrong-secret tokens return 403
- Public endpoint GET /status/read-only bypasses auth guard entirely
- PUT /pause persistence error returns 503; reindex conflict returns 409
- Audit trail verified via vi.spyOn worker-mock-safe approach
- Response shape contract: 401/403/503 use error shape, 200 uses envelope
- Guard consistency matrix: every protected route checked for 401 and 403

tests/routes/admin.banStore.test.ts
- Auth gate: 401 no header, 403 wrong token, 503 key unset
- JWT role=admin passes; role=operator returns 403
- Happy path: store unavailable, healthy, and in fallback mode
- getHybridBanStoreStatus throws returns 503 SERVICE_UNAVAILABLE
- Error response does not leak stack traces or internal paths
- Success and error envelope shape contract

tests/routes/admin.wsDisconnect.test.ts
- Auth gate: 401, 403, 503 and JWT role variants
- Input validation: missing, null, number, boolean, empty string, whitespace-only, and object stream_id all return 400 VALIDATION_ERROR
- Hub not initialised returns 503 SERVICE_UNAVAILABLE
- Audit persistence failure returns 503 PERSISTENCE_ERROR with disconnectedCount preserved in error details
- Happy path: disconnectedCount, whitespace trim, audit call verified
- Response envelope shape for all error and success paths