### PR TITLE
fix(sdk): refine SDK generation contract and lock refinements with regression tests (#1055)

### DIFF
--- a/scripts/generate-sdk-ts.mjs
+++ b/scripts/generate-sdk-ts.mjs
@@ -732,6 +732,8 @@ export interface ListStreamsParams {
   recipient?: string;
   /** When \`true\`, include \`total\` count in the response. */
   include_total?: boolean;
+  /** Maximum pages to auto-paginate (default 10 000). */
+  maxPages?: number;
 }
 `;
 }
@@ -1205,10 +1207,34 @@ function generatePagination() {
  * treat them as black boxes — do not construct or decode manually.
  * See \`docs/openapi/README.md\` for the full cursor protocol.
  *
+ * ## Retry idempotency
+ * When a page fetch fails, the internal cursor is **not** advanced — the next
+ * call to \`nextPage()\` retries the same logical page. This makes pagination
+ * fully idempotent under transient network failures.
+ *
+ * ## Concurrency guard
+ * \`nextPage()\` rejects with \`ValidationError\` if a fetch is already in-flight
+ * for this paginator, preventing interleaved cursor mutations.
+ *
+ * ## Page-limit safety
+ * \`autoPaginate()\` stops after \`maxPages\` pages (default 10 000) to prevent
+ * infinite iteration against a misbehaving server that never sets \`has_more\`
+ * to \`false\`.
+ *
  * @module @fluxora/sdk/pagination
  */
 
 import type { Stream, ListStreamsParams, StreamListResponse } from './types.js';
+import { ValidationError } from './errors.js';
+
+/** Default page size returned when \`limit\` is omitted. */
+export const DEFAULT_PAGE_LIMIT = 20;
+/** Minimum allowed page size. */
+export const MIN_PAGE_LIMIT = 1;
+/** Maximum allowed page size (server-enforced). */
+export const MAX_PAGE_LIMIT = 100;
+/** Default safety cap on pages fetched by \`autoPaginate()\`. */
+export const DEFAULT_MAX_PAGES = 10_000;
 
 /**
  * Cursor-based paginator for the GET /api/streams endpoint.
@@ -1234,11 +1260,16 @@ export class StreamPaginator {
   private readonly sender?: string;
   private readonly recipient?: string;
   private readonly includeTotal: boolean;
+  private readonly maxPages: number;
 
   /** Opaque cursor from the last response; \`null\` = start of sequence. */
   private nextCursor: string | null = null;
   /** \`false\` once the server signals no more pages. */
   private hasMore = true;
+  /** Tracks total pages fetched across all calls. */
+  private pagesFetchedCount = 0;
+  /** Guards against concurrent \`nextPage()\` calls. */
+  private inFlight = false;
 
   /**
    * @param fetchPage - Calls the API and returns a \`StreamListResponse\`.
@@ -1249,16 +1280,32 @@ export class StreamPaginator {
     fetchPage: (params: ListStreamsParams) => Promise<StreamListResponse>,
     params: ListStreamsParams = {},
   ) {
-    const limit = params.limit ?? 20;
-    if (limit < 1 || limit > 100) {
+    const limit = params.limit ?? DEFAULT_PAGE_LIMIT;
+    if (limit < MIN_PAGE_LIMIT || limit > MAX_PAGE_LIMIT) {
       throw new Error('limit must be an integer between 1 and 100 per paginationSchema');
     }
     this.fetchPage = fetchPage;
     this.limit = limit;
+    this.maxPages = params.maxPages ?? DEFAULT_MAX_PAGES;
     this.status = params.status;
     this.sender = params.sender;
     this.recipient = params.recipient;
     this.includeTotal = params.include_total ?? false;
+  }
+
+  /** The most recent opaque cursor, or \`null\` before the first fetch. */
+  get currentCursor(): string | null {
+    return this.nextCursor;
+  }
+
+  /** Whether the server may have more pages. */
+  get hasMorePages(): boolean {
+    return this.hasMore;
+  }
+
+  /** Total number of pages fetched so far. */
+  get pagesFetched(): number {
+    return this.pagesFetchedCount;
   }
 
   /**
@@ -1266,34 +1313,44 @@ export class StreamPaginator {
    *
    * @returns Array of \`Stream\` objects for this page, or \`null\` when all
    *          pages have been consumed (\`has_more\` was \`false\`).
+   * @throws {ValidationError} When a fetch is already in-flight.
    */
   async nextPage(): Promise<Stream[] | null> {
+    if (this.inFlight) {
+      throw new ValidationError('A pagination request is already in flight');
+    }
     if (!this.hasMore) return null;
 
-    const response = await this.fetchPage({
-      limit: this.limit,
-      cursor: this.nextCursor ?? undefined,
-      status: this.status,
-      sender: this.sender,
-      recipient: this.recipient,
-      include_total: this.includeTotal,
-    });
+    this.inFlight = true;
+    try {
+      const response = await this.fetchPage({
+        limit: this.limit,
+        cursor: this.nextCursor ?? undefined,
+        status: this.status,
+        sender: this.sender,
+        recipient: this.recipient,
+        include_total: this.includeTotal,
+      });
 
-    const pageData = response.data;
-    const streams: Stream[] = pageData?.streams ?? [];
-    const hasMore: boolean = pageData?.has_more ?? false;
-    const nextCursor: string | null =
-      pageData?.next_cursor ??
-      (response.meta?.next_cursor as string | null | undefined) ??
-      null;
+      const pageData = response.data;
+      const streams: Stream[] = pageData?.streams ?? [];
+      const hasMore: boolean = pageData?.has_more ?? false;
+      const nextCursor: string | null =
+        pageData?.next_cursor ??
+        (response.meta?.next_cursor as string | null | undefined) ??
+        null;
 
-    if (nextCursor && hasMore) {
-      this.nextCursor = nextCursor;
-    } else {
-      this.hasMore = false;
+      if (nextCursor && hasMore) {
+        this.nextCursor = nextCursor;
+      } else {
+        this.hasMore = false;
+      }
+
+      this.pagesFetchedCount++;
+      return streams;
+    } finally {
+      this.inFlight = false;
     }
-
-    return streams;
   }
 
   /**
@@ -1302,10 +1359,13 @@ export class StreamPaginator {
    * Pagination terminates automatically when the server has no more results.
    * A \`break\` inside \`for await\` stops iteration without fetching further pages.
    *
+   * A safety cap of \`maxPages\` (default 10 000) prevents infinite iteration
+   * against a misbehaving server.
+   *
    * @yields \`Stream\` objects one at a time.
    */
   async *autoPaginate(): AsyncGenerator<Stream, void, unknown> {
-    while (this.hasMore) {
+    while (this.hasMore && this.pagesFetchedCount < this.maxPages) {
       const page = await this.nextPage();
       if (!page) break;
       for (const item of page) {
@@ -1316,6 +1376,7 @@ export class StreamPaginator {
 }
 `;
 }
+
 
 // ── src/client.ts ─────────────────────────────────────────────────────────────
 

--- a/tests/sdk/sdkGenerationContract.test.ts
+++ b/tests/sdk/sdkGenerationContract.test.ts
@@ -1,0 +1,229 @@
+/**
+ * Regression tests for the Fluxora SDK Generation Contract.
+ *
+ * Issue: GitHub #1055 — "Refine SDK generation contract"
+ * Refines the contract between `scripts/generate-sdk-ts.mjs` and the on-disk
+ * files under `sdk/typescript/`. These tests pin the contract down so future
+ * contributors cannot silently revert the refined behavior.
+ *
+ * Two layers of assertions:
+ *  1. Generator-on-disk parity: `node scripts/generate-sdk-ts.mjs --check`
+ *     must report zero drift (exit 0).
+ *  2. Refined surface: the on-disk files expose the documented safety
+ *     refinements (DEFAULT_PAGE_LIMIT/MAX_PAGE_LIMIT/DEFAULT_MAX_PAGES,
+ *     inFlight ValidationError guard, hasMorePages/currentCursor/pagesFetched
+ *     getters, maxPages cap on autoPaginate, and the idempotency_replayed
+ *     envelope alias).
+ *
+ * @see sdk/typescript/README.md for the human-readable contract.
+ */
+
+import { spawnSync } from 'node:child_process';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, it, expect } from 'vitest';
+
+import {
+  FluxoraApiError,
+  ValidationError,
+  StreamPaginator,
+  DEFAULT_PAGE_LIMIT,
+  MIN_PAGE_LIMIT,
+  MAX_PAGE_LIMIT,
+  DEFAULT_MAX_PAGES,
+  canonicalizeBody,
+  generateIdempotencyKey,
+} from '../../sdk/typescript/src/index.js';
+
+import type {
+  ResponseMeta,
+  ListStreamsParams,
+  StreamListResponse,
+} from '../../sdk/typescript/src/types.js';
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+/**
+ * Build a one-page response wrapper used by paginator tests.
+ *
+ * @param streams  streams on this page
+ * @param hasMore  whether more pages exist
+ * @param cursor   next opaque cursor to forward
+ */
+function makePage(
+  streams: Array<{ id: string }>,
+  hasMore: boolean,
+  cursor: string | null,
+): StreamListResponse {
+  return {
+    success: true,
+    data: {
+      streams: streams as unknown as StreamListResponse['data']['streams'],
+      has_more: hasMore,
+      next_cursor: cursor,
+    },
+    meta: { timestamp: '2026-01-01T00:00:00Z' },
+  };
+}
+
+// ── 1. Generator <-> on-disk parity ─────────────────────────────────────────
+
+describe('SDK Generation Contract — generator parity', () => {
+  it('node scripts/generate-sdk-ts.mjs --check exits 0 with no drift', () => {
+    // Resolve the project root from this test file's location so the spawn
+    // works even when vitest is invoked from a subdirectory.
+    const projectRoot = path.resolve(fileURLToPath(import.meta.url), '../../..');
+    const result = spawnSync('node', ['scripts/generate-sdk-ts.mjs', '--check'], {
+      cwd: projectRoot,
+      encoding: 'utf8',
+    });
+    if (result.status !== 0) {
+      // Surface every line so a regression is debuggable from CI logs.
+      const stdout = (result.stdout ?? '').toString();
+      const stderr = (result.stderr ?? '').toString();
+      throw new Error(
+        [
+          `Drift check reported a mismatch (exit=${result.status}).`,
+          '--- stdout ---',
+          stdout,
+          '--- stderr ---',
+          stderr,
+        ].join('\n'),
+      );
+    }
+    expect(result.status).toBe(0);
+    expect((result.stdout ?? '')).toMatch(/DRIFT CHECK PASSED/);
+    expect((result.stderr ?? '')).not.toMatch(/DRIFT DETECTED/);
+  });
+});
+
+// ── 2. Refined surface — pagination constants and getters ───────────────────
+
+describe('SDK Generation Contract — pagination safety refinements', () => {
+  it('exports the documented page-limit constants with the documented defaults', () => {
+    expect(DEFAULT_PAGE_LIMIT).toBe(20);
+    expect(MIN_PAGE_LIMIT).toBe(1);
+    expect(MAX_PAGE_LIMIT).toBe(100);
+    expect(DEFAULT_MAX_PAGES).toBe(10_000);
+  });
+
+  it('ListStreamsParams includes the maxPages field on the refined contract', () => {
+    // Pure type-level check via assignment: this would fail to compile if the
+    // field were removed.
+    const params: ListStreamsParams = {
+      limit: 25,
+      status: 'active',
+      maxPages: 250,
+    };
+    expect(params.maxPages).toBe(250);
+  });
+
+  it('StreamPaginator exposes currentCursor / hasMorePages / pagesFetched getters', async () => {
+    const pages: StreamListResponse[] = [
+      makePage([{ id: 'a' }], true, 'CURSOR-1'),
+      makePage([{ id: 'b' }], false, null),
+    ];
+    let i = 0;
+    const fetchPage = async (): Promise<StreamListResponse> => pages[i++];
+
+    const paginator = new StreamPaginator(fetchPage, { limit: 1 });
+    expect(paginator.currentCursor).toBeNull();
+    expect(paginator.hasMorePages).toBe(true);
+    expect(paginator.pagesFetched).toBe(0);
+
+    const first = await paginator.nextPage();
+    expect(first?.map((s) => s.id)).toEqual(['a']);
+    expect(paginator.currentCursor).toBe('CURSOR-1');
+    expect(paginator.hasMorePages).toBe(true);
+    expect(paginator.pagesFetched).toBe(1);
+
+    const second = await paginator.nextPage();
+    expect(second?.map((s) => s.id)).toEqual(['b']);
+    expect(paginator.hasMorePages).toBe(false);
+    expect(paginator.pagesFetched).toBe(2);
+
+    const third = await paginator.nextPage();
+    expect(third).toBeNull();
+    expect(paginator.pagesFetched).toBe(2); // No fetch on empty tail.
+  });
+
+  it('nextPage() rejects with ValidationError when a fetch is already in-flight', async () => {
+    // First fetch hangs forever; second nextPage() must reject immediately.
+    let resolveFirst!: () => void;
+    const fetchPage = (): Promise<StreamListResponse> =>
+      new Promise<StreamListResponse>((r) => {
+        resolveFirst = () =>
+          r(makePage([{ id: 'x' }], false, null));
+      });
+
+    const paginator = new StreamPaginator(fetchPage, { limit: 1 });
+    const inFlight = paginator.nextPage();
+    // Now any concurrent nextPage() must reject with ValidationError.
+    await expect(paginator.nextPage()).rejects.toBeInstanceOf(ValidationError);
+    // Release the first (so the test doesn't leak promises).
+    resolveFirst();
+    await inFlight;
+  });
+
+  it('autoPaginate() caps iteration by maxPages to prevent infinite loops', async () => {
+    // Synthetic page factory — always says "more pages" so a missing cap
+    // would loop forever. The cap must stop iteration.
+    let calls = 0;
+    const fetchPage = async (): Promise<StreamListResponse> => {
+      calls += 1;
+      return makePage([{ id: `s-${calls}` }], true, `cursor-${calls}`);
+    };
+    const paginator = new StreamPaginator(fetchPage, { limit: 1, maxPages: 3 });
+    const collected: string[] = [];
+    for await (const stream of paginator.autoPaginate()) {
+      collected.push(stream.id);
+    }
+    expect(collected.length).toBe(3);
+    expect(collected).toEqual(['s-1', 's-2', 's-3']);
+    expect(paginator.pagesFetched).toBe(3);
+  });
+});
+
+// ── 3. Refined surface — idem alias and helpers ──────────────────────────────
+
+describe('SDK Generation Contract — response envelope and helpers', () => {
+  it('ResponseMeta accepts both metadata and alias idempotency_replayed flags', () => {
+    // Type-level assignment. If either alias is removed, this fails to compile.
+    const meta: ResponseMeta = {
+      timestamp: '2026-01-01T00:00:00Z',
+      requestId: 'req-1',
+      idempotency_replayed: true, // primary
+      idempotencyReplayed: false, // alias used on envelopes
+    };
+    expect(meta.idempotency_replayed).toBe(true);
+    expect(meta.idempotencyReplayed).toBe(false);
+  });
+
+  it('FluxoraApiError preserves statusCode/code/requestId/message for diagnostics', () => {
+    const err = new FluxoraApiError(503, 'SERVICE_UNAVAILABLE', 'shutting down', undefined, 'req-xyz');
+    expect(err).toBeInstanceOf(Error);
+    expect(err.statusCode).toBe(503);
+    expect(err.code).toBe('SERVICE_UNAVAILABLE');
+    expect(err.requestId).toBe('req-xyz');
+    expect(err.message).toContain('503');
+    expect(err.name).toBe('FluxoraApiError');
+  });
+
+  it('canonicalizeBody is order-independent so fingerprint is deterministic', () => {
+    const a = canonicalizeBody({ z: 1, a: { y: 2, b: 3 } });
+    const b = canonicalizeBody({ a: { b: 3, y: 2 }, z: 1 });
+    expect(a).toBe(b);
+  });
+
+  it('generateIdempotencyKey returns a fresh UUID v4 string on each call', () => {
+    const a = generateIdempotencyKey();
+    const b = generateIdempotencyKey();
+    expect(a).not.toBe(b);
+    expect(a).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i,
+    );
+    expect(b).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i,
+    );
+  });
+});


### PR DESCRIPTION
## Summary

The TypeScript SDK under `sdk/typescript/` had drifted from the output of `scripts/generate-sdk-ts.mjs`, breaking the SDK generation contract that specifies `pnpm check:sdk:ts` as the source of truth for parity.

## Drift before this PR

```
[DRIFT CHECK] Checking TypeScript SDK files in .../sdk/typescript...
[DRIFT DETECTED] Content mismatch: src/types.ts
[DRIFT DETECTED] Content mismatch: src/pagination.ts
[DRIFT CHECK FAILED] Run `pnpm generate:sdk:ts` and commit the result.
```

Two specific gaps:

1. `sdk/typescript/src/types.ts` exposed `maxPages?: number` on `ListStreamsParams`, but `generateTypes()` did not emit it. The drift check would silently flag this every time `pnpm check:sdk:ts` was run.
2. `sdk/typescript/src/pagination.ts` had been hand-stabilized in the recent pagination stabilization PR (`currentCursor`, `hasMorePages`, `pagesFetched` getters, the constants `DEFAULT_PAGE_LIMIT`/`MIN_PAGE_LIMIT`/`MAX_PAGE_LIMIT`/`DEFAULT_MAX_PAGES`, an `inFlight` ValidationError guard for concurrent `nextPage()` calls, and a `maxPages` safety cap on `autoPaginate()`), but `generatePagination()` in the script did not embed those refinements. A regeneration would silently revert them.

## Fix

* `generateTypes()` now emits `maxPages?: number` on `ListStreamsParams` (using U+202F narrow no-break space to match the on-disk format byte-exactly).
* `generatePagination()` now embeds the canonical `sdk/typescript/src/pagination.ts` as a JS template-literal string with `\``, `\`, and `${...}` escape rules applied in that order (so future `${}` interpolations do not double-escape).
* After this patch, `node scripts/generate-sdk-ts.mjs --check` reports `[DRIFT CHECK PASSED]` (exit 0). Verified locally.

## Tests added

`tests/sdk/sdkGenerationContract.test.ts` (10 regression cases) pins the refinements:

1. `node scripts/generate-sdk-ts.mjs --check` exits 0 (drift check).
2. `DEFAULT_PAGE_LIMIT=20`, `MIN_PAGE_LIMIT=1`, `MAX_PAGE_LIMIT=100`, `DEFAULT_MAX_PAGES=10_000` exported.
3. `ListStreamsParams.maxPages` field present (type + runtime).
4. `StreamPaginator` exposes `currentCursor`/`hasMorePages`/`pagesFetched` getters.
5. `nextPage()` rejects with `ValidationError` when already in-flight.
6. `autoPaginate()` caps iteration by `maxPages`.
7. `ResponseMeta` accepts both `idempotency_replayed` AND `idempotencyReplayed` aliases.
8. `FluxoraApiError` diagnostic fields and `instanceof` semantics.
9. `canonicalizeBody` order-independence (deterministic fingerprint).
10. `generateIdempotencyKey` returns UUID v4.

Test was run via `pnpm vitest run tests/sdk/sdkGenerationContract.test.ts` — 10/10 pass in 126 ms.

## Acceptance criteria from #1055

* ✅ Existing API/service behavior is preserved (drift check exits 0 means generator produces byte-identical SDK).
* ✅ Edge cases are documented and covered by tests (see above).
* ✅ Stays backward compatible with the current backend release (the on-disk canonical files were already in this state; this PR only restores the script-side tooling that maintains them).

## Out of scope (follow-up issues to file)

* Convert the embedded `pagination.ts` copy into a runtime `fs.readFileSync` within `generateTypeScriptSdk()` so the script auto-syncs with the on-disk file instead of relying on the patch.
* Pre-existing failure in `src/webhooks/dispatcher.ts(586,5)` (orphan `} catch` clause) is not addressed in this PR — confirmed unrelated by `git stash; pnpm typecheck` reproducing the same failure on `main`.

Closes #1055