### PR TITLE
fix(ws): harden websocket backpressure metrics with edge case handling and remove duplicate doc

### DIFF
--- a/src/metrics/wsBackpressure.ts
+++ b/src/metrics/wsBackpressure.ts
@@ -31,16 +31,6 @@
  *   - `fluxora_ws_batch_size_exceeded_total` — flushes where the batch hit
  *     `WS_BATCH_MAX_SIZE` before the flush window expired (early ejection).
  *
- * ### Micro-batching counters (three series)
- *
- *   - `fluxora_ws_batch_flush_total`         — total flush operations (each
- *     flush produces one outbound `stream_update_batch` frame per client).
- *   - `fluxora_ws_batch_events_coalesced_total` — total individual events
- *     that were coalesced across all flushes.  Comparing this to
- *     `fluxora_ws_batch_flush_total` gives the average batch size.
- *   - `fluxora_ws_batch_size_exceeded_total` — flushes where the batch hit
- *     `WS_BATCH_MAX_SIZE` before the flush window expired (early ejection).
- *
  * The per-client gauge is updated by a poll loop so the value reflects the
  * actual kernel/OS send-buffer state, not just the snapshot taken during a
  * `deliverBatch` call.  Series for disconnected clients are explicitly removed
@@ -56,8 +46,9 @@ import type { StreamHub } from '../ws/hub.js';
 /**
  * Default warning threshold for "slow client" classification.
  * Mirrors `BACKPRESSURE_DROP_BYTES` in `src/ws/hub.ts` (1 MiB) by default,
- * but can be overridden via `startWsBackpressureCollector` to e.g. trigger
- * before the hub actively drops frames.
+ * but can be overridden via the `slowThresholdBytes` parameter of
+ * `collectWsBackpressureMetrics` to e.g. trigger before the hub actively
+ * drops frames.
  */
 export const DEFAULT_WS_SLOW_CLIENT_BYTES = 1 * 1024 * 1024;
 
@@ -203,6 +194,22 @@ export const wsBatchSizeExceededTotal = metric(
 
 // ── Collection ────────────────────────────────────────────────────────────
 
+/**
+ * Collect all WebSocket backpressure and subscription-cardinality metrics
+ * from the hub and publish them to Prometheus gauges.
+ *
+ * Should be called on a periodic interval (typically every 5 s).  The
+ * function is designed to be resilient — missing hub methods, undefined
+ * socket properties, and invalid parameter values are all handled without
+ * throwing.
+ *
+ * @param hub                   StreamHub instance (or stub) providing
+ *                              `_getClients` and `_getStreamSubscriptions`.
+ * @param slowThresholdBytes    Buffered-amount threshold above which a client
+ *                              is classified as "slow".  Clamped to 0.
+ * @param topN                  Maximum number of stream-subscription-cardinality
+ *                              series to emit.  Clamped to 1.
+ */
 export function collectWsBackpressureMetrics(
   hub: {
     _getClients?: () => IterableIterator<[unknown, { id: string }]>;
@@ -211,20 +218,27 @@ export function collectWsBackpressureMetrics(
   slowThresholdBytes: number = DEFAULT_WS_SLOW_CLIENT_BYTES,
   topN: number = DEFAULT_WS_STREAM_CARDINALITY_TOP_N,
 ): void {
+  const effectiveSlowThreshold = slowThresholdBytes >= 0 ? slowThresholdBytes : 0;
+  const effectiveTopN = topN >= 1 ? topN : 1;
+
   const clientIterator = hub._getClients?.();
   if (clientIterator) {
     let max = 0;
     let slowCount = 0;
 
     for (const [ws, state] of clientIterator) {
+      if (!state || !state.id) continue;
+
       const socket = ws as { readyState?: number; bufferedAmount?: number };
       if (socket.readyState !== 1) continue;
 
-      const ba = typeof socket.bufferedAmount === 'number' ? socket.bufferedAmount : 0;
+      const ba = typeof socket.bufferedAmount === 'number' && socket.bufferedAmount >= 0
+        ? socket.bufferedAmount
+        : 0;
       wsClientBufferedBytes.set({ connection_id: state.id }, ba);
 
       if (ba > max) max = ba;
-      if (ba > slowThresholdBytes) slowCount++;
+      if (ba > effectiveSlowThreshold) slowCount++;
     }
 
     wsMaxBufferedBytes.set(max);
@@ -234,9 +248,9 @@ export function collectWsBackpressureMetrics(
   const streamSubs = hub._getStreamSubscriptions?.();
   if (streamSubs) {
     const sorted = Array.from(streamSubs.entries())
-      .map(([id, set]) => [id, set.size] as const)
+      .map(([id, set]) => [id, set?.size ?? 0] as const)
       .sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]))
-      .slice(0, topN);
+      .slice(0, effectiveTopN);
 
     wsStreamSubscriberCount.reset();
     for (const [id, count] of sorted) {

--- a/tests/ws/hub.backpressureEdgeCases.test.ts
+++ b/tests/ws/hub.backpressureEdgeCases.test.ts
@@ -1,0 +1,143 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  collectWsBackpressureMetrics,
+  removeWsClientBackpressureGauge,
+  resetWsBackpressureMetrics,
+  wsClientBufferedBytes,
+  wsMaxBufferedBytes,
+  wsSlowClients,
+  wsStreamSubscriberCount,
+} from '../../src/metrics/wsBackpressure.js';
+
+interface StubSocket {
+  OPEN: 1;
+  CLOSING: 2;
+  CLOSED: 3;
+  readyState: number;
+  bufferedAmount: number;
+}
+
+const stubSocket = (initialBuffered: number): StubSocket =>
+  ({
+    OPEN: 1,
+    CLOSING: 2,
+    CLOSED: 3,
+    readyState: 1,
+    bufferedAmount: initialBuffered,
+  }) as unknown as StubSocket;
+
+function makeFakeHub(
+  clients: Array<[StubSocket, { id: string }]>,
+  streamSubs?: Map<string, Set<unknown>>,
+) {
+  return {
+    _getClients: function* () {
+      for (const entry of clients) yield entry;
+    },
+    _getStreamSubscriptions: () => streamSubs ?? new Map(),
+  };
+}
+
+type AnyHub = any;
+
+describe('WebSocket backpressure edge cases', () => {
+  beforeEach(() => {
+    resetWsBackpressureMetrics();
+  });
+
+  afterEach(() => {
+    resetWsBackpressureMetrics();
+  });
+
+  it('clamps negative slowThresholdBytes to 0', async () => {
+    const hub = makeFakeHub([
+      [stubSocket(500), { id: 'conn-a' }],
+    ]);
+    collectWsBackpressureMetrics(hub as AnyHub, -100);
+    expect(await readGauge(wsSlowClients)).toBe(1);
+  });
+
+  it('clamps topN less than 1 to 1', async () => {
+    const subs = new Map<string, Set<unknown>>([
+      ['stream-a', new Set(['c1', 'c2'])],
+      ['stream-b', new Set(['c3'])],
+    ]);
+    const hub = makeFakeHub([], subs);
+    collectWsBackpressureMetrics(
+      { _getStreamSubscriptions: () => subs } as AnyHub,
+      undefined,
+      -5,
+    );
+    const result = await wsStreamSubscriberCount.get() as { values: Array<{ labels: Record<string, string>; value: number }> };
+    expect(result.values.length).toBe(1);
+    expect(result.values[0].labels.stream_id).toBe('stream-a');
+  });
+
+  it('skips clients with missing state.id', async () => {
+    const ws = stubSocket(100);
+    const hub = makeFakeHub([
+      [ws, { id: '' }],
+    ]);
+    collectWsBackpressureMetrics(hub as AnyHub);
+    const result = await wsClientBufferedBytes.get() as { values: Array<{ labels: Record<string, string>; value: number }> };
+    expect(result.values).toEqual([]);
+  });
+
+  it('handles undefined hub methods gracefully', () => {
+    expect(() => collectWsBackpressureMetrics({} as AnyHub)).not.toThrow();
+  });
+
+  it('handles missing _getClients without error', () => {
+    const hub = { _getStreamSubscriptions: () => new Map() };
+    expect(() => collectWsBackpressureMetrics(hub as AnyHub)).not.toThrow();
+  });
+
+  it('handles empty client list without error', async () => {
+    const hub = makeFakeHub([]);
+    collectWsBackpressureMetrics(hub as AnyHub);
+    expect(await readGauge(wsMaxBufferedBytes)).toBe(0);
+    expect(await readGauge(wsSlowClients)).toBe(0);
+  });
+
+  it('treats negative bufferedAmount as 0', async () => {
+    const ws = stubSocket(-100);
+    const hub = makeFakeHub([[ws, { id: 'conn-neg' }]]);
+    collectWsBackpressureMetrics(hub as AnyHub);
+    expect(await readLabel(wsClientBufferedBytes, 'conn-neg')).toBe(0);
+  });
+
+  it('handles stream subscription set being undefined', async () => {
+    const subs = new Map<string, Set<unknown> | undefined>([
+      ['stream-a', undefined],
+    ]);
+    const hub = {
+      _getStreamSubscriptions: () => subs,
+    };
+    expect(() => collectWsBackpressureMetrics(hub as AnyHub)).not.toThrow();
+  });
+
+  it('removes gauge label after disconnect', async () => {
+    const hub = makeFakeHub([[stubSocket(500), { id: 'conn-rm' }]]);
+    collectWsBackpressureMetrics(hub as AnyHub);
+    expect(await readLabel(wsClientBufferedBytes, 'conn-rm')).toBe(500);
+
+    removeWsClientBackpressureGauge('conn-rm');
+    expect(await readLabel(wsClientBufferedBytes, 'conn-rm')).toBeNull();
+  });
+
+  async function readLabel(
+    gauge: typeof wsClientBufferedBytes,
+    connectionId: string,
+  ): Promise<number | null> {
+    const result = await gauge.get() as { values: Array<{ labels: Record<string, string>; value: number }> };
+    const match = result.values.find((v) => v.labels?.connection_id === connectionId);
+    return match ? match.value : null;
+  }
+
+  async function readGauge(
+    gauge: typeof wsMaxBufferedBytes,
+  ): Promise<number> {
+    const result = await gauge.get() as { values: Array<{ value: number }> };
+    return result.values[0]?.value ?? 0;
+  }
+});


### PR DESCRIPTION
## Overview

This PR hardens the WebSocket backpressure metrics module by removing a duplicated doc comment block, fixing an incorrect function reference, adding parameter validation, and adding comprehensive edge-case tests.

## Related Issue

Closes #1048

## Changes

- **`src/metrics/wsBackpressure.ts`**:
  - Removed duplicated `### Micro-batching counters` doc comment block
  - Fixed stale comment referencing `startWsBackpressureCollector` → now correctly references `collectWsBackpressureMetrics`
  - Added JSDoc to `collectWsBackpressureMetrics` documenting edge-case behavior
  - Added validation: negative `slowThresholdBytes` clamped to 0, `topN < 1` clamped to 1
  - Added defensive guards: skip clients with missing/invalid `state.id`, treat negative `bufferedAmount` as 0, handle undefined stream subscription sets
- **`tests/ws/hub.backpressureEdgeCases.test.ts`** — New test file covering 9 edge cases:
  - Negative slow threshold clamping
  - topN < 1 clamping
  - Missing state.id skip
  - Undefined hub methods (graceful handling)
  - Missing `_getClients`
  - Empty client list
  - Negative bufferedAmount fallback
  - Undefined stream set
  - Gauge label removal on disconnect

## Verification Results

All existing tests continue to pass. The new edge-case tests pass independently.

| Acceptance Criteria | Status |
|--|--|
| Current API/service behavior still works as today | ✅ No breaking changes to public API |
| Edge-case behavior is documented and covered by tests | ✅ 9 new edge-case tests + JSDoc |
| Change stays backward compatible | ✅ All existing exports and signatures preserved