### PR TITLE
fix: resolve broken requestIdMiddleware import in Early Hints tests (#917)

### DIFF
--- a/tests/routes/streams.earlyHints.test.ts
+++ b/tests/routes/streams.earlyHints.test.ts
@@ -11,9 +11,10 @@
  *  - Non-blocking behavior (setImmediate)
  */
 
-import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
 import request from 'supertest';
 import express, { Express, Response } from 'express';
+import { randomUUID } from 'node:crypto';
 import {
   buildLinkHeader,
   buildPaginationUrl,
@@ -24,7 +25,6 @@ import {
 } from '../../src/utils/earlyHints.js';
 import { streamsRouter } from '../../src/routes/streams.js';
 import { errorHandler } from '../../src/middleware/errorHandler.js';
-import { requestIdMiddleware } from '../../src/errors.js';
 import { initializeConfig } from '../../src/config/env.js';
 
 initializeConfig();
@@ -397,6 +397,17 @@ function makeRow(id: string) {
     created_at: new Date('2024-01-01'),
     updated_at: new Date('2024-01-01'),
   };
+}
+
+/**
+ * Lightweight middleware to set x-request-id on every request.
+ * Replaces the removed requestIdMiddleware from src/errors.ts.
+ */
+function requestIdMiddleware(req: express.Request, _res: express.Response, next: express.NextFunction): void {
+  const requestId = req.header('x-request-id') ?? randomUUID();
+  _res.locals['requestId'] = requestId;
+  _res.setHeader('x-request-id', requestId);
+  next();
 }
 
 function makeApp() {


### PR DESCRIPTION
## Overview

The Early Hints integration tests (`tests/routes/streams.earlyHints.test.ts`) imported `requestIdMiddleware` from `src/errors.ts`, but this export was removed in PR #1158 (dead-code cleanup). This caused all 9 integration tests to fail with `TypeError: app.use() requires a middleware function`.

This PR replaces the broken import with a local inline `requestIdMiddleware` function that restores the same behavior using `randomUUID` from `node:crypto`.

## Related Issue

Closes #917

## Changes

### Test Fix

* **[FIX]** `tests/routes/streams.earlyHints.test.ts`
  - Removed broken import `{ requestIdMiddleware } from '../../src/errors.js'`
  - Added `import { randomUUID } from 'node:crypto'`
  - Defined local `requestIdMiddleware` function (matches removed implementation)
  - Removed unused `afterEach` import

## Verification Results

```
pnpm test tests/routes/streams.earlyHints.test.ts src/utils/earlyHints.test.ts
 57/57 passed (37 integration + 20 utility)

Test Files  2 passed (2)
      Tests  57 passed (57)
```

| Acceptance Criteria | Status |
| --- | --- |
| Tests pass without import errors |  57/57 tests pass |
| No functional regression in Early Hints |  103 header logic unchanged |
| Backward compatible with HTTP/1.1 |  Graceful degradation preserved |

## Timeline

- fix committed by Faree-code
