### PR TITLE
Stabilize SDK pagination helpers and websocket backpressure metrics

### DIFF
--- a/src/metrics/wsBackpressure.ts
+++ b/src/metrics/wsBackpressure.ts
@@ -145,7 +145,7 @@ export const wsBroadcastBatchFlushLatencySeconds = metric(
  * Helper to record batch flush latency in seconds.
  */
 export function recordWsBroadcastBatchFlushLatency(durationSeconds: number): void {
-  if (durationSeconds >= 0) {
+  if (typeof durationSeconds === 'number' && isFinite(durationSeconds) && durationSeconds >= 0) {
     wsBroadcastBatchFlushLatencySeconds.observe(durationSeconds);
   }
 }
@@ -254,4 +254,8 @@ export function resetWsBackpressureMetrics(): void {
   wsMaxBufferedBytes.reset();
   wsSlowClients.reset();
   wsStreamSubscriberCount.reset();
+  wsBatchFlushTotal.reset();
+  wsBatchEventsCoalescedTotal.reset();
+  wsBatchSizeExceededTotal.reset();
+  wsBroadcastBatchFlushLatencySeconds.reset();
 }

--- a/tests/metrics/wsBackpressure.stabilization.test.ts
+++ b/tests/metrics/wsBackpressure.stabilization.test.ts
@@ -1,0 +1,147 @@
+/**
+ * Stabilization tests for WebSocket backpressure metrics (#1049).
+ *
+ * Locks down edge cases previously implicit: micro-batching counter increments,
+ * hub with partial or absent optional methods, and recordWsBroadcastBatchFlushLatency
+ * edge values.
+ */
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  collectWsBackpressureMetrics,
+  removeWsClientBackpressureGauge,
+  resetWsBackpressureMetrics,
+  wsClientBufferedBytes,
+  wsBatchFlushTotal,
+  wsBatchEventsCoalescedTotal,
+  wsBatchSizeExceededTotal,
+  recordWsBroadcastBatchFlushLatency,
+  wsBroadcastBatchFlushLatencySeconds,
+  DEFAULT_WS_SLOW_CLIENT_BYTES,
+  DEFAULT_WS_BACKPRESSURE_INTERVAL_MS,
+  DEFAULT_WS_STREAM_CARDINALITY_TOP_N,
+} from '../../src/metrics/wsBackpressure.js';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type AnyHub = any;
+
+async function readCounter(gauge: typeof wsBatchFlushTotal): Promise<number> {
+  const result = (await gauge.get()) as { values: Array<{ value: number }> };
+  return result.values[0]?.value ?? 0;
+}
+
+async function readHistogramCount(histogram: typeof wsBroadcastBatchFlushLatencySeconds): Promise<number> {
+  const result = (await histogram.get()) as { values: Array<{ metricName: string; value: number }> };
+  return result.values.find((v) => v.metricName.endsWith('_count'))?.value ?? 0;
+}
+
+describe('WebSocket Backpressure Stabilization (#1049)', () => {
+  beforeEach(() => {
+    resetWsBackpressureMetrics();
+  });
+
+  describe('hub with partial optional methods', () => {
+    it('handles hub with _getClients() returning undefined (no clients method at all)', () => {
+      const hub = {};
+      expect(() => collectWsBackpressureMetrics(hub)).not.toThrow();
+    });
+
+    it('handles hub with _getStreamSubscriptions() returning undefined', () => {
+      const hub = { _getClients: function* () {} };
+      expect(() => collectWsBackpressureMetrics(hub)).not.toThrow();
+    });
+
+    it('handles hub with clients but without stream subscriptions', () => {
+      const clientIterator = (function* () {
+        yield [{ readyState: 1, bufferedAmount: 500 }, { id: 'conn-0' }];
+      })();
+      const hub = { _getClients: () => clientIterator };
+      expect(() => collectWsBackpressureMetrics(hub)).not.toThrow();
+    });
+
+    it('handles hub with stream subscriptions but without clients', () => {
+      const subs = new Map<string, Set<unknown>>();
+      subs.set('stream-A', new Set([{ readyState: 1, bufferedAmount: 0 }]));
+      const hub = { _getStreamSubscriptions: () => subs };
+      expect(() => collectWsBackpressureMetrics(hub)).not.toThrow();
+    });
+  });
+
+  describe('micro-batching counters', () => {
+    it('wsBatchFlushTotal increments via manual observe (simulating hub.ts calls)', async () => {
+      wsBatchFlushTotal.inc();
+      wsBatchFlushTotal.inc();
+      const val = await readCounter(wsBatchFlushTotal);
+      expect(val).toBe(2);
+    });
+
+    it('wsBatchEventsCoalescedTotal increments correctly', async () => {
+      wsBatchEventsCoalescedTotal.inc(10);
+      wsBatchEventsCoalescedTotal.inc(5);
+      const val = await readCounter(wsBatchEventsCoalescedTotal);
+      expect(val).toBe(15);
+    });
+
+    it('wsBatchSizeExceededTotal increments correctly', async () => {
+      wsBatchSizeExceededTotal.inc();
+      wsBatchSizeExceededTotal.inc();
+      wsBatchSizeExceededTotal.inc();
+      const val = await readCounter(wsBatchSizeExceededTotal);
+      expect(val).toBe(3);
+    });
+
+    it('all three counters are independently tracked', async () => {
+      wsBatchFlushTotal.inc();
+      wsBatchEventsCoalescedTotal.inc(7);
+      wsBatchSizeExceededTotal.inc();
+
+      const [flush, coalesced, exceeded] = await Promise.all([
+        readCounter(wsBatchFlushTotal),
+        readCounter(wsBatchEventsCoalescedTotal),
+        readCounter(wsBatchSizeExceededTotal),
+      ]);
+      expect(flush).toBe(1);
+      expect(coalesced).toBe(7);
+      expect(exceeded).toBe(1);
+    });
+  });
+
+  describe('recordWsBroadcastBatchFlushLatency edge cases', () => {
+    beforeEach(() => {
+      wsBroadcastBatchFlushLatencySeconds.reset();
+    });
+
+    it('ignores negative duration', async () => {
+      recordWsBroadcastBatchFlushLatency(-1);
+      expect(await readHistogramCount(wsBroadcastBatchFlushLatencySeconds)).toBe(0);
+    });
+
+    it('ignores NaN duration', async () => {
+      recordWsBroadcastBatchFlushLatency(NaN);
+      expect(await readHistogramCount(wsBroadcastBatchFlushLatencySeconds)).toBe(0);
+    });
+
+    it('ignores Infinity duration', async () => {
+      recordWsBroadcastBatchFlushLatency(Infinity);
+      expect(await readHistogramCount(wsBroadcastBatchFlushLatencySeconds)).toBe(0);
+    });
+
+    it('records zero latency as valid', async () => {
+      recordWsBroadcastBatchFlushLatency(0);
+      expect(await readHistogramCount(wsBroadcastBatchFlushLatencySeconds)).toBe(1);
+    });
+  });
+
+  describe('default constants', () => {
+    it('DEFAULT_WS_SLOW_CLIENT_BYTES is 1 MiB', () => {
+      expect(DEFAULT_WS_SLOW_CLIENT_BYTES).toBe(1 * 1024 * 1024);
+    });
+
+    it('DEFAULT_WS_BACKPRESSURE_INTERVAL_MS is 5000', () => {
+      expect(DEFAULT_WS_BACKPRESSURE_INTERVAL_MS).toBe(5_000);
+    });
+
+    it('DEFAULT_WS_STREAM_CARDINALITY_TOP_N is 20', () => {
+      expect(DEFAULT_WS_STREAM_CARDINALITY_TOP_N).toBe(20);
+    });
+  });
+});

--- a/tests/sdk/pagination.stabilization.test.ts
+++ b/tests/sdk/pagination.stabilization.test.ts
@@ -1,0 +1,175 @@
+/**
+ * Stabilization tests for SDK pagination helpers (#1088).
+ *
+ * Locks down edge cases that were previously implicit: filter params carry-through,
+ * retry-idempotent state after failure, autoPaginate early break, and param immutability.
+ *
+ * All tests use only the public API (constructor, nextPage, autoPaginate) to
+ * verify behavior — the class exposes no public getters for internal state.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { StreamPaginator } from '../../sdk/typescript/src/pagination.js';
+import type { Stream, StreamListResponse, ListStreamsParams } from '../../sdk/typescript/src/types.js';
+
+function mockPage(streams: Partial<Stream>[], nextCursor?: string): StreamListResponse {
+  return {
+    success: true,
+    data: {
+      streams: streams as Stream[],
+      has_more: !!nextCursor,
+      next_cursor: nextCursor ?? null,
+    },
+    meta: {},
+  };
+}
+
+describe('SDK Pagination Stabilization (#1088)', () => {
+  describe('filter params carry-through', () => {
+    it('forwards status filter on every page fetch', async () => {
+      const fetcher = vi
+        .fn()
+        .mockResolvedValueOnce(mockPage([{ id: 's1' }], 'c2'))
+        .mockResolvedValueOnce(mockPage([{ id: 's2' }]));
+      const p = new StreamPaginator(fetcher, { limit: 1, status: 'active' });
+      await p.nextPage();
+      await p.nextPage();
+      expect(fetcher).toHaveBeenCalledTimes(2);
+      for (const call of fetcher.mock.calls) {
+        expect((call[0] as ListStreamsParams).status).toBe('active');
+      }
+    });
+
+    it('forwards sender filter on every page fetch', async () => {
+      const fetcher = vi
+        .fn()
+        .mockResolvedValueOnce(mockPage([{ id: 's1' }], 'c2'))
+        .mockResolvedValueOnce(mockPage([{ id: 's2' }]));
+      const p = new StreamPaginator(fetcher, { limit: 1, sender: 'GABCDE' });
+      await p.nextPage();
+      await p.nextPage();
+      for (const call of fetcher.mock.calls) {
+        expect((call[0] as ListStreamsParams).sender).toBe('GABCDE');
+      }
+    });
+
+    it('forwards recipient filter on every page fetch', async () => {
+      const fetcher = vi
+        .fn()
+        .mockResolvedValueOnce(mockPage([{ id: 's1' }], 'c2'))
+        .mockResolvedValueOnce(mockPage([{ id: 's2' }]));
+      const p = new StreamPaginator(fetcher, { limit: 1, recipient: 'GZYXWV' });
+      await p.nextPage();
+      await p.nextPage();
+      for (const call of fetcher.mock.calls) {
+        expect((call[0] as ListStreamsParams).recipient).toBe('GZYXWV');
+      }
+    });
+
+    it('forwards include_total on every page fetch', async () => {
+      const fetcher = vi
+        .fn()
+        .mockResolvedValueOnce(mockPage([{ id: 's1' }], 'c2'))
+        .mockResolvedValueOnce(mockPage([{ id: 's2' }]));
+      const p = new StreamPaginator(fetcher, { limit: 1, include_total: true });
+      await p.nextPage();
+      await p.nextPage();
+      for (const call of fetcher.mock.calls) {
+        expect((call[0] as ListStreamsParams).include_total).toBe(true);
+      }
+    });
+
+    it('forwards all combined filters simultaneously', async () => {
+      const fetcher = vi.fn().mockResolvedValue(mockPage([{ id: 's1' }]));
+      const p = new StreamPaginator(fetcher, {
+        limit: 5,
+        status: 'active',
+        sender: 'GABCDE',
+        recipient: 'GZYXWV',
+        include_total: true,
+      });
+      await p.nextPage();
+      const params = fetcher.mock.calls[0]![0] as ListStreamsParams;
+      expect(params.limit).toBe(5);
+      expect(params.status).toBe('active');
+      expect(params.sender).toBe('GABCDE');
+      expect(params.recipient).toBe('GZYXWV');
+      expect(params.include_total).toBe(true);
+    });
+  });
+
+  describe('retry and error recovery', () => {
+    it('allows retrying after a fetch failure without advancing state', async () => {
+      const fetcher = vi
+        .fn()
+        .mockResolvedValueOnce(mockPage([{ id: 's1' }], 'c2'))
+        .mockRejectedValueOnce(new Error('Transient network error'))
+        .mockResolvedValueOnce(mockPage([{ id: 's2' }]));
+
+      const p = new StreamPaginator(fetcher, { limit: 1 });
+
+      // First page succeeds — returns items, passes cursor for next page
+      const p1 = await p.nextPage();
+      expect(p1).toEqual([{ id: 's1' }]);
+
+      // Second page fails — error propagates, caller can retry
+      await expect(p.nextPage()).rejects.toThrow('Transient network error');
+
+      // Retry succeeds — the paginator retries the same cursor
+      const p2 = await p.nextPage();
+      expect(p2).toEqual([{ id: 's2' }]);
+
+      // After successful retry, no more pages
+      const p3 = await p.nextPage();
+      expect(p3).toBeNull();
+
+      // Three fetchPage calls total = initial + failed retry + successful retry
+      expect(fetcher).toHaveBeenCalledTimes(3);
+    });
+  });
+
+  describe('autoPaginate early break', () => {
+    it('stops iterating when loop breaks early (no extra fetch)', async () => {
+      const fetcher = vi
+        .fn()
+        .mockResolvedValueOnce(mockPage([{ id: 's1' }, { id: 's2' }, { id: 's3' }], 'c2'))
+        .mockResolvedValueOnce(mockPage([{ id: 's4' }], 'c3'));
+      const p = new StreamPaginator(fetcher, { limit: 3 });
+
+      const items: Stream[] = [];
+      for await (const item of p.autoPaginate()) {
+        items.push(item);
+        if (items.length >= 2) break;
+      }
+      expect(items).toHaveLength(2);
+      // break prevents fetching next page even though hasMore is true
+      expect(fetcher).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('param immutability', () => {
+    it('does not mutate the original params object', async () => {
+      const fetcher = vi.fn().mockResolvedValue(mockPage([{ id: 's1' }]));
+      const params: ListStreamsParams = { limit: 20 };
+      Object.freeze(params);
+      const p = new StreamPaginator(fetcher, params);
+      await p.nextPage();
+      expect(params).toEqual({ limit: 20 });
+    });
+  });
+
+  describe('cursor param consistency', () => {
+    it('passes undefined cursor on first call, then opaque cursor on subsequent calls', async () => {
+      const fetcher = vi
+        .fn()
+        .mockResolvedValueOnce(mockPage([{ id: 's1' }], 'opaque-token'))
+        .mockResolvedValueOnce(mockPage([{ id: 's2' }]));
+      const p = new StreamPaginator(fetcher, { limit: 1 });
+
+      await p.nextPage();
+      expect((fetcher.mock.calls[0]![0] as ListStreamsParams).cursor).toBeUndefined();
+
+      await p.nextPage();
+      expect((fetcher.mock.calls[1]![0] as ListStreamsParams).cursor).toBe('opaque-token');
+    });
+  });
+});


### PR DESCRIPTION
## Overview

This PR stabilizes two areas identified in issues #1088 and #1049:

1. **SDK Pagination Helpers** — Adds deterministic, regression-safe tests for `StreamPaginator` covering filter param carry-through, retry-idempotent state, `autoPaginate` early break, param immutability, and cursor param consistency.

2. **WebSocket Backpressure Metrics** — Adds tests for hub partial optional methods, micro-batching counter increments, `recordWsBroadcastBatchFlushLatency` edge values (NaN, Infinity, negative, zero), and exported constant defaults. Fixes `recordWsBroadcastBatchFlushLatency` to guard against Infinity/NaN in addition to negative values. Fixes `resetWsBackpressureMetrics` to reset batch counters and flush latency histogram for proper test isolation.

## Related Issue

Closes #1088
Closes #1049

## Changes

### 📈 SDK Pagination Stabilization (#1088)

- **[ADD]** `tests/sdk/pagination.stabilization.test.ts` — 9 tests covering:
  - Filter params carry-through (status, sender, recipient, include_total, combined) on every page fetch
  - Retry-idempotent state after fetch failure (state preserved, retry succeeds)
  - `autoPaginate` early break (no extra fetch when loop breaks early)
  - Param immutability (frozen params object accepted without mutation)
  - Cursor param consistency (undefined on first call, opaque cursor on subsequent calls)

### 📊 WebSocket Backpressure Stabilization (#1049)

- **[ADD]** `tests/metrics/wsBackpressure.stabilization.test.ts` — 15 tests covering:
  - Hub with partial or absent optional methods (`_getClients`, `_getStreamSubscriptions` returning undefined)
  - Micro-batching counter increments (flush total, events coalesced, size exceeded — independently tracked)
  - `recordWsBroadcastBatchFlushLatency` edge values (NaN, Infinity, negative ignored; zero accepted)
  - Exported constant defaults (slow threshold 1 MiB, poll interval 5s, top-N = 20)

- **[MODIFY]** `src/metrics/wsBackpressure.ts`:
  - `recordWsBroadcastBatchFlushLatency`: added `isFinite()` guard so Infinity/NaN are silently ignored instead of throwing
  - `resetWsBackpressureMetrics`: now resets `wsBatchFlushTotal`, `wsBatchEventsCoalescedTotal`, `wsBatchSizeExceededTotal`, and `wsBroadcastBatchFlushLatencySeconds` in addition to gauges

## Verification Results

```
npm test -- tests/sdk/pagination.stabilization.test.ts tests/metrics/wsBackpressure.stabilization.test.ts
✅ 24/24 passed

npm test -- tests/ws/hub.backpressureGauge.unit.test.ts tests/ws/hub.subscriptionCardinality.test.ts tests/ws/hub.batchFlushLatency.test.ts
✅ 18/18 passed (existing tests unaffected)
```

| Acceptance Criteria | Status |
| --- | --- |
| SDK pagination filter params carried through every page fetch | ✅ |
| Retry-idempotent state after error preserved | ✅ |
| AutoPaginate early break works without extra fetch | ✅ |
| Backpressure metrics handle hub with missing optional methods | ✅ |
| Batch counters properly reset between collections | ✅ |
| `recordWsBroadcastBatchFlushLatency` guards against NaN/Infinity | ✅ |
| Existing tests unchanged | ✅ |