### PR TITLE
fix(auth): restore API key repository-boundary lookup for scope enforcement

### DIFF
--- a/src/lib/apiKey.ts
+++ b/src/lib/apiKey.ts
@@ -219,11 +219,22 @@ export async function listApiKeys(): Promise<ApiKeyRecord[]> {
 }
 
 /**
- * Validates a raw API key.
+ * Resolves a raw API key to its full active {@link ApiKeyRecord} (including
+ * scopes and key id), or `undefined` if the key is unknown, malformed, or
+ * inactive.
  *
- * Resolves candidate active rows by the indexed key prefix (O(log n)) and then
- * performs a constant-time comparison against each candidate's salted/peppered
- * hash. Returns `true` on the first match.
+ * This is the single repository-boundary lookup: it resolves candidate active
+ * rows by the indexed key prefix (O(log n) — see
+ * {@link apiKeyRepository.findActiveByPrefix}, which filters `active = true`
+ * at the SQL level so revoked keys never surface as candidates) and then
+ * performs a constant-time comparison against every candidate's
+ * salted/peppered hash, never early-returning, so timing does not reveal
+ * which row (if any) matched within a colliding prefix bucket.
+ *
+ * Both {@link isValidApiKey} (boolean check) and `authenticateApiKey`
+ * (needs the full record to attach `keyScopes`/`keyId` to the request for
+ * {@link requireScope} to enforce) are built on this function so there is
+ * exactly one code path that ever touches key material.
  *
  * Latency is recorded in the `fluxora_auth_apikey_lookup_duration_seconds`
  * histogram, labelled only by `outcome` (`success` | `failure`). No key id,
@@ -233,27 +244,47 @@ export async function listApiKeys(): Promise<ApiKeyRecord[]> {
  *
  * @param rawKey - The raw key presented by the caller.
  */
-export async function isValidApiKey(rawKey: string): Promise<boolean> {
+export async function findRecordByRawKey(rawKey: string): Promise<ApiKeyRecord | undefined> {
   const endTimer = authApiKeyLookupDurationSeconds.startTimer();
 
   if (!rawKey || typeof rawKey !== 'string') {
     endTimer({ outcome: 'failure' });
-    return false;
+    return undefined;
   }
 
   const prefix = rawKey.slice(0, PREFIX_LENGTH);
   const candidates = await apiKeyRepository.findActiveByPrefix(prefix);
 
-  let matched = false;
+  let matchedRecord: ApiKeyRecord | undefined;
   for (const candidate of candidates) {
     // Compare every candidate (do not early-return) so timing does not reveal
     // which row, if any, matched within a colliding prefix bucket.
     if (hashesMatch(hashKey(rawKey, candidate.salt), candidate.keyHash)) {
-      matched = true;
+      matchedRecord = candidate;
     }
   }
-  endTimer({ outcome: matched ? 'success' : 'failure' });
-  return matched;
+  endTimer({ outcome: matchedRecord ? 'success' : 'failure' });
+  return matchedRecord;
+}
+
+/**
+ * @deprecated Alias for {@link findRecordByRawKey}, kept so existing callers
+ * and tests written against the older name keep working unchanged.
+ */
+export const getApiKeyRecord = findRecordByRawKey;
+
+/**
+ * Validates a raw API key.
+ *
+ * Thin wrapper over {@link findRecordByRawKey} — a key is valid iff a
+ * matching active record is found. Delegating here (rather than duplicating
+ * the prefix-lookup/hash-comparison loop) guarantees `isValidApiKey` and the
+ * record-returning lookup used by the auth middleware can never drift apart.
+ *
+ * @param rawKey - The raw key presented by the caller.
+ */
+export async function isValidApiKey(rawKey: string): Promise<boolean> {
+  return (await findRecordByRawKey(rawKey)) !== undefined;
 }
 
 /**

--- a/src/middleware/auth.ts
+++ b/src/middleware/auth.ts
@@ -23,7 +23,7 @@ export async function authenticateApiKey(req: Request, res: Response, next: Next
   }
 
   try {
-    const record = await getApiKeyRecord(rawKey);
+    const record = await findRecordByRawKey(rawKey);
     
     if (!record) {
       warn('API key authentication failed — key not found', { requestId });

--- a/tests/routes/api-key-scopes.test.ts
+++ b/tests/routes/api-key-scopes.test.ts
@@ -11,15 +11,17 @@
  */
 
 import request from 'supertest';
-import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { describe, it, expect, beforeAll, beforeEach, afterEach, vi } from 'vitest';
+import { initializeConfig } from '../../src/config/env.js';
+import { generateToken } from '../../src/lib/auth.js';
 import type { ApiKeyRecord } from '../../src/db/types.js';
 
-vi.mock('../../src/config/env.js', () => ({
-  getConfig: () => ({
-    apiKeyPepper: 'test-pepper-32-chars-long-secret-key-pepper!',
-  }),
-}));
-
+// Deliberately does NOT mock '../../src/config/env.js': app.ts's createApp()
+// needs the real loadConfig() (not just getConfig()) to build a working
+// Express app, and tests/setup.ts already seeds API_KEY_PEPPER and friends
+// for every test process. A partial mock here previously replaced the whole
+// module and broke `loadConfig`, which silently took this entire suite
+// offline (see issue #1063).
 const inMemoryKeys = new Map<string, ApiKeyRecord>();
 
 vi.mock('../../src/db/repositories/apiKeyRepository.js', () => ({
@@ -61,6 +63,14 @@ import {
 } from '../../src/lib/apiKey.js';
 
 describe('API Key Scopes & getApiKeyRecord', () => {
+  beforeAll(() => {
+    // createApiKey()/isValidApiKey() read the API_KEY_PEPPER via getConfig(),
+    // which requires the singleton config to have been initialized once per
+    // test file (tests/setup.ts seeds the env var, but does not itself call
+    // initializeConfig()).
+    initializeConfig();
+  });
+
   beforeEach(() => {
     inMemoryKeys.clear();
   });
@@ -157,12 +167,16 @@ describe('API Key Scopes & getApiKeyRecord', () => {
       expect(response.body.error?.message).toContain('scopes');
     });
 
-    it('should allow request without API key (anonymous)', async () => {
+    it('should deny a fully anonymous request (no API key, no JWT)', async () => {
+      // requireScope() rejects before any controller logic runs when neither
+      // an API key (`req.keyId`) nor a JWT (`req.user`) principal is present
+      // — scoped routes never fall open to anonymous callers.
       const response = await request(app)
         .get('/api/streams')
         .query({ limit: 10 });
 
-      expect(response.status).not.toBe(401);
+      expect(response.status).toBe(401);
+      expect(response.body.error?.code).toBe('UNAUTHORIZED');
     });
 
     it('should deny request with invalid API key', async () => {
@@ -178,10 +192,17 @@ describe('API Key Scopes & getApiKeyRecord', () => {
 
   describe('POST /api/streams with API key', () => {
     it('should deny request with API key missing streams:write scope', async () => {
+      // POST is gated by both `requireAuth` (a JWT principal) and
+      // `requireScope('streams:write')`. Attach an operator JWT so the
+      // request clears `requireAuth` and actually reaches the scope check —
+      // requireScope() prefers API-key scopes over JWT permissions once a
+      // key is present, so the read-only key is what triggers the 403 here.
+      const jwt = generateToken({ address: 'GOPERATOR000000000000000000000000000000000000', role: 'operator' });
       const apiKey = await createApiKey('read-only-key', ['streams:read']);
-      
+
       const response = await request(app)
         .post('/api/streams')
+        .set('Authorization', `Bearer ${jwt}`)
         .set('X-API-Key', apiKey.key)
         .set('Idempotency-Key', 'test-key-1')
         .send({
@@ -220,10 +241,14 @@ describe('API Key Scopes & getApiKeyRecord', () => {
 
   describe('DELETE /api/streams/:id with API key', () => {
     it('should deny request with API key missing streams:write scope', async () => {
+      // Same reasoning as the POST case above: DELETE also requires
+      // `requireAuth`, so a JWT is needed to reach the scope check at all.
+      const jwt = generateToken({ address: 'GOPERATOR000000000000000000000000000000000000', role: 'operator' });
       const apiKey = await createApiKey('read-only-key', ['streams:read']);
-      
+
       const response = await request(app)
         .delete('/api/streams/stream-123')
+        .set('Authorization', `Bearer ${jwt}`)
         .set('X-API-Key', apiKey.key);
 
       expect(response.status).toBe(403);

--- a/tests/unit/apiKey.test.ts
+++ b/tests/unit/apiKey.test.ts
@@ -51,6 +51,7 @@ import {
   revokeApiKey,
   listApiKeys,
   getApiKeyRecord,
+  findRecordByRawKey,
   isValidApiKey,
   getApiKeyFromRequest,
   DEFAULT_SCOPES,
@@ -70,6 +71,32 @@ describe('src/lib/apiKey.ts unit tests', () => {
       expect((apiKeyModule as any).getApiKeyScopes).toBeUndefined();
       expect((apiKeyModule as any).hasScope).toBeUndefined();
       expect((apiKeyModule as any)._resetApiKeyStoreForTest).toBeUndefined();
+    });
+  });
+
+  // Regression coverage for issue #1063: `src/middleware/auth.ts` imports
+  // `findRecordByRawKey`, while other callers/tests still use the older
+  // `getApiKeyRecord` name. Both names must resolve to the exact same
+  // repository-boundary lookup so the two call sites can never drift apart
+  // again the way they did when this broke (import said one name, the call
+  // site referenced the other, and neither was actually exported).
+  describe('findRecordByRawKey / getApiKeyRecord aliasing (issue #1063)', () => {
+    it('exports findRecordByRawKey as a function', () => {
+      expect(typeof findRecordByRawKey).toBe('function');
+    });
+
+    it('getApiKeyRecord is the exact same function reference as findRecordByRawKey', () => {
+      expect(getApiKeyRecord).toBe(findRecordByRawKey);
+    });
+
+    it('both names resolve an active key to an identical record', async () => {
+      const created = await createApiKey('alias-check', ['streams:read']);
+
+      const viaOldName = await getApiKeyRecord(created.key);
+      const viaNewName = await findRecordByRawKey(created.key);
+
+      expect(viaOldName).toEqual(viaNewName);
+      expect(viaOldName?.id).toBe(created.id);
     });
   });
 


### PR DESCRIPTION
Closes #1063.

## Root cause

`authenticateApiKey` (`src/middleware/auth.ts`) imported `findRecordByRawKey` from `src/lib/apiKey.ts` but called a differently-named `getApiKeyRecord`, which no longer existed anywhere in `apiKey.ts`. Two independent PRs had each implemented this same repository-boundary lookup under a different name (#836's `findRecordByRawKey`, and an unrelated async-migration refactor's `getApiKeyRecord`); a later merge/edit ended up combining the *import* from one branch with the *call site* from the other, and dropped both real implementations from `apiKey.ts` entirely.

Net effect on `main` today: every request carrying an `X-API-Key` header throws a `ReferenceError` inside `authenticateApiKey`'s try/catch, which is swallowed and turned into a generic `401 Authentication failed`. `requireScope` never runs, so API-key scope enforcement is currently dead — this reproduces with the repo's own existing tests (`tests/unit/apiKey.test.ts`, `tests/unit/middleware/auth.test.ts`), which fail on `main` with `TypeError: getApiKeyRecord is not a function` / `expected "spy" to be called at least once`.

Separately, `tests/routes/api-key-scopes.test.ts` — the suite most directly about this feature — was silently never executing: its `vi.mock('../../src/config/env.js', ...)` only stubbed `getConfig`, not `loadConfig`, which `app.ts`'s `createApp()` needs to build the app at all. So this regression had zero test signal telling anyone about it.

## Fix

- `src/lib/apiKey.ts`: reinstate `findRecordByRawKey` as the single repository-boundary lookup (indexed prefix candidates + constant-time hash comparison against every candidate, active-only via `apiKeyRepository.findActiveByPrefix`). Export `getApiKeyRecord` as an alias (`export const getApiKeyRecord = findRecordByRawKey;`) so existing callers/tests written against the older name keep working unchanged — both names now provably can't drift apart again. `isValidApiKey` is rebuilt as a thin wrapper around the same function instead of duplicating the lookup, preserving its existing `fluxora_auth_apikey_lookup_duration_seconds` metric contract (single observation per call, `outcome`-only label).
- `src/middleware/auth.ts`: fix the call site to use the already-imported `findRecordByRawKey`.
- `tests/routes/api-key-scopes.test.ts`: removed the mock that broke `loadConfig` (unnecessary — `tests/setup.ts` already seeds `API_KEY_PEPPER` for every test process), added the `initializeConfig()` call other route-integration tests use. Corrected three assertions that no longer matched the actual route wiring once the suite could run at all: `POST`/`DELETE /api/streams` sit behind both `requireAuth` (needs a JWT) and `requireScope`, so a bare API key can't reach the scope check on those routes without a JWT too; a fully anonymous request is always `401` from `requireScope` itself (no route allows anonymous access). All 21 tests in this file pass now.
- `tests/unit/apiKey.test.ts`: added regression coverage asserting `getApiKeyRecord` and `findRecordByRawKey` are the exact same function reference, so this can't silently split into two implementations again.

## Backward compatibility

No behavior change from what the codebase's own tests already document as intended — this restores the working state that PR #836 established, using the newer `findRecordByRawKey` name as canonical while keeping `getApiKeyRecord` as a permanent alias for existing call sites.

## Test plan

- [x] `vitest run tests/unit/apiKey.test.ts tests/routes/api-key-scopes.test.ts tests/unit/middleware/auth.test.ts tests/db/apiKeyRepository.test.ts` — all green
- [x] `tsc --noEmit` — no new errors (the two pre-existing errors in `src/webhooks/dispatcher.ts` and `tests/integration/broadcast-auth.test.ts` are untouched by this change and present on `main`)
- [x] `eslint` on all four changed files — no new errors/warnings (the errors reported in `src/middleware/auth.ts` are all on lines untouched by this diff)
- [x] Confirmed the bug reproduces on unmodified `main` (git-bisected to a merge that combined two independent fixes for the same problem under different names) and that the previously-failing tests now pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)