### PR TITLE
fix(jobs): add DLQ validation, size budgets, retention purge, and comprehensive tests

### DIFF
--- a/src/jobs/queue.ts
+++ b/src/jobs/queue.ts
@@ -207,6 +207,12 @@ export class JobQueue {
    * logged, and re‑thrown to allow pg‑boss to retry according to the supplied options.
    */
   register(name: string, handler: JobHandler, options: JobRegistrationOptions = {}): void {
+    if (typeof name !== 'string' || name.trim() === '') {
+      throw new TypeError('register: name must be a non-empty string');
+    }
+    if (typeof handler !== 'function') {
+      throw new TypeError('register: handler must be a function');
+    }
     this.handlers.set(name, { handler, options });
   }
 
@@ -274,6 +280,9 @@ export class JobQueue {
    * it will be moved to the configured dead‑letter queue.
    */
   async send(name: string, data: unknown, options?: JobSendOptions): Promise<string | null> {
+    if (typeof name !== 'string' || name.trim() === '') {
+      throw new TypeError('send: name must be a non-empty string');
+    }
     const sendOpts = this.toSendOptions(options);
     return this.boss.send(name, data as object | null, sendOpts);
   }
@@ -290,6 +299,12 @@ export class JobQueue {
    * pg‑boss will apply the retry configuration before eventually moving it to the dead‑letter queue.
    */
   async schedule(name: string, cron: string, data?: unknown, options?: JobScheduleOptions): Promise<void> {
+    if (typeof name !== 'string' || name.trim() === '') {
+      throw new TypeError('schedule: name must be a non-empty string');
+    }
+    if (typeof cron !== 'string' || cron.trim() === '') {
+      throw new TypeError('schedule: cron must be a non-empty string');
+    }
     const schedOpts: Record<string, unknown> = {
       ...this.toSendOptions(options),
       ...(options?.tz ? { tz: options.tz } : {}),
@@ -313,16 +328,51 @@ export class JobQueue {
   private toSendOptions(opts?: JobSendOptions): Record<string, unknown> {
     const s: Record<string, unknown> = {};
     if (!opts) return s;
-    if (opts.retryLimit !== undefined) s.retryLimit = opts.retryLimit;
-    if (opts.retryDelay !== undefined) s.retryDelay = opts.retryDelay;
+    if (opts.retryLimit !== undefined) {
+      if (typeof opts.retryLimit !== 'number' || !Number.isFinite(opts.retryLimit) || opts.retryLimit < 0) {
+        throw new TypeError('toSendOptions: retryLimit must be a non-negative finite number');
+      }
+      s.retryLimit = opts.retryLimit;
+    }
+    if (opts.retryDelay !== undefined) {
+      if (typeof opts.retryDelay !== 'number' || !Number.isFinite(opts.retryDelay) || opts.retryDelay < 0) {
+        throw new TypeError('toSendOptions: retryDelay must be a non-negative finite number');
+      }
+      s.retryDelay = opts.retryDelay;
+    }
     if (opts.retryBackoff !== undefined) s.retryBackoff = opts.retryBackoff;
-    if (opts.retryDelayMax !== undefined) s.retryDelayMax = opts.retryDelayMax;
-    if (opts.expireInSeconds !== undefined) s.expireInSeconds = opts.expireInSeconds;
-    if (opts.deadLetter !== undefined) s.deadLetter = opts.deadLetter;
+    if (opts.retryDelayMax !== undefined) {
+      if (typeof opts.retryDelayMax !== 'number' || !Number.isFinite(opts.retryDelayMax) || opts.retryDelayMax < 0) {
+        throw new TypeError('toSendOptions: retryDelayMax must be a non-negative finite number');
+      }
+      s.retryDelayMax = opts.retryDelayMax;
+    }
+    if (opts.expireInSeconds !== undefined) {
+      if (typeof opts.expireInSeconds !== 'number' || !Number.isFinite(opts.expireInSeconds) || opts.expireInSeconds < 0) {
+        throw new TypeError('toSendOptions: expireInSeconds must be a non-negative finite number');
+      }
+      s.expireInSeconds = opts.expireInSeconds;
+    }
+    if (opts.deadLetter !== undefined) {
+      if (typeof opts.deadLetter !== 'string' || opts.deadLetter.trim() === '') {
+        throw new TypeError('toSendOptions: deadLetter must be a non-empty string');
+      }
+      s.deadLetter = opts.deadLetter;
+    }
     if (opts.startAfter !== undefined) s.startAfter = opts.startAfter;
     if (opts.singletonKey !== undefined) s.singletonKey = opts.singletonKey;
-    if (opts.singletonSeconds !== undefined) s.singletonSeconds = opts.singletonSeconds;
-    if (opts.priority !== undefined) s.priority = opts.priority;
+    if (opts.singletonSeconds !== undefined) {
+      if (typeof opts.singletonSeconds !== 'number' || !Number.isFinite(opts.singletonSeconds) || opts.singletonSeconds < 0) {
+        throw new TypeError('toSendOptions: singletonSeconds must be a non-negative finite number');
+      }
+      s.singletonSeconds = opts.singletonSeconds;
+    }
+    if (opts.priority !== undefined) {
+      if (typeof opts.priority !== 'number' || !Number.isFinite(opts.priority)) {
+        throw new TypeError('toSendOptions: priority must be a finite number');
+      }
+      s.priority = opts.priority;
+    }
     return s;
   }
 }
@@ -345,6 +395,14 @@ const DLQ_MAX_ERROR_BYTES = 2048;
  * pg JSONB can hold large documents, but we cap this to avoid runaway rows.
  */
 const DLQ_MAX_PAYLOAD_BYTES = 65536; // 64 KiB
+
+/**
+ * Default retention period in days for `job_dead_letter` entries.
+ * Entries older than this are eligible for purging by the partition‑maintenance
+ * job.  90 days keeps enough history for post‑mortem analysis while bounding
+ * table growth.
+ */
+export const DEFAULT_DLQ_RETENTION_DAYS = 90;
 
 /**
  * Singleton accessor for the JobQueue.
@@ -397,6 +455,19 @@ export function startBackgroundJobs(pool: Pool): void {
           behindSchedule: t.behindSchedule,
         })),
       });
+
+      // Purge expired dead‑letter entries alongside the daily maintenance
+      // to keep the DLQ table size bounded without a dedicated cron.
+      try {
+        const deleted = await purgeJobDeadLetter(pool, DEFAULT_DLQ_RETENTION_DAYS);
+        if (deleted > 0) {
+          logger.info('DLQ retention purge removed entries', ctx.id, { deletedCount: deleted });
+        }
+      } catch (dlqErr) {
+        logger.error('DLQ retention purge failed, continuing', ctx.id, {
+          error: dlqErr instanceof Error ? dlqErr.message : String(dlqErr),
+        });
+      }
     },
     {
       retryLimit: DEFAULT_RETRY_LIMIT,
@@ -531,4 +602,44 @@ export async function stopBackgroundJobs(): Promise<void> {
     // or tests can detect the queue is no longer active.
     setJobQueue(null);
   }
+}
+
+/**
+ * Purges expired entries from the `job_dead_letter` table.
+ *
+ * Deletes rows whose `failed_at` timestamp is older than `retentionDays`.
+ * This prevents unbounded growth of the dead-letter table while keeping
+ * recent entries available for post-mortem analysis.
+ *
+ * The function is called automatically by the partition-maintenance job;
+ * callers should not normally need to invoke it directly.
+ *
+ * @param pool - PostgreSQL pool to query against.
+ * @param retentionDays - Age threshold in days (defaults to `DEFAULT_DLQ_RETENTION_DAYS`).
+ * @returns The number of deleted rows.
+ *
+ * @throws {Error} If `pool` is null or the query fails.
+ */
+export async function purgeJobDeadLetter(
+  pool: Pool,
+  retentionDays: number = DEFAULT_DLQ_RETENTION_DAYS,
+): Promise<number> {
+  if (pool == null) {
+    throw new Error('purgeJobDeadLetter requires a valid PostgreSQL pool');
+  }
+  if (typeof retentionDays !== 'number' || !Number.isFinite(retentionDays) || retentionDays < 0) {
+    throw new TypeError('purgeJobDeadLetter: retentionDays must be a non-negative finite number');
+  }
+
+  const result = await pool.query(
+    `DELETE FROM job_dead_letter WHERE failed_at < NOW() - INTERVAL '1 day' * $1`,
+    [retentionDays],
+  );
+
+  const deletedCount = result.rowCount ?? 0;
+  logger.info('DLQ retention purge complete', undefined, {
+    deletedCount,
+    retentionDays,
+  });
+  return deletedCount;
 }

--- a/src/jobs/queue.ts
+++ b/src/jobs/queue.ts
@@ -388,13 +388,31 @@ export const DEAD_LETTER_QUEUE = 'job_dead_letter_queue';
  * Maximum byte-length for persisted `error_message` in job_dead_letter.
  * Prevents oversized error strings from blowing the TEXT column budget.
  */
-const DLQ_MAX_ERROR_BYTES = 2048;
+export const DLQ_MAX_ERROR_BYTES = 2048;
 
 /**
  * Maximum byte-length for the serialised `payload` stored in job_dead_letter.
  * pg JSONB can hold large documents, but we cap this to avoid runaway rows.
  */
-const DLQ_MAX_PAYLOAD_BYTES = 65536; // 64 KiB
+export const DLQ_MAX_PAYLOAD_BYTES = 65536; // 64 KiB
+
+/**
+ * Safely truncates a UTF‑8 string to fit within `maxBytes` without breaking
+ * multi‑byte character boundaries.  Returns the original string if it already
+ * fits within the limit.
+ *
+ * @internal
+ */
+function truncateUtf8(str: string, maxBytes: number): string {
+  if (Buffer.byteLength(str, 'utf-8') <= maxBytes) return str;
+  let truncated = '';
+  for (const char of str) {
+    const next = truncated + char;
+    if (Buffer.byteLength(next, 'utf-8') > maxBytes) break;
+    truncated = next;
+  }
+  return truncated;
+}
 
 /**
  * Default retention period in days for `job_dead_letter` entries.
@@ -432,6 +450,9 @@ export function startBackgroundJobs(pool: Pool): void {
   // inside the DLQ handler when pool.query is eventually called.
   if (pool == null) {
     throw new Error('startBackgroundJobs requires a valid PostgreSQL pool');
+  }
+  if (typeof pool.query !== 'function') {
+    throw new TypeError('startBackgroundJobs: pool must expose a query method');
   }
 
   if (_jobQueue) {
@@ -527,6 +548,22 @@ export function startBackgroundJobs(pool: Pool): void {
         error: errorMessage,
       });
 
+      // Apply size budgets before persisting, so oversized entries don't
+      // cause INSERT failures or bloat the dead‑letter table.
+      const finalErrorMessage = truncateUtf8(errorMessage, DLQ_MAX_ERROR_BYTES);
+
+      let finalPayload: unknown = originalPayload;
+      if (finalPayload !== null) {
+        try {
+          const payloadJson = JSON.stringify(finalPayload);
+          if (Buffer.byteLength(payloadJson, 'utf-8') > DLQ_MAX_PAYLOAD_BYTES) {
+            finalPayload = { _truncated: true };
+          }
+        } catch {
+          finalPayload = { _truncated: true };
+        }
+      }
+
       // Increment the observable counter so on-call can alert on DLQ growth.
       jobDlqEntriesTotal.inc({ job_name: originalJobName });
 
@@ -537,7 +574,7 @@ export function startBackgroundJobs(pool: Pool): void {
         await pool.query(
           `INSERT INTO job_dead_letter (job_name, job_id, payload, error_message, retry_count)
            VALUES ($1, $2, $3, $4, $5)`,
-          [originalJobName, originalJobId, originalPayload, errorMessage, retryCount],
+          [originalJobName, originalJobId, finalPayload, finalErrorMessage, retryCount],
         );
       } catch (insertErr) {
         // Log but do not re-throw: the job is terminally failed.  A failed

--- a/tests/jobs/queue.test.ts
+++ b/tests/jobs/queue.test.ts
@@ -742,6 +742,146 @@ describe('startBackgroundJobs', () => {
     const [, params] = mockPool.query.mock.calls[0] as [string, unknown[]];
     expect(params[4]).toBe(0);
   });
+
+  // ── DLQ handler: error message truncation ─────────────────────────────────
+
+  describe('DLQ handler – error message truncation', () => {
+    it('truncates error message exceeding DLQ_MAX_ERROR_BYTES', async () => {
+      const mod = await import('../../src/jobs/queue.js');
+      const mockPool = { query: vi.fn().mockResolvedValue({ rowCount: 1 }) };
+      const dlqHandler = await getDlqHandler(mockPool);
+
+      const longError = 'x'.repeat(3000);
+      await dlqHandler({
+        id: 'dlq-ctx-id',
+        name: 'job_dead_letter_queue',
+        data: { name: 'j', id: 'id-trunc', output: longError, retryCount: 1 },
+      } as never);
+
+      const [, params] = mockPool.query.mock.calls[0] as [string, unknown[]];
+      expect((params[3] as string).length).toBe(mod.DLQ_MAX_ERROR_BYTES);
+    });
+
+    it('does NOT truncate error message within the byte limit', async () => {
+      const mockPool = { query: vi.fn().mockResolvedValue({ rowCount: 1 }) };
+      const dlqHandler = await getDlqHandler(mockPool);
+
+      const shortError = 'short error';
+      await dlqHandler({
+        id: 'dlq-ctx-id',
+        name: 'job_dead_letter_queue',
+        data: { name: 'j', id: 'id-short', output: shortError, retryCount: 1 },
+      } as never);
+
+      const [, params] = mockPool.query.mock.calls[0] as [string, unknown[]];
+      expect(params[3]).toBe('short error');
+    });
+
+    it('handles multi‑byte characters at the truncation boundary safely', async () => {
+      const mod = await import('../../src/jobs/queue.js');
+      const mockPool = { query: vi.fn().mockResolvedValue({ rowCount: 1 }) };
+      const dlqHandler = await getDlqHandler(mockPool);
+
+      // Each emoji is 4 bytes.  2050 bytes ÷ 4 = 512 emoji + 2 bytes remainder.
+      // The last full emoji that fits within 2048 bytes is at position 512.
+      const longError = '😀'.repeat(600); // 2400 bytes > 2048
+      await dlqHandler({
+        id: 'dlq-ctx-id',
+        name: 'job_dead_letter_queue',
+        data: { name: 'j', id: 'id-emoji', output: longError, retryCount: 1 },
+      } as never);
+
+      const [, params] = mockPool.query.mock.calls[0] as [string, unknown[]];
+      const stored = params[3] as string;
+      // Must be ≤ 2048 bytes
+      expect(Buffer.byteLength(stored, 'utf-8')).toBeLessThanOrEqual(mod.DLQ_MAX_ERROR_BYTES);
+      // Must not end with a partial multi‑byte character (should be an even number of emoji)
+      expect(stored.length % 2).toBe(0);
+    });
+  });
+
+  // ── DLQ handler: payload truncation ───────────────────────────────────────
+
+  describe('DLQ handler – payload truncation', () => {
+    it('replaces oversized payload with a truncated marker', async () => {
+      const mod = await import('../../src/jobs/queue.js');
+      const mockPool = { query: vi.fn().mockResolvedValue({ rowCount: 1 }) };
+      const dlqHandler = await getDlqHandler(mockPool);
+
+      // Payload > 64 KiB when serialized
+      const largePayload = { data: 'x'.repeat(70000) };
+      await dlqHandler({
+        id: 'dlq-ctx-id',
+        name: 'job_dead_letter_queue',
+        data: { name: 'j', id: 'id-big', data: largePayload, output: 'err', retryCount: 0 },
+      } as never);
+
+      const [, params] = mockPool.query.mock.calls[0] as [string, unknown[]];
+      expect(params[2]).toEqual({ _truncated: true });
+    });
+
+    it('preserves payload within the byte limit', async () => {
+      const mockPool = { query: vi.fn().mockResolvedValue({ rowCount: 1 }) };
+      const dlqHandler = await getDlqHandler(mockPool);
+
+      const smallPayload = { a: 1, b: 'hello' };
+      await dlqHandler({
+        id: 'dlq-ctx-id',
+        name: 'job_dead_letter_queue',
+        data: { name: 'j', id: 'id-small', data: smallPayload, output: 'err', retryCount: 0 },
+      } as never);
+
+      const [, params] = mockPool.query.mock.calls[0] as [string, unknown[]];
+      expect(params[2]).toEqual({ a: 1, b: 'hello' });
+    });
+
+    it('replaces payload that cannot be serialized (circular ref) with truncated marker', async () => {
+      const mockPool = { query: vi.fn().mockResolvedValue({ rowCount: 1 }) };
+      const dlqHandler = await getDlqHandler(mockPool);
+
+      const circular: Record<string, unknown> = { name: 'loop' };
+      circular.self = circular;
+
+      await dlqHandler({
+        id: 'dlq-ctx-id',
+        name: 'job_dead_letter_queue',
+        data: { name: 'j', id: 'id-circ', data: circular, output: 'err', retryCount: 0 },
+      } as never);
+
+      const [, params] = mockPool.query.mock.calls[0] as [string, unknown[]];
+      expect(params[2]).toEqual({ _truncated: true });
+    });
+
+    it('preserves null payload unchanged', async () => {
+      const mockPool = { query: vi.fn().mockResolvedValue({ rowCount: 1 }) };
+      const dlqHandler = await getDlqHandler(mockPool);
+
+      await dlqHandler({
+        id: 'dlq-ctx-id',
+        name: 'job_dead_letter_queue',
+        data: { name: 'j', id: 'id-null', data: null, output: 'err', retryCount: 0 },
+      } as never);
+
+      const [, params] = mockPool.query.mock.calls[0] as [string, unknown[]];
+      expect(params[2]).toBeNull();
+    });
+
+    it('preserves payload at exactly the byte limit', async () => {
+      const mockPool = { query: vi.fn().mockResolvedValue({ rowCount: 1 }) };
+      const dlqHandler = await getDlqHandler(mockPool);
+
+      // Build a payload serializing to exactly (or just under) 65536 bytes
+      const exactPayload = { data: 'x'.repeat(65510) };
+      await dlqHandler({
+        id: 'dlq-ctx-id',
+        name: 'job_dead_letter_queue',
+        data: { name: 'j', id: 'id-exact', data: exactPayload, output: 'err', retryCount: 0 },
+      } as never);
+
+      const [, params] = mockPool.query.mock.calls[0] as [string, unknown[]];
+      expect((params[2] as Record<string, unknown>)._truncated).toBeUndefined();
+    });
+  });
 });
 
 // ── DEAD_LETTER_QUEUE constant ────────────────────────────────────────────
@@ -1023,5 +1163,38 @@ describe('partition-maintenance DLQ purge integration', () => {
     await expect(
       handler({ id: 'pm-test', name: 'partition-maintenance', data: {} } as never),
     ).resolves.toBeUndefined();
+  });
+});
+
+// ── startBackgroundJobs: pool validation ──────────────────────────────────
+
+describe('startBackgroundJobs – pool validation', () => {
+  beforeEach(async () => {
+    const { setJobQueue } = await import('../../src/jobs/queue.js');
+    setJobQueue(null);
+  });
+
+  it('throws TypeError when pool has no query method', async () => {
+    const mod = await import('../../src/jobs/queue.js');
+    expect(() => mod.startBackgroundJobs({} as never)).toThrow(TypeError);
+    expect(() => mod.startBackgroundJobs({} as never)).toThrow('pool must expose a query method');
+  });
+
+  it('does NOT throw for a pool with a valid query method', async () => {
+    const mod = await import('../../src/jobs/queue.js');
+    vi.spyOn(mod.JobQueue.prototype, 'register');
+    vi.spyOn(mod.JobQueue.prototype, 'start').mockResolvedValue(undefined);
+    vi.spyOn(mod.JobQueue.prototype, 'schedule').mockResolvedValue(undefined);
+    vi.spyOn(mod.JobQueue.prototype, 'send').mockResolvedValue(null);
+
+    expect(() => mod.startBackgroundJobs({ query: vi.fn() } as never)).not.toThrow();
+    // Cleanup: clear the singleton that was set
+    mod.setJobQueue(null);
+  });
+
+  it('still throws Error for null pool before the Type check', async () => {
+    const mod = await import('../../src/jobs/queue.js');
+    // null pool still throws Error
+    expect(() => mod.startBackgroundJobs(null as never)).toThrow('requires a valid PostgreSQL pool');
   });
 });

--- a/tests/jobs/queue.test.ts
+++ b/tests/jobs/queue.test.ts
@@ -634,4 +634,394 @@ describe('startBackgroundJobs', () => {
 
     expect(incSpy).toHaveBeenCalledWith({ job_name: 'unknown' });
   });
+
+  // ── DLQ handler: empty‑string name/id fields ──────────────────────────────
+
+  it('DLQ handler: falls back to "unknown" for empty‑string job name', async () => {
+    const mockPool = { query: vi.fn().mockResolvedValue({ rowCount: 1 }) };
+    const dlqHandler = await getDlqHandler(mockPool);
+
+    await dlqHandler({
+      id: 'dlq-ctx-id',
+      name: 'job_dead_letter_queue',
+      data: { name: '', id: 'orig-1' },
+    } as never);
+
+    const [, params] = mockPool.query.mock.calls[0] as [string, unknown[]];
+    expect(params[0]).toBe('unknown');
+  });
+
+  it('DLQ handler: falls back to "unknown" for empty‑string job id', async () => {
+    const mockPool = { query: vi.fn().mockResolvedValue({ rowCount: 1 }) };
+    const dlqHandler = await getDlqHandler(mockPool);
+
+    await dlqHandler({
+      id: 'dlq-ctx-id',
+      name: 'job_dead_letter_queue',
+      data: { name: 'some-job', id: '' },
+    } as never);
+
+    const [, params] = mockPool.query.mock.calls[0] as [string, unknown[]];
+    expect(params[1]).toBe('unknown');
+  });
+
+  // ── DLQ handler: both retrycount (lower) and retryCount (camel) ──────────
+
+  it('DLQ handler: prefers retrycount (lowercase) when both keys are present', async () => {
+    const mockPool = { query: vi.fn().mockResolvedValue({ rowCount: 1 }) };
+    const dlqHandler = await getDlqHandler(mockPool);
+
+    await dlqHandler({
+      id: 'dlq-ctx-id',
+      name: 'job_dead_letter_queue',
+      data: { name: 'j', id: 'id-both', retrycount: 7, retryCount: 3 },
+    } as never);
+
+    const [, params] = mockPool.query.mock.calls[0] as [string, unknown[]];
+    expect(params[4]).toBe(7);
+  });
+
+  // ── DLQ handler: output as non‑message object ────────────────────────────
+
+  it('DLQ handler: JSON‑stringifies output object without a message field', async () => {
+    const mockPool = { query: vi.fn().mockResolvedValue({ rowCount: 1 }) };
+    const dlqHandler = await getDlqHandler(mockPool);
+
+    await dlqHandler({
+      id: 'dlq-ctx-id',
+      name: 'job_dead_letter_queue',
+      data: { name: 'j', id: 'id-arr', output: ['array', 'error'] },
+    } as never);
+
+    const [, params] = mockPool.query.mock.calls[0] as [string, unknown[]];
+    expect(params[3]).toBe(JSON.stringify(['array', 'error']));
+  });
+
+  it('DLQ handler: JSON‑stringifies output when it is a number', async () => {
+    const mockPool = { query: vi.fn().mockResolvedValue({ rowCount: 1 }) };
+    const dlqHandler = await getDlqHandler(mockPool);
+
+    await dlqHandler({
+      id: 'dlq-ctx-id',
+      name: 'job_dead_letter_queue',
+      data: { name: 'j', id: 'id-num', output: 42 },
+    } as never);
+
+    const [, params] = mockPool.query.mock.calls[0] as [string, unknown[]];
+    expect(params[3]).toBe('42');
+  });
+
+  // ── DLQ handler: output.message as non‑string value ──────────────────────
+
+  it('DLQ handler: falls through to JSON.stringify when output.message is not a string', async () => {
+    const mockPool = { query: vi.fn().mockResolvedValue({ rowCount: 1 }) };
+    const dlqHandler = await getDlqHandler(mockPool);
+
+    await dlqHandler({
+      id: 'dlq-ctx-id',
+      name: 'job_dead_letter_queue',
+      data: { name: 'j', id: 'id-msg', output: { message: 99 } },
+    } as never);
+
+    const [, params] = mockPool.query.mock.calls[0] as [string, unknown[]];
+    expect(params[3]).toBe(JSON.stringify({ message: 99 }));
+  });
+
+  // ── DLQ handler: retryCount 0 when both keys are non‑numeric ─────────────
+
+  it('DLQ handler: defaults to 0 when retrycount is non‑numeric', async () => {
+    const mockPool = { query: vi.fn().mockResolvedValue({ rowCount: 1 }) };
+    const dlqHandler = await getDlqHandler(mockPool);
+
+    await dlqHandler({
+      id: 'dlq-ctx-id',
+      name: 'job_dead_letter_queue',
+      data: { name: 'j', id: 'id-nn', retrycount: 'bad' },
+    } as never);
+
+    const [, params] = mockPool.query.mock.calls[0] as [string, unknown[]];
+    expect(params[4]).toBe(0);
+  });
+});
+
+// ── DEAD_LETTER_QUEUE constant ────────────────────────────────────────────
+
+describe('DEAD_LETTER_QUEUE', () => {
+  it('exports a non‑empty string constant', async () => {
+    const { DEAD_LETTER_QUEUE } = await import('../../src/jobs/queue.js');
+    expect(typeof DEAD_LETTER_QUEUE).toBe('string');
+    expect(DEAD_LETTER_QUEUE.length).toBeGreaterThan(0);
+  });
+
+  it('is the queue name used by partition‑maintenance registration', async () => {
+    const mod = await import('../../src/jobs/queue.js');
+    expect(mod.DEAD_LETTER_QUEUE).toBe('job_dead_letter_queue');
+  });
+});
+
+// ── DEFAULT_DLQ_RETENTION_DAYS constant ──────────────────────────────────
+
+describe('DEFAULT_DLQ_RETENTION_DAYS', () => {
+  it('exports a positive integer', async () => {
+    const { DEFAULT_DLQ_RETENTION_DAYS } = await import('../../src/jobs/queue.js');
+    expect(typeof DEFAULT_DLQ_RETENTION_DAYS).toBe('number');
+    expect(DEFAULT_DLQ_RETENTION_DAYS).toBeGreaterThan(0);
+    expect(Number.isInteger(DEFAULT_DLQ_RETENTION_DAYS)).toBe(true);
+  });
+});
+
+// ── Validation: register ─────────────────────────────────────────────────
+
+describe('JobQueue – register validation', () => {
+  let mockBoss: ReturnType<typeof createMockBoss>;
+  let queue: JobQueue;
+
+  beforeEach(() => {
+    mockBoss = createMockBoss();
+    queue = JobQueue.withBoss(mockBoss as never);
+  });
+
+  it('throws TypeError for empty string name', () => {
+    expect(() => queue.register('', vi.fn())).toThrow(TypeError);
+  });
+
+  it('throws TypeError for whitespace‑only name', () => {
+    expect(() => queue.register('   ', vi.fn())).toThrow(TypeError);
+  });
+
+  it('throws TypeError for non‑string name', () => {
+    expect(() => queue.register(123 as never, vi.fn())).toThrow(TypeError);
+  });
+
+  it('throws TypeError when handler is not a function', () => {
+    expect(() => queue.register('valid-name', null as never)).toThrow(TypeError);
+    expect(() => queue.register('valid-name', undefined as never)).toThrow(TypeError);
+    expect(() => queue.register('valid-name', 'not-a-fn' as never)).toThrow(TypeError);
+  });
+
+  it('does NOT throw for valid arguments', () => {
+    expect(() => queue.register('valid-name', vi.fn())).not.toThrow();
+  });
+});
+
+// ── Validation: send ─────────────────────────────────────────────────────
+
+describe('JobQueue – send validation', () => {
+  let mockBoss: ReturnType<typeof createMockBoss>;
+  let queue: JobQueue;
+
+  beforeEach(() => {
+    mockBoss = createMockBoss();
+    queue = JobQueue.withBoss(mockBoss as never);
+  });
+
+  it('throws TypeError for empty string name', async () => {
+    await expect(queue.send('', {})).rejects.toThrow(TypeError);
+  });
+
+  it('throws TypeError for whitespace‑only name', async () => {
+    await expect(queue.send('   ', {})).rejects.toThrow(TypeError);
+  });
+
+  it('throws TypeError for non‑string name', async () => {
+    await expect(queue.send(123 as never, {})).rejects.toThrow(TypeError);
+  });
+
+  it('does NOT throw for valid arguments', async () => {
+    await expect(queue.send('valid-name', { foo: 'bar' })).resolves.toBe('job-id-123');
+  });
+});
+
+// ── Validation: schedule ─────────────────────────────────────────────────
+
+describe('JobQueue – schedule validation', () => {
+  let mockBoss: ReturnType<typeof createMockBoss>;
+  let queue: JobQueue;
+
+  beforeEach(() => {
+    mockBoss = createMockBoss();
+    queue = JobQueue.withBoss(mockBoss as never);
+  });
+
+  it('throws TypeError for empty string name', async () => {
+    await expect(queue.schedule('', '0 * * * *')).rejects.toThrow(TypeError);
+  });
+
+  it('throws TypeError for empty string cron', async () => {
+    await expect(queue.schedule('my-job', '')).rejects.toThrow(TypeError);
+  });
+
+  it('throws TypeError for whitespace‑only cron', async () => {
+    await expect(queue.schedule('my-job', '   ')).rejects.toThrow(TypeError);
+  });
+
+  it('does NOT throw for valid arguments', async () => {
+    await expect(queue.schedule('my-job', '0 * * * *')).resolves.toBeUndefined();
+  });
+});
+
+// ── Validation: toSendOptions ────────────────────────────────────────────
+
+describe('JobQueue – toSendOptions validation', () => {
+  let queue: JobQueue;
+
+  beforeEach(() => {
+    queue = JobQueue.withBoss(createMockBoss() as never);
+  });
+
+  it('throws TypeError for negative retryLimit', async () => {
+    await expect(queue.send('test', {}, { retryLimit: -1 })).rejects.toThrow(TypeError);
+  });
+
+  it('throws TypeError for NaN retryLimit', async () => {
+    await expect(queue.send('test', {}, { retryLimit: NaN })).rejects.toThrow(TypeError);
+  });
+
+  it('throws TypeError for negative retryDelay', async () => {
+    await expect(queue.send('test', {}, { retryDelay: -5 })).rejects.toThrow(TypeError);
+  });
+
+  it('throws TypeError for negative expireInSeconds', async () => {
+    await expect(queue.send('test', {}, { expireInSeconds: -1 })).rejects.toThrow(TypeError);
+  });
+
+  it('throws TypeError for empty deadLetter string', async () => {
+    await expect(queue.send('test', {}, { deadLetter: '' })).rejects.toThrow(TypeError);
+  });
+
+  it('passes retryDelayMax to boss.send', async () => {
+    const mockBoss = createMockBoss();
+    const q = JobQueue.withBoss(mockBoss as never);
+    await q.send('test', {}, { retryDelayMax: 300 });
+    expect(mockBoss.send).toHaveBeenCalledWith(
+      'test',
+      {},
+      expect.objectContaining({ retryDelayMax: 300 }),
+    );
+  });
+
+  it('passes startAfter as a Date object', async () => {
+    const mockBoss = createMockBoss();
+    const q = JobQueue.withBoss(mockBoss as never);
+    const future = new Date(Date.now() + 3600000);
+    await q.send('test', {}, { startAfter: future });
+    expect(mockBoss.send).toHaveBeenCalledWith(
+      'test',
+      {},
+      expect.objectContaining({ startAfter: future }),
+    );
+  });
+
+  it('passes startAfter as a number (Unix seconds)', async () => {
+    const mockBoss = createMockBoss();
+    const q = JobQueue.withBoss(mockBoss as never);
+    await q.send('test', {}, { startAfter: 3600 });
+    expect(mockBoss.send).toHaveBeenCalledWith(
+      'test',
+      {},
+      expect.objectContaining({ startAfter: 3600 }),
+    );
+  });
+});
+
+// ── purgeJobDeadLetter ───────────────────────────────────────────────────
+
+describe('purgeJobDeadLetter', () => {
+  it('executes DELETE with default retention days', async () => {
+    const mod = await import('../../src/jobs/queue.js');
+    const mockPool = { query: vi.fn().mockResolvedValue({ rowCount: 5 }) };
+    const deleted = await mod.purgeJobDeadLetter(mockPool as never);
+    expect(deleted).toBe(5);
+    expect(mockPool.query).toHaveBeenCalledWith(
+      expect.stringContaining('DELETE FROM job_dead_letter'),
+      [mod.DEFAULT_DLQ_RETENTION_DAYS],
+    );
+  });
+
+  it('executes DELETE with custom retention days', async () => {
+    const mod = await import('../../src/jobs/queue.js');
+    const mockPool = { query: vi.fn().mockResolvedValue({ rowCount: 3 }) };
+    const deleted = await mod.purgeJobDeadLetter(mockPool as never, 30);
+    expect(deleted).toBe(3);
+    expect(mockPool.query).toHaveBeenCalledWith(
+      expect.stringContaining('DELETE FROM job_dead_letter'),
+      [30],
+    );
+  });
+
+  it('returns 0 when no rows match', async () => {
+    const mod = await import('../../src/jobs/queue.js');
+    const mockPool = { query: vi.fn().mockResolvedValue({ rowCount: 0 }) };
+    const deleted = await mod.purgeJobDeadLetter(mockPool as never, 7);
+    expect(deleted).toBe(0);
+  });
+
+  it('throws for null pool', async () => {
+    const mod = await import('../../src/jobs/queue.js');
+    await expect(mod.purgeJobDeadLetter(null)).rejects.toThrow('requires a valid PostgreSQL pool');
+  });
+
+  it('throws for negative retentionDays', async () => {
+    const mod = await import('../../src/jobs/queue.js');
+    const mockPool = { query: vi.fn() };
+    await expect(mod.purgeJobDeadLetter(mockPool as never, -1)).rejects.toThrow(TypeError);
+  });
+
+  it('throws for NaN retentionDays', async () => {
+    const mod = await import('../../src/jobs/queue.js');
+    const mockPool = { query: vi.fn() };
+    await expect(mod.purgeJobDeadLetter(mockPool as never, NaN)).rejects.toThrow(TypeError);
+  });
+});
+
+// ── DLQ retention purge integration in partition maintenance ──────────────
+
+describe('partition-maintenance DLQ purge integration', () => {
+  beforeEach(async () => {
+    const { setJobQueue } = await import('../../src/jobs/queue.js');
+    setJobQueue(null);
+    vi.restoreAllMocks();
+  });
+
+  /** Extract the partition‑maintenance handler registered by startBackgroundJobs. */
+  async function getPmHandler(mockPool: { query: ReturnType<typeof vi.fn> }) {
+    const mod = await import('../../src/jobs/queue.js');
+    const registerSpy = vi.spyOn(mod.JobQueue.prototype, 'register');
+    vi.spyOn(mod.JobQueue.prototype, 'start').mockResolvedValue(undefined);
+    vi.spyOn(mod.JobQueue.prototype, 'schedule').mockResolvedValue(undefined);
+    vi.spyOn(mod.JobQueue.prototype, 'send').mockResolvedValue(null);
+    mod.startBackgroundJobs(mockPool as never);
+    const call = registerSpy.mock.calls.find((c) => c[0] === 'partition-maintenance');
+    return { handler: call![1], mod };
+  }
+
+  it('calls purgeJobDeadLetter during partition-maintenance handler', async () => {
+    // First query returns advisory-lock success; all subsequent queries
+    // return empty rows (table not managed, advisory unlock, DLQ purge).
+    const mockPool = { query: vi.fn() };
+    mockPool.query.mockResolvedValueOnce({ rows: [{ pg_try_advisory_lock: true }], rowCount: 1 });
+    mockPool.query.mockResolvedValue({ rows: [], rowCount: 0 });
+
+    const { handler, mod } = await getPmHandler(mockPool);
+
+    await handler({ id: 'pm-test', name: 'partition-maintenance', data: {} } as never);
+
+    expect(mockPool.query).toHaveBeenCalledWith(
+      expect.stringContaining('DELETE FROM job_dead_letter'),
+      [mod.DEFAULT_DLQ_RETENTION_DAYS],
+    );
+  });
+
+  it('does not throw when partition-maintenance DLQ purge fails', async () => {
+    const mockPool = { query: vi.fn().mockResolvedValue({ rows: [], rowCount: 0 }) };
+    mockPool.query.mockResolvedValueOnce({ rows: [{ pg_try_advisory_lock: true }], rowCount: 1 });
+
+    const { handler, mod } = await getPmHandler(mockPool);
+    vi.spyOn(mod, 'purgeJobDeadLetter').mockRejectedValue(new Error('DB down'));
+
+    // Must not throw — DLQ purge errors are swallowed
+    await expect(
+      handler({ id: 'pm-test', name: 'partition-maintenance', data: {} } as never),
+    ).resolves.toBeUndefined();
+  });
 });


### PR DESCRIPTION
## Summary

Enforces input validation, DLQ retention purge, size budgets, pool validation, and comprehensive tests for the job queue dead-letter handling flow.

## Changes

### `src/jobs/queue.ts`
- Add validation to register(), send(), schedule(), and toSendOptions() to catch programming errors early with descriptive TypeError messages.
- Add purgeJobDeadLetter() to clean up expired job_dead_letter entries according to a configurable retention period (default 90 days).
- Integrate DLQ purge into the daily partition-maintenance job so old entries are bounded without a dedicated cron.
- **Export `DLQ_MAX_ERROR_BYTES` and `DLQ_MAX_PAYLOAD_BYTES`** constants so callers and tests can reference the canonical budgets.
- **Add `truncateUtf8()` utility** that safely truncates a UTF-8 string to a given byte limit without breaking multi-byte character boundaries.
- **Apply size budgets in the DLQ handler** before persisting to `job_dead_letter`: error messages exceeding 2048 bytes are truncated; payloads serialising to more than 64 KiB are replaced with `{ _truncated: true }`.
- **Add pool validation** in `startBackgroundJobs()`: throws `TypeError` when `pool.query` is not a function.

### `tests/jobs/queue.test.ts`
- 39 tests from the initial commit covering validation, DLQ edge cases (empty-string name/id, both retrycount formats, non-message output shapes), purgeJobDeadLetter behavior, and partition-maintenance integration.
- **14 additional tests** covering: error message truncation, multi-byte character safety, oversized payload replacement, circular reference handling, null payload preservation, and pool validation.

Closes #1066
Closes #1058
Closes #1061