### PR TITLE
fix(csrf): harden CSRF enforcement with security logging and whitespace handling (#1047)

### DIFF
--- a/src/middleware/csrf.ts
+++ b/src/middleware/csrf.ts
@@ -3,6 +3,7 @@ import { createHmac, timingSafeEqual, randomBytes } from 'node:crypto';
 import { errorResponse } from '../utils/response.js';
 import { ApiErrorCode } from './errorHandler.js';
 import { getApiKeyFromRequest } from '../lib/apiKey.js';
+import { warn } from '../utils/logger.js';
 
 /** Cookie name used to deliver the double-submit CSRF token to browser clients. */
 export const CSRF_COOKIE_NAME = 'fluxora_csrf';
@@ -187,8 +188,15 @@ export function csrfMiddleware(req: Request, res: Response, next: NextFunction):
   const headerTokenRaw = req.headers[CSRF_HEADER_NAME] ?? req.headers['x-csrf-token'];
   const headerToken = Array.isArray(headerTokenRaw) ? headerTokenRaw[0] : headerTokenRaw;
 
-  // 4. Validate presence of both tokens
-  if (!cookieToken || !headerToken) {
+  // 4. Trim whitespace from extracted token values to prevent whitespace-only
+  //    tokens from passing presence checks (a whitespace-only string is truthy
+  //    but is not a valid token).
+  const cookieTokenTrimmed = cookieToken?.trim();
+  const headerTokenTrimmed = headerToken?.trim();
+
+  // 5. Validate presence of both tokens (after trimming)
+  if (!cookieTokenTrimmed || !headerTokenTrimmed) {
+    warn('CSRF token missing', { requestId, method: req.method, path: req.path, ip: req.ip });
     res.status(403).json(
       errorResponse(
         ApiErrorCode.FORBIDDEN,
@@ -200,8 +208,9 @@ export function csrfMiddleware(req: Request, res: Response, next: NextFunction):
     return;
   }
 
-  // 5. Compare tokens in constant time
-  if (!safeCompareCsrfTokens(cookieToken, headerToken)) {
+  // 6. Compare tokens in constant time
+  if (!safeCompareCsrfTokens(cookieTokenTrimmed, headerTokenTrimmed)) {
+    warn('CSRF token mismatch', { requestId, method: req.method, path: req.path, ip: req.ip });
     res.status(403).json(
       errorResponse(
         ApiErrorCode.FORBIDDEN,

--- a/tests/middleware/csrf.test.ts
+++ b/tests/middleware/csrf.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
 import express, { Request, Response } from 'express';
 import request from 'supertest';
 import {
@@ -12,6 +12,14 @@ import {
   CSRF_HEADER_NAME,
 } from '../../src/middleware/csrf.js';
 import { errorHandler } from '../../src/middleware/errorHandler.js';
+
+// Spy on the warn logger — all modules import from src/lib/logger.ts, which
+// is re-exported through src/utils/logger.ts.
+vi.mock('../../src/utils/logger.js', async () => {
+  const actual = await vi.importActual('../../src/utils/logger.js');
+  return { ...(actual as object), warn: vi.fn(), error: vi.fn() };
+});
+const { warn: warnSpy } = await import('../../src/utils/logger.js');
 
 // ---------------------------------------------------------------------------
 // Helper — build a minimal Express app wired with csrfMiddleware
@@ -569,6 +577,28 @@ describe('csrfMiddleware integration — token format edge cases', () => {
     expect(res.status).toBe(403);
     expect(res.body.error.message).toContain('CSRF token missing');
   });
+
+  it('blocks when fluxora_csrf cookie value is whitespace-only', async () => {
+    const headerToken = generateCsrfToken();
+    const res = await request(app)
+      .post('/api/streams')
+      .set('Cookie', `session=abc; ${CSRF_COOKIE_NAME}=   `)
+      .set('X-CSRF-Token', headerToken)
+      .send({});
+    expect(res.status).toBe(403);
+    expect(res.body.error.message).toContain('CSRF token missing');
+  });
+
+  it('blocks when X-CSRF-Token header value is whitespace-only', async () => {
+    const token = generateCsrfToken();
+    const res = await request(app)
+      .post('/api/streams')
+      .set('Cookie', `session=abc; ${CSRF_COOKIE_NAME}=${token}`)
+      .set('X-CSRF-Token', '   ')
+      .send({});
+    expect(res.status).toBe(403);
+    expect(res.body.error.message).toContain('CSRF token missing');
+  });
 });
 
 describe('csrfMiddleware integration — correlationId in error responses', () => {
@@ -639,6 +669,129 @@ describe('csrfMiddleware integration — correlationId in error responses', () =
     expect(res.status).toBe(403);
     // requestId should be undefined / not present when no id was assigned
     expect(res.body.error.requestId).toBeUndefined();
+  });
+});
+
+describe('csrfMiddleware integration — security logging on violations', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('logs a warning when CSRF tokens are missing (cookie session, no tokens)', async () => {
+    const app = buildApp();
+    const res = await request(app)
+      .post('/api/streams')
+      .set('Cookie', 'session=abc')
+      .send({});
+    expect(res.status).toBe(403);
+    expect(warnSpy).toHaveBeenCalled();
+    const callArgs = (warnSpy as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(callArgs[0]).toBe('CSRF token missing');
+    expect(callArgs[1]).toMatchObject({ method: 'POST', path: '/api/streams' });
+  });
+
+  it('logs a warning when CSRF tokens mismatch', async () => {
+    const app = buildApp();
+    const cookieToken = generateCsrfToken();
+    const headerToken = generateCsrfToken();
+    const res = await request(app)
+      .post('/api/streams')
+      .set('Cookie', `session=abc; ${CSRF_COOKIE_NAME}=${cookieToken}`)
+      .set('X-CSRF-Token', headerToken)
+      .send({});
+    expect(res.status).toBe(403);
+    expect(warnSpy).toHaveBeenCalled();
+    const callArgs = (warnSpy as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(callArgs[0]).toBe('CSRF token mismatch');
+    expect(callArgs[1]).toMatchObject({ method: 'POST', path: '/api/streams' });
+  });
+
+  it('does NOT log a warning when CSRF enforcement passes', async () => {
+    const app = buildApp();
+    const token = generateCsrfToken();
+    await request(app)
+      .post('/api/streams')
+      .set('Cookie', `session=abc; ${CSRF_COOKIE_NAME}=${token}`)
+      .set('X-CSRF-Token', token)
+      .send({});
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it('does NOT log a warning when API auth bypasses CSRF (Bearer token)', async () => {
+    const app = buildApp();
+    await request(app)
+      .post('/api/streams')
+      .set('Authorization', 'Bearer valid.jwt')
+      .set('Cookie', 'session=abc')
+      .send({});
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it('does NOT log a warning for safe methods even with cookies', async () => {
+    const app = buildApp();
+    await request(app)
+      .get('/api/streams')
+      .set('Cookie', 'session=abc');
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it('does NOT log a warning when no cookie is present', async () => {
+    const app = buildApp();
+    await request(app)
+      .post('/api/streams')
+      .send({});
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+});
+
+describe('csrfMiddleware integration — requestId edge cases', () => {
+  it('uses req.id over req.correlationId when both are present', async () => {
+    const token = generateCsrfToken();
+    const app = express();
+    app.use(express.json());
+    app.use((req: Request, _res: Response, next) => {
+      (req as any).id = 'hardcoded-req-id';
+      (req as any).correlationId = 'should-not-be-used';
+      next();
+    });
+    app.use(csrfMiddleware);
+    app.post('/api/streams', (_req: Request, res: Response) => res.json({ ok: true }));
+    app.use(errorHandler);
+
+    const res = await request(app)
+      .post('/api/streams')
+      .set('Cookie', `session=abc; ${CSRF_COOKIE_NAME}=${token}`)
+      .set('X-CSRF-Token', generateCsrfToken())
+      .send({});
+
+    expect(res.status).toBe(403);
+    expect(res.body.error.requestId).toBe('hardcoded-req-id');
+  });
+
+  it('includes requestId in 403 body when req.correlationId is set and req.id is absent', async () => {
+    const token = generateCsrfToken();
+    const correlationId = 'csrf-err-corr-001';
+    const app = express();
+    app.use(express.json());
+    app.use((req: Request, _res: Response, next) => {
+      (req as any).correlationId = correlationId;
+      // req.id is deliberately NOT set — verify fallback to correlationId
+      next();
+    });
+    app.use(csrfMiddleware);
+    app.post('/api/streams', (_req: Request, res: Response) => res.json({ ok: true }));
+    app.use(errorHandler);
+
+    const res = await request(app)
+      .post('/api/streams')
+      .set('Cookie', `session=abc; ${CSRF_COOKIE_NAME}=${token}`)
+      .set('X-CSRF-Token', generateCsrfToken())
+      .send({});
+
+    expect(res.status).toBe(403);
+    // requestId resolves to req.id first, falls back to req.correlationId
+    // Since req.id is not set, correlationId is used
+    expect(res.body.error.requestId).toBe(correlationId);
   });
 });
 


### PR DESCRIPTION
## Summary

Closes #1047

This PR hardens the CSRF middleware enforcement path by adding security observability (logging) and closing a whitespace-only token bypass edge case. All existing behavior is preserved — this is purely additive hardening.

## Changes

### `src/middleware/csrf.ts`

1. **Security logging on CSRF violations** — Added `warn()` calls before returning 403 responses for both missing and mismatched CSRF tokens. Each log includes `requestId`, `method`, `path`, and `ip` for security audit trails, matching the pattern used in the auth middleware.

2. **Whitespace trimming for token values** — Both the cookie token and header token are now trimmed via `.trim()` before presence validation. Previously, a whitespace-only header value (e.g., `"   "`) would pass the truthiness check, bypassing CSRF. Now whitespace-only tokens are treated as absent and rejected with a 403.

### `tests/middleware/csrf.test.ts` — 10 new tests

| Test | What it covers |
|------|---------------|
| logs a warning when CSRF tokens are missing | `warn()` called with correct message + metadata |
| logs a warning when CSRF tokens mismatch | `warn()` called on token mismatch |
| does NOT log when CSRF enforcement passes | No false positives on valid CSRF requests |
| does NOT log when API auth bypasses CSRF | Bearer/API-key paths remain silent |
| does NOT log for safe methods | GET/HEAD/OPTIONS don't trigger CSRF logging |
| does NOT log when no cookie is present | Unauthenticated requests skip CSRF entirely |
| blocks when fluxora_csrf cookie value is whitespace-only | Whitespace cookie → 403 |
| blocks when X-CSRF-Token header value is whitespace-only | Whitespace header → 403 |
| uses req.id over req.correlationId when both are present | Precedence order verified in error body |
| includes requestId in 403 body when only req.correlationId is set | Fallback behavior verified |

## Backward Compatibility

- Hex-encoded CSRF tokens (`[0-9a-f]{64}`) never contain whitespace, so `.trim()` is a no-op for all valid tokens.
- The `warn()` logging is additive — no existing response behavior or status codes change.
- Test suite: 75/75 tests pass.

## Verification

```bash
npx vitest run tests/middleware/csrf.test.ts  # 75 passed, 0 failed
```
