### PR TITLE
fix(csrf): align requestId resolution with auth middleware pattern (#…

### DIFF
--- a/src/middleware/csrf.ts
+++ b/src/middleware/csrf.ts
@@ -177,7 +177,7 @@ export function csrfMiddleware(req: Request, res: Response, next: NextFunction):
     return next();
   }
 
-  const requestId = req.correlationId ?? req.id;
+  const requestId = req.id ?? req.correlationId;
 
   // 3. Extract cookie token and header token
   const cookies = parseCookies(req.headers.cookie);


### PR DESCRIPTION
CLOSES #1070 
…1070)

Change req.correlationId ?? req.id to req.id ?? req.correlationId in csrfMiddleware to match the pattern established in #1157 for auth middleware.