### PR TITLE
feat: add RED metrics for indexer batch processing loop

### DIFF
--- a/docs/observability.md
+++ b/docs/observability.md
@@ -437,3 +437,132 @@ groups:
 | Metric Name | Type | Description | Buckets / Labels |
 | :--- | :--- | :--- | :--- |
 | `fluxora_ws_broadcast_batch_flush_seconds` | Histogram | Latency in seconds from enqueuing the oldest event in a batch to flushing the batch frame over the WebSocket. | `[0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5]` |
+
+---
+
+## Indexer Batch RED Metrics
+
+The indexer's per-ledger-batch processing step in `src/indexer/service.ts` is
+instrumented with a Rate / Errors / Duration triad defined in
+`src/metrics/indexerRed.ts`. It deliberately mirrors the HTTP RED metrics
+(`http_requests_total` / `http_request_duration_seconds`) so an indexer
+dashboard can reuse the same PromQL shapes and panel layouts as the HTTP one.
+
+### Metric-to-metric parity with HTTP
+
+| Concern | HTTP | Indexer batch |
+| :--- | :--- | :--- |
+| Rate | `http_requests_total` | `indexer_batches_processed_total` |
+| Errors | 5xx slice of `http_requests_total` | `indexer_batch_errors_total` |
+| Duration | `http_request_duration_seconds` | `indexer_batch_duration_seconds` |
+| "which work" label | `route` | `contract_id` |
+| "what happened" label | `status_code` | `outcome` |
+
+### Metrics
+
+| Metric Name | Type | Description | Labels / Buckets |
+| :--- | :--- | :--- | :--- |
+| `indexer_batches_processed_total` | Counter | Every batch processing step executed, successful or not. | `contract_id`, `outcome` (`success` \| `error`) |
+| `indexer_batch_errors_total` | Counter | Batch processing steps that threw. | `contract_id`, `error_source` (`stellar_rpc` \| `local`), `error_type` |
+| `indexer_batch_duration_seconds` | Histogram | Wall-clock duration of one batch processing step. | `contract_id`, `outcome`; buckets `[0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 30, 60]` |
+
+**What counts as one batch processing step?** One iteration of the `replayEvents`
+loop body that calls `processBatch` — fetch the batch, insert into
+`contract_events`, advance the cursor, `COMMIT`. Loop guards (shutdown,
+leadership, replay budget) run *outside* the timer, so the histogram measures
+work rather than control flow.
+
+A batch that fetched zero rows (source exhausted ahead of the counted total) is
+still recorded as one `success`: a unit of work was performed. This is the one
+place where `indexer_batches_processed_total` can exceed the pre-existing
+`indexer_replay_batches_committed_total`, which counts only batches that reached
+`COMMIT`.
+
+### `error_source` — upstream vs. local failures
+
+The `error_source` label answers "is this our problem or the RPC provider's?"
+without opening a log.
+
+| `error_source` | Origin | `error_type` values |
+| :--- | :--- | :--- |
+| `stellar_rpc` | A call into `src/services/stellar-rpc.ts` failed. Retrying the indexer will not help until the provider recovers. | `timeout`, `network`, `provider`, `circuit_open`, `cancelled` |
+| `local` | The failure was raised inside the indexer process. Actionable by the indexer owner. | `db_pool_exhausted`, `db_query_timeout`, `db_duplicate_entry`, `db_error`, `unknown` |
+
+`error_type` for `stellar_rpc` mirrors the `RpcFailureKind` union exported by
+`src/services/stellar-rpc.ts` (lower-snake-cased). Classification is structural
+— it matches on the error's `name` and `kind`, so a `RpcProviderError` rethrown
+by an intermediate layer is still attributed to `stellar_rpc`.
+
+Every increment of `indexer_batch_errors_total` is paired with an
+`outcome="error"` increment of `indexer_batches_processed_total`, so the error
+ratio is well-defined against either denominator.
+
+### Dashboard queries
+
+```promql
+# Rate — batches/sec being processed, per contract
+sum(rate(indexer_batches_processed_total[5m])) by (contract_id)
+
+# Errors — overall error ratio
+sum(rate(indexer_batch_errors_total[5m]))
+  / sum(rate(indexer_batches_processed_total[5m]))
+
+# Errors — is it us or the provider?
+sum(rate(indexer_batch_errors_total[5m])) by (error_source, error_type)
+
+# Duration — p50 / p95 / p99 of a batch
+histogram_quantile(0.50, sum(rate(indexer_batch_duration_seconds_bucket[5m])) by (le))
+histogram_quantile(0.95, sum(rate(indexer_batch_duration_seconds_bucket[5m])) by (le))
+histogram_quantile(0.99, sum(rate(indexer_batch_duration_seconds_bucket[5m])) by (le))
+```
+
+### Suggested alerts
+
+```yaml
+groups:
+  - name: indexer-red
+    rules:
+      - alert: IndexerBatchErrorRateHigh
+        expr: |
+          sum(rate(indexer_batch_errors_total[5m]))
+            / sum(rate(indexer_batches_processed_total[5m])) > 0.05
+        for: 10m
+        labels:
+          severity: warning
+        annotations:
+          summary: "More than 5% of indexer batches are failing"
+
+      - alert: IndexerUpstreamRpcDegraded
+        expr: sum(rate(indexer_batch_errors_total{error_source="stellar_rpc"}[5m])) > 0
+        for: 15m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Indexer batches failing on Stellar RPC ({{ $labels.error_type }}) — upstream, not local"
+
+      - alert: IndexerBatchLatencyHigh
+        expr: |
+          histogram_quantile(0.99,
+            sum(rate(indexer_batch_duration_seconds_bucket[5m])) by (le)) > 10
+        for: 10m
+        labels:
+          severity: warning
+        annotations:
+          summary: "p99 indexer batch duration above 10s — replays will miss their budget"
+```
+
+### Cardinality and data-safety notes
+
+- `contract_id` is trimmed and truncated to 64 characters (the same convention
+  as `indexer_replay_*`), and blank/absent ids collapse to `unknown`. A
+  malformed replay request cannot mint an unbounded label value.
+- Replay is reachable only via `POST /api/indexer/events/replay`, which requires
+  a JWT carrying `Permission.INDEXER_REPLAY`, so `contract_id` values are not
+  attacker-supplied from unauthenticated traffic.
+- `error_source` and `error_type` are drawn from closed unions in
+  `src/metrics/indexerRed.ts`. **Raw error messages are never used as label
+  values**, so an error carrying user input, credentials, or PII cannot leak
+  into the `/metrics` payload or inflate cardinality.
+- The classifier is total: a thrown string, `null`, or an unrecognised object
+  yields `local` / `unknown` rather than throwing. Metric recording can never
+  mask the original batch failure — the error is always rethrown to the caller.

--- a/src/indexer/service.ts
+++ b/src/indexer/service.ts
@@ -17,6 +17,21 @@ import {
   indexerEventsIngestedTotal,
   indexerLagSeconds,
 } from '../metrics/businessMetrics.js';
+import {
+  recordIndexerBatchFailure,
+  recordIndexerBatchSuccess,
+} from '../metrics/indexerRed.js';
+
+/**
+ * Seconds elapsed since a `process.hrtime.bigint()` reading.
+ *
+ * Uses the monotonic clock rather than `Date.now()` so a wall-clock adjustment
+ * (NTP step, DST) mid-batch can never produce a negative or wildly inflated
+ * duration observation.
+ */
+function elapsedSecondsSince(startedAt: bigint): number {
+  return Number(process.hrtime.bigint() - startedAt) / 1e9;
+}
 
 // ── Replay budget error ────────────────────────────────────────────────────────
 
@@ -488,12 +503,39 @@ export class IndexerService {
         }
 
         // Acquire a fresh connection for this batch.
-        const batchResult = await this.processBatch(
-          cursor.id,
-          request,
-          offset,
-          batchIndex,
-        );
+        //
+        // RED instrumentation wraps *only* this call so the histogram measures
+        // the batch processing step itself (fetch → insert → cursor advance →
+        // COMMIT) and nothing else. The loop guards above are control flow, not
+        // work, and deliberately stay outside the measurement.
+        const batchStartedAt = process.hrtime.bigint();
+        let batchResult: { rowsFetched: number };
+        try {
+          batchResult = await this.processBatch(
+            cursor.id,
+            request,
+            offset,
+            batchIndex,
+          );
+        } catch (batchError) {
+          const classification = recordIndexerBatchFailure(
+            request.contract_id,
+            elapsedSecondsSince(batchStartedAt),
+            batchError,
+          );
+          logger.warn('replay_batch_failed', undefined, {
+            event: 'replay_batch_failed',
+            contract_id: request.contract_id,
+            ledger: request.ledger,
+            cursor_id: cursor.id,
+            batch_index: batchIndex,
+            offset,
+            error_source: classification.source,
+            error_type: classification.type,
+          });
+          throw batchError;
+        }
+        recordIndexerBatchSuccess(request.contract_id, elapsedSecondsSince(batchStartedAt));
 
         if (batchResult.rowsFetched === 0) {
           // Source exhausted ahead of totalRows count — safe to stop.

--- a/src/metrics/indexerRed.ts
+++ b/src/metrics/indexerRed.ts
@@ -1,0 +1,335 @@
+/**
+ * RED (Rate / Errors / Duration) metrics for the indexer batch processing loop.
+ *
+ * ## Why a dedicated module
+ *
+ * `src/metrics/indexerMetrics.ts` tracks *replay-run* level counters
+ * (`indexer_replay_*`) — one observation per replay job. Those are useful for
+ * backfill progress but cannot answer the three questions an on-call operator
+ * asks about the per-batch processing step itself:
+ *
+ *   Rate      — how many ledger batches are we processing per second?
+ *   Errors    — what fraction of them fail, and why?
+ *   Duration  — how long does one batch take (p50/p95/p99)?
+ *
+ * This module provides exactly that triad, mirroring the HTTP RED metrics in
+ * `src/metrics.ts` (`http_requests_total` / `http_request_duration_seconds`)
+ * so an indexer dashboard can be built from the same PromQL shapes as the
+ * HTTP dashboard.
+ *
+ * ## Naming / label parity with the HTTP RED metrics
+ *
+ * | Concern  | HTTP                             | Indexer batch                          |
+ * |----------|----------------------------------|----------------------------------------|
+ * | Rate     | `http_requests_total`            | `indexer_batches_processed_total`       |
+ * | Errors   | (5xx slice of the above)         | `indexer_batch_errors_total`            |
+ * | Duration | `http_request_duration_seconds`  | `indexer_batch_duration_seconds`        |
+ * | "what"   | `route`                          | `contract_id`                           |
+ * | "result" | `status_code`                    | `outcome` (`success` \| `error`)        |
+ *
+ * Both the rate counter and the duration histogram carry the same label set
+ * (`contract_id`, `outcome`) — exactly as the HTTP pair does — so a single
+ * PromQL template works for either subsystem.
+ *
+ * ## Cardinality and safety
+ *
+ * - `contract_id` is truncated to 64 characters (same convention as
+ *   `indexerMetrics.ts`) and falls back to `unknown` when absent, so a
+ *   malformed request can never create an unbounded label value.
+ * - `error_source` and `error_type` are drawn from closed unions declared in
+ *   this file. Raw error messages are **never** used as label values, so an
+ *   error carrying user input (or PII) cannot inflate cardinality or leak into
+ *   the `/metrics` payload.
+ *
+ * @module metrics/indexerRed
+ */
+
+import { Counter, Histogram } from 'prom-client';
+import { registry } from '../metrics.js';
+// Type-only import: keeps this module free of any runtime dependency on the
+// Stellar RPC service (and its Redis/tracing import chain) while still binding
+// the RPC error taxonomy to its single source of truth.
+import type { RpcFailureKind } from '../services/stellar-rpc.js';
+
+// ── Label unions ──────────────────────────────────────────────────────────────
+
+/** Terminal result of one batch processing step. Mirrors HTTP `status_code`. */
+export type IndexerBatchOutcome = 'success' | 'error';
+
+/**
+ * Where a batch failure originated.
+ *
+ * `stellar_rpc` — the error was raised by a call into
+ *                 `src/services/stellar-rpc.ts` (provider outage, timeout,
+ *                 open circuit breaker, …). These are *upstream* failures:
+ *                 retrying the indexer will not help until the provider
+ *                 recovers.
+ * `local`       — the error was raised by this process while processing the
+ *                 batch (database failure, unexpected exception). These are
+ *                 *our* failures and are actionable by the indexer owner.
+ */
+export type IndexerBatchErrorSource = 'stellar_rpc' | 'local';
+
+/** Error taxonomy for failures originating in `src/services/stellar-rpc.ts`. */
+export type IndexerRpcErrorType =
+  | 'timeout'
+  | 'network'
+  | 'provider'
+  | 'circuit_open'
+  | 'cancelled';
+
+/** Error taxonomy for failures originating inside the indexer process. */
+export type IndexerLocalErrorType =
+  | 'db_pool_exhausted'
+  | 'db_query_timeout'
+  | 'db_duplicate_entry'
+  | 'db_error'
+  | 'unknown';
+
+export type IndexerBatchErrorType = IndexerRpcErrorType | IndexerLocalErrorType;
+
+/** Result of {@link classifyIndexerBatchError}. */
+export interface IndexerBatchErrorClassification {
+  source: IndexerBatchErrorSource;
+  type: IndexerBatchErrorType;
+}
+
+// ── Metrics ───────────────────────────────────────────────────────────────────
+
+/**
+ * **Rate.** Total batch processing steps executed, including the ones that
+ * failed — the `outcome` label separates them, exactly as `status_code` does
+ * for `http_requests_total`.
+ *
+ * This differs from `indexer_replay_batches_committed_total`, which counts
+ * only batches that reached COMMIT. A batch that fetched zero rows (source
+ * exhausted) still counts here as one `success`, because one unit of work was
+ * performed.
+ *
+ * ```promql
+ * sum(rate(indexer_batches_processed_total[5m])) by (contract_id)
+ * ```
+ */
+export const indexerBatchesProcessedTotal =
+  (registry.getSingleMetric('indexer_batches_processed_total') as Counter<
+    'contract_id' | 'outcome'
+  >) ||
+  new Counter({
+    name: 'indexer_batches_processed_total',
+    help: 'Total number of indexer ledger-batch processing steps executed, by outcome',
+    labelNames: ['contract_id', 'outcome'] as const,
+    registers: [registry],
+  });
+
+/**
+ * **Errors.** Failed batch processing steps, broken down by where the failure
+ * came from and what kind it was.
+ *
+ * Every increment here is accompanied by an `outcome="error"` increment on
+ * {@link indexerBatchesProcessedTotal}, so the error *ratio* is computable
+ * from either metric:
+ *
+ * ```promql
+ * # Error ratio, all causes
+ * sum(rate(indexer_batch_errors_total[5m]))
+ *   / sum(rate(indexer_batches_processed_total[5m]))
+ *
+ * # Is it us, or is it the RPC provider?
+ * sum(rate(indexer_batch_errors_total[5m])) by (error_source, error_type)
+ * ```
+ */
+export const indexerBatchErrorsTotal =
+  (registry.getSingleMetric('indexer_batch_errors_total') as Counter<
+    'contract_id' | 'error_source' | 'error_type'
+  >) ||
+  new Counter({
+    name: 'indexer_batch_errors_total',
+    help: 'Total number of failed indexer ledger-batch processing steps, by error source and type',
+    labelNames: ['contract_id', 'error_source', 'error_type'] as const,
+    registers: [registry],
+  });
+
+/**
+ * **Duration.** Wall-clock time of one batch processing step, in seconds.
+ *
+ * Buckets start finer than the HTTP histogram's (a batch is a multi-statement
+ * transaction, not a single request) and extend to 60 s so a pathologically
+ * slow batch still lands in a real bucket instead of `+Inf`.
+ *
+ * ```promql
+ * histogram_quantile(0.99, sum(rate(indexer_batch_duration_seconds_bucket[5m])) by (le))
+ * ```
+ */
+export const indexerBatchDurationSeconds =
+  (registry.getSingleMetric('indexer_batch_duration_seconds') as Histogram<
+    'contract_id' | 'outcome'
+  >) ||
+  new Histogram({
+    name: 'indexer_batch_duration_seconds',
+    help: 'Duration of indexer ledger-batch processing steps in seconds',
+    labelNames: ['contract_id', 'outcome'] as const,
+    buckets: [0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 30, 60],
+    registers: [registry],
+  });
+
+// ── Label helpers ─────────────────────────────────────────────────────────────
+
+/** Maximum length of the `contract_id` label value. Matches indexerMetrics.ts. */
+const MAX_CONTRACT_ID_LABEL_LENGTH = 64;
+
+/**
+ * Normalise a contract id into a bounded label value.
+ *
+ * Truncates to {@link MAX_CONTRACT_ID_LABEL_LENGTH} characters and maps
+ * missing/blank ids to `unknown`, so a metric series can never be created from
+ * an arbitrarily long caller-supplied string.
+ */
+export function normalizeContractIdLabel(contractId: string | undefined | null): string {
+  if (typeof contractId !== 'string') return 'unknown';
+  const trimmed = contractId.trim();
+  if (trimmed.length === 0) return 'unknown';
+  return trimmed.slice(0, MAX_CONTRACT_ID_LABEL_LENGTH);
+}
+
+// ── Error classification ──────────────────────────────────────────────────────
+
+/**
+ * Error `name` values exported by `src/services/stellar-rpc.ts`.
+ *
+ * Matched structurally rather than with `instanceof` so classification keeps
+ * working when an error crosses a module-instance boundary (dual ESM/CJS
+ * resolution, vitest module mocking) — and so this module needs no runtime
+ * import of the RPC service.
+ */
+const RPC_ERROR_NAMES = new Set(['RpcProviderError', 'CircuitOpenError']);
+
+/** `RpcFailureKind` → the lower-snake-case label value we expose. */
+const RPC_KIND_TO_ERROR_TYPE: Record<RpcFailureKind, IndexerRpcErrorType> = {
+  TIMEOUT: 'timeout',
+  NETWORK: 'network',
+  PROVIDER: 'provider',
+  CIRCUIT_OPEN: 'circuit_open',
+  CANCELLED: 'cancelled',
+};
+
+/** Error `name` values exported by `src/db/pool.ts` → local label value. */
+const LOCAL_ERROR_NAME_TO_TYPE: Record<string, IndexerLocalErrorType> = {
+  PoolExhaustedError: 'db_pool_exhausted',
+  QueryTimeoutError: 'db_query_timeout',
+  DuplicateEntryError: 'db_duplicate_entry',
+};
+
+/** Postgres SQLSTATE codes are exactly five uppercase alphanumerics. */
+const SQLSTATE_PATTERN = /^[0-9A-Z]{5}$/;
+
+/**
+ * Classify a batch failure into a bounded `(source, type)` label pair.
+ *
+ * The classifier is deliberately total: any value — including a thrown string,
+ * `null`, or an error with no recognisable shape — yields
+ * `{ source: 'local', type: 'unknown' }` rather than throwing. Metric recording
+ * must never be able to mask the original failure.
+ *
+ * @param error The value thrown by the batch processing step.
+ * @returns The `error_source` / `error_type` labels to record.
+ */
+export function classifyIndexerBatchError(
+  error: unknown,
+): IndexerBatchErrorClassification {
+  if (typeof error !== 'object' || error === null) {
+    return { source: 'local', type: 'unknown' };
+  }
+
+  const candidate = error as { name?: unknown; kind?: unknown; code?: unknown };
+  const name = typeof candidate.name === 'string' ? candidate.name : '';
+  const kind = typeof candidate.kind === 'string' ? candidate.kind : '';
+
+  // 1. Stellar RPC failures — recognised by error name, or by a `kind` field
+  //    holding a known RpcFailureKind (covers subclasses and re-wrapped errors).
+  const rpcType = RPC_KIND_TO_ERROR_TYPE[kind as RpcFailureKind];
+  if (RPC_ERROR_NAMES.has(name)) {
+    return { source: 'stellar_rpc', type: rpcType ?? 'provider' };
+  }
+  if (rpcType !== undefined) {
+    return { source: 'stellar_rpc', type: rpcType };
+  }
+
+  // 2. Known local database errors raised by src/db/pool.ts.
+  const localType = LOCAL_ERROR_NAME_TO_TYPE[name];
+  if (localType !== undefined) {
+    return { source: 'local', type: localType };
+  }
+
+  // 3. Raw driver errors from `pg` carry a SQLSTATE in `code`.
+  if (typeof candidate.code === 'string' && SQLSTATE_PATTERN.test(candidate.code)) {
+    return { source: 'local', type: 'db_error' };
+  }
+
+  return { source: 'local', type: 'unknown' };
+}
+
+// ── Recording helpers ─────────────────────────────────────────────────────────
+
+/**
+ * Record a batch processing step that completed without throwing.
+ *
+ * @param contractId       Contract whose ledger batch was processed.
+ * @param durationSeconds  Wall-clock duration of the step, in seconds.
+ */
+export function recordIndexerBatchSuccess(
+  contractId: string,
+  durationSeconds: number,
+): void {
+  const labels = { contract_id: normalizeContractIdLabel(contractId), outcome: 'success' as const };
+  indexerBatchesProcessedTotal.inc(labels);
+  indexerBatchDurationSeconds.observe(labels, durationSeconds);
+}
+
+/**
+ * Record a batch processing step that threw.
+ *
+ * Increments the rate counter with `outcome="error"` (so the denominator stays
+ * correct), observes the duration up to the point of failure, and increments
+ * the error counter with the classified `(error_source, error_type)` pair.
+ *
+ * @param contractId       Contract whose ledger batch was being processed.
+ * @param durationSeconds  Wall-clock duration until the failure, in seconds.
+ * @param error            The thrown value; classified via
+ *                         {@link classifyIndexerBatchError}.
+ * @returns The classification that was recorded, so callers can reuse it in
+ *          structured logs without re-classifying.
+ */
+export function recordIndexerBatchFailure(
+  contractId: string,
+  durationSeconds: number,
+  error: unknown,
+): IndexerBatchErrorClassification {
+  const contract = normalizeContractIdLabel(contractId);
+  const classification = classifyIndexerBatchError(error);
+
+  indexerBatchesProcessedTotal.inc({ contract_id: contract, outcome: 'error' });
+  indexerBatchDurationSeconds.observe({ contract_id: contract, outcome: 'error' }, durationSeconds);
+  indexerBatchErrorsTotal.inc({
+    contract_id: contract,
+    error_source: classification.source,
+    error_type: classification.type,
+  });
+
+  return classification;
+}
+
+// ── Test isolation ────────────────────────────────────────────────────────────
+
+/**
+ * Zero every indexer RED series. Test use only.
+ *
+ * Deliberately `reset()` rather than `registry.removeSingleMetric()`: removal
+ * would leave the module-level singletons above pointing at collectors that are
+ * no longer in the registry, so subsequent recordings would silently vanish
+ * from `/metrics`. Resetting keeps the registration intact.
+ */
+export function resetIndexerRedMetrics(): void {
+  indexerBatchesProcessedTotal.reset();
+  indexerBatchErrorsTotal.reset();
+  indexerBatchDurationSeconds.reset();
+}

--- a/tests/indexer/redMetrics.test.ts
+++ b/tests/indexer/redMetrics.test.ts
@@ -1,0 +1,492 @@
+/**
+ * tests/indexer/redMetrics.test.ts
+ *
+ * Tests for the indexer batch-processing RED metrics
+ * (`src/metrics/indexerRed.ts`) and their wiring into
+ * `IndexerService.replayEvents` (`src/indexer/service.ts`).
+ *
+ * Covers:
+ *  - Metric registration: names, help text, and label sets are registered on
+ *    the shared registry and mirror the HTTP RED metric conventions.
+ *  - `normalizeContractIdLabel`: truncation, blank/non-string fallback.
+ *  - `classifyIndexerBatchError`: Stellar RPC failures are distinguishable from
+ *    local processing failures, using the *real* error classes exported by
+ *    `src/services/stellar-rpc.ts` and `src/db/pool.ts`.
+ *  - Recording helpers: success/failure update the rate counter, the error
+ *    counter, and the duration histogram consistently.
+ *  - End-to-end: a replay run increments the RED triad once per batch, and a
+ *    failing batch is recorded with the correct `error_source`/`error_type`
+ *    before the error propagates to the caller.
+ *  - Edge cases: thrown non-Error values, unknown RPC kinds, zero-row batches,
+ *    and oversized contract ids.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import type pg from 'pg';
+
+import {
+  indexerBatchesProcessedTotal,
+  indexerBatchErrorsTotal,
+  indexerBatchDurationSeconds,
+  classifyIndexerBatchError,
+  normalizeContractIdLabel,
+  recordIndexerBatchSuccess,
+  recordIndexerBatchFailure,
+  resetIndexerRedMetrics,
+} from '../../src/metrics/indexerRed.js';
+import { registry } from '../../src/metrics.js';
+import {
+  CircuitOpenError,
+  RpcProviderError,
+} from '../../src/services/stellar-rpc.js';
+import {
+  DuplicateEntryError,
+  PoolExhaustedError,
+  QueryTimeoutError,
+} from '../../src/db/pool.js';
+import {
+  IndexerService,
+  ReplayCursorRepository,
+  replayLock,
+  replayState,
+} from '../../src/indexer/service.js';
+import type { IndexerLeaderElection } from '../../src/indexer/leaderElection.js';
+
+// ── Metric read helpers ───────────────────────────────────────────────────────
+
+type LabelBag = Record<string, string | number | undefined>;
+
+/** Sum of all counter samples whose labels match every entry in `match`. */
+async function counterValue(
+  metric: { get(): Promise<{ values: Array<{ labels: LabelBag; value: number }> }> },
+  match: LabelBag,
+): Promise<number> {
+  const { values } = await metric.get();
+  return values
+    .filter((v) => Object.entries(match).every(([k, want]) => v.labels[k] === want))
+    .reduce((sum, v) => sum + v.value, 0);
+}
+
+/** Observation count of a histogram series (the `_count` sample). */
+async function histogramCount(match: LabelBag): Promise<number> {
+  const { values } = await indexerBatchDurationSeconds.get();
+  return values
+    .filter(
+      (v) =>
+        (v as { metricName?: string }).metricName === 'indexer_batch_duration_seconds_count' &&
+        Object.entries(match).every(([k, want]) => v.labels[k] === want),
+    )
+    .reduce((sum, v) => sum + v.value, 0);
+}
+
+/** Sum of a histogram series (the `_sum` sample). */
+async function histogramSum(match: LabelBag): Promise<number> {
+  const { values } = await indexerBatchDurationSeconds.get();
+  return values
+    .filter(
+      (v) =>
+        (v as { metricName?: string }).metricName === 'indexer_batch_duration_seconds_sum' &&
+        Object.entries(match).every(([k, want]) => v.labels[k] === want),
+    )
+    .reduce((sum, v) => sum + v.value, 0);
+}
+
+// ── IndexerService mock harness (mirrors tests/indexer-replay.test.ts) ─────────
+
+type QueryFn = (sql: string, params?: unknown[]) => Promise<{ rows: unknown[]; rowCount?: number | null }>;
+
+function makeClient(queryImpl?: QueryFn): pg.PoolClient {
+  return {
+    query: vi.fn().mockImplementation(
+      queryImpl ?? (() => Promise.resolve({ rows: [], rowCount: 0, command: '', oid: 0, fields: [] })),
+    ),
+    release: vi.fn(),
+  } as unknown as pg.PoolClient;
+}
+
+function makePool(...clients: pg.PoolClient[]): pg.Pool {
+  let callCount = 0;
+  return {
+    connect: vi.fn(async () => {
+      const c = clients[callCount % clients.length];
+      callCount++;
+      return c;
+    }),
+    totalCount: 1,
+    idleCount: 1,
+    waitingCount: 0,
+  } as unknown as pg.Pool;
+}
+
+function makeFakeLeaderElection(): IndexerLeaderElection {
+  return {
+    isLeader: vi.fn(() => true),
+    tryAcquire: vi.fn(async () => true),
+    release: vi.fn(async () => {}),
+  };
+}
+
+function makeCursorRepo(totalRows: number): ReplayCursorRepository {
+  return {
+    findActive: vi.fn(async () => null),
+    create: vi.fn(async (_client, cid: string, ledger: number) => ({
+      id: 'red-cursor',
+      contract_id: cid,
+      ledger,
+      from_block: null,
+      to_block: null,
+      total_rows: totalRows,
+      last_committed_offset: 0,
+      started_at: new Date(),
+      completed_at: null,
+    })),
+    advanceOffset: vi.fn(async () => {}),
+    markCompleted: vi.fn(async () => {}),
+  } as unknown as ReplayCursorRepository;
+}
+
+function makeEvent(eventId: string, blockHeight = 1000) {
+  return {
+    event_id: eventId,
+    contract_id: CONTRACT,
+    ledger: 1,
+    event_type: 'transfer',
+    event_data: { amount: '100' },
+    block_height: blockHeight,
+    transaction_hash: `tx-${eventId}`,
+  };
+}
+
+const CONTRACT = 'red-metrics-contract';
+const REQUEST = { contract_id: CONTRACT, ledger: 1 };
+
+function makeService(pool: pg.Pool, cursorRepo: ReplayCursorRepository, batchSize: number): IndexerService {
+  return new IndexerService(pool, batchSize, 0, 0, cursorRepo, makeFakeLeaderElection());
+}
+
+// ── Setup / teardown ──────────────────────────────────────────────────────────
+
+beforeEach(() => {
+  if (replayLock.isHeld()) (replayLock as unknown as { _isReplaying: boolean })._isReplaying = false;
+  replayState.endReplay();
+  resetIndexerRedMetrics();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  if (replayLock.isHeld()) (replayLock as unknown as { _isReplaying: boolean })._isReplaying = false;
+});
+
+// ── Registration / naming parity ──────────────────────────────────────────────
+
+describe('indexerRed — registration and naming parity', () => {
+  it('registers the RED triad on the shared registry', () => {
+    expect(registry.getSingleMetric('indexer_batches_processed_total')).toBeDefined();
+    expect(registry.getSingleMetric('indexer_batch_errors_total')).toBeDefined();
+    expect(registry.getSingleMetric('indexer_batch_duration_seconds')).toBeDefined();
+  });
+
+  it('exposes the triad in the scrape payload with the expected label names', async () => {
+    recordIndexerBatchSuccess(CONTRACT, 0.5);
+    recordIndexerBatchFailure(CONTRACT, 0.1, new RpcProviderError('boom', 'TIMEOUT'));
+
+    const scrape = await registry.metrics();
+
+    expect(scrape).toContain('# TYPE indexer_batches_processed_total counter');
+    expect(scrape).toContain('# TYPE indexer_batch_errors_total counter');
+    expect(scrape).toContain('# TYPE indexer_batch_duration_seconds histogram');
+    expect(scrape).toContain(`indexer_batches_processed_total{contract_id="${CONTRACT}",outcome="success"`);
+    expect(scrape).toContain('error_source="stellar_rpc"');
+    expect(scrape).toContain('error_type="timeout"');
+  });
+
+  it('uses the same duration unit and outcome-style label as the HTTP RED metrics', () => {
+    // http_request_duration_seconds{method,route,status_code} is the template:
+    // seconds-valued histogram + a label carrying the terminal result.
+    expect(indexerBatchDurationSeconds.get()).toBeInstanceOf(Promise);
+    expect(indexerBatchesProcessedTotal).toBeDefined();
+    expect(registry.getSingleMetric('http_request_duration_seconds')).toBeDefined();
+  });
+});
+
+// ── normalizeContractIdLabel ──────────────────────────────────────────────────
+
+describe('normalizeContractIdLabel', () => {
+  it('passes through a normal contract id', () => {
+    expect(normalizeContractIdLabel('C123')).toBe('C123');
+  });
+
+  it('truncates to 64 characters to bound label cardinality', () => {
+    const long = 'X'.repeat(500);
+    expect(normalizeContractIdLabel(long)).toHaveLength(64);
+  });
+
+  it('falls back to "unknown" for blank, missing, or non-string ids', () => {
+    expect(normalizeContractIdLabel('')).toBe('unknown');
+    expect(normalizeContractIdLabel('   ')).toBe('unknown');
+    expect(normalizeContractIdLabel(undefined)).toBe('unknown');
+    expect(normalizeContractIdLabel(null)).toBe('unknown');
+    expect(normalizeContractIdLabel(42 as unknown as string)).toBe('unknown');
+  });
+});
+
+// ── classifyIndexerBatchError ─────────────────────────────────────────────────
+
+describe('classifyIndexerBatchError — Stellar RPC failures', () => {
+  it.each([
+    ['TIMEOUT', 'timeout'],
+    ['NETWORK', 'network'],
+    ['PROVIDER', 'provider'],
+    ['CANCELLED', 'cancelled'],
+    ['CIRCUIT_OPEN', 'circuit_open'],
+  ] as const)('maps RpcProviderError kind %s to error_type %s', (kind, expected) => {
+    expect(classifyIndexerBatchError(new RpcProviderError('rpc down', kind))).toEqual({
+      source: 'stellar_rpc',
+      type: expected,
+    });
+  });
+
+  it('maps CircuitOpenError to stellar_rpc/circuit_open', () => {
+    expect(classifyIndexerBatchError(new CircuitOpenError())).toEqual({
+      source: 'stellar_rpc',
+      type: 'circuit_open',
+    });
+  });
+
+  it('falls back to provider for an RPC error carrying an unrecognised kind', () => {
+    const err = new RpcProviderError('weird', 'SOMETHING_NEW' as never);
+    expect(classifyIndexerBatchError(err)).toEqual({ source: 'stellar_rpc', type: 'provider' });
+  });
+
+  it('classifies a re-wrapped RPC failure by its kind field alone', () => {
+    // A caller may rethrow with a different class but preserve `kind`.
+    const rewrapped = Object.assign(new Error('wrapped'), { kind: 'NETWORK' });
+    expect(classifyIndexerBatchError(rewrapped)).toEqual({ source: 'stellar_rpc', type: 'network' });
+  });
+});
+
+describe('classifyIndexerBatchError — local failures', () => {
+  it('maps PoolExhaustedError to local/db_pool_exhausted', () => {
+    expect(classifyIndexerBatchError(new PoolExhaustedError())).toEqual({
+      source: 'local',
+      type: 'db_pool_exhausted',
+    });
+  });
+
+  it('maps QueryTimeoutError to local/db_query_timeout', () => {
+    expect(classifyIndexerBatchError(new QueryTimeoutError())).toEqual({
+      source: 'local',
+      type: 'db_query_timeout',
+    });
+  });
+
+  it('maps DuplicateEntryError to local/db_duplicate_entry', () => {
+    expect(classifyIndexerBatchError(new DuplicateEntryError('dupe'))).toEqual({
+      source: 'local',
+      type: 'db_duplicate_entry',
+    });
+  });
+
+  it('maps a raw pg error carrying a SQLSTATE to local/db_error', () => {
+    const pgErr = Object.assign(new Error('relation does not exist'), { code: '42P01' });
+    expect(classifyIndexerBatchError(pgErr)).toEqual({ source: 'local', type: 'db_error' });
+  });
+
+  it('does not treat a non-SQLSTATE code as a database error', () => {
+    const err = Object.assign(new Error('nope'), { code: 'not-a-sqlstate' });
+    expect(classifyIndexerBatchError(err)).toEqual({ source: 'local', type: 'unknown' });
+  });
+
+  it.each([
+    ['plain Error', new Error('kaboom')],
+    ['thrown string', 'kaboom' as unknown],
+    ['thrown null', null as unknown],
+    ['thrown undefined', undefined as unknown],
+    ['thrown number', 7 as unknown],
+  ])('classifies %s as local/unknown without throwing', (_label, thrown) => {
+    expect(classifyIndexerBatchError(thrown)).toEqual({ source: 'local', type: 'unknown' });
+  });
+});
+
+// ── Recording helpers ─────────────────────────────────────────────────────────
+
+describe('recordIndexerBatchSuccess / recordIndexerBatchFailure', () => {
+  it('records a success on the rate counter and duration histogram only', async () => {
+    recordIndexerBatchSuccess(CONTRACT, 0.25);
+
+    expect(await counterValue(indexerBatchesProcessedTotal, { contract_id: CONTRACT, outcome: 'success' })).toBe(1);
+    expect(await counterValue(indexerBatchErrorsTotal, { contract_id: CONTRACT })).toBe(0);
+    expect(await histogramCount({ contract_id: CONTRACT, outcome: 'success' })).toBe(1);
+    expect(await histogramSum({ contract_id: CONTRACT, outcome: 'success' })).toBeCloseTo(0.25, 6);
+  });
+
+  it('records a failure on all three metrics so the error ratio stays computable', async () => {
+    const classification = recordIndexerBatchFailure(
+      CONTRACT,
+      0.75,
+      new RpcProviderError('upstream 503', 'PROVIDER'),
+    );
+
+    expect(classification).toEqual({ source: 'stellar_rpc', type: 'provider' });
+    expect(await counterValue(indexerBatchesProcessedTotal, { contract_id: CONTRACT, outcome: 'error' })).toBe(1);
+    expect(
+      await counterValue(indexerBatchErrorsTotal, {
+        contract_id: CONTRACT,
+        error_source: 'stellar_rpc',
+        error_type: 'provider',
+      }),
+    ).toBe(1);
+    expect(await histogramCount({ contract_id: CONTRACT, outcome: 'error' })).toBe(1);
+    expect(await histogramSum({ contract_id: CONTRACT, outcome: 'error' })).toBeCloseTo(0.75, 6);
+  });
+
+  it('keeps RPC and local failures on separate error series', async () => {
+    recordIndexerBatchFailure(CONTRACT, 0.1, new RpcProviderError('timeout', 'TIMEOUT'));
+    recordIndexerBatchFailure(CONTRACT, 0.1, new PoolExhaustedError());
+
+    expect(await counterValue(indexerBatchErrorsTotal, { error_source: 'stellar_rpc' })).toBe(1);
+    expect(await counterValue(indexerBatchErrorsTotal, { error_source: 'local' })).toBe(1);
+    expect(
+      await counterValue(indexerBatchErrorsTotal, { error_source: 'stellar_rpc', error_type: 'timeout' }),
+    ).toBe(1);
+    expect(
+      await counterValue(indexerBatchErrorsTotal, { error_source: 'local', error_type: 'db_pool_exhausted' }),
+    ).toBe(1);
+  });
+
+  it('never uses the error message as a label value', async () => {
+    recordIndexerBatchFailure(CONTRACT, 0.1, new Error('secret-token-abc123'));
+    const scrape = await registry.metrics();
+    expect(scrape).not.toContain('secret-token-abc123');
+    expect(await counterValue(indexerBatchErrorsTotal, { error_type: 'unknown' })).toBe(1);
+  });
+
+  it('bounds the contract_id label for an oversized id', async () => {
+    const huge = 'Z'.repeat(300);
+    recordIndexerBatchSuccess(huge, 0.01);
+    expect(await counterValue(indexerBatchesProcessedTotal, { contract_id: 'Z'.repeat(64) })).toBe(1);
+  });
+});
+
+// ── End-to-end wiring into IndexerService.replayEvents ────────────────────────
+
+describe('IndexerService.replayEvents — RED instrumentation', () => {
+  it('increments the rate counter and duration histogram once per batch', async () => {
+    // 4 source rows, batchSize 2 → two batch processing steps.
+    const cursorClient = makeClient(async (sql) =>
+      sql.includes('COUNT') ? { rows: [{ count: '4' }] } : { rows: [] },
+    );
+    let fetches = 0;
+    const batchClient = makeClient(async (sql) => {
+      if (sql.includes('FROM historical_events')) {
+        fetches++;
+        return { rows: [makeEvent(`e${fetches}a`), makeEvent(`e${fetches}b`)] };
+      }
+      return { rows: [] };
+    });
+    const completeClient = makeClient(async () => ({ rows: [] }));
+
+    const svc = makeService(makePool(cursorClient, batchClient, completeClient), makeCursorRepo(4), 2);
+    await svc.replayEvents(REQUEST);
+
+    expect(await counterValue(indexerBatchesProcessedTotal, { contract_id: CONTRACT, outcome: 'success' })).toBe(2);
+    expect(await histogramCount({ contract_id: CONTRACT, outcome: 'success' })).toBe(2);
+    expect(await counterValue(indexerBatchErrorsTotal, { contract_id: CONTRACT })).toBe(0);
+    expect(await histogramSum({ contract_id: CONTRACT, outcome: 'success' })).toBeGreaterThanOrEqual(0);
+  });
+
+  it('counts a zero-row batch as a processed step (work was performed)', async () => {
+    // The count query claims 2 rows but the source returns none — the loop
+    // performs one batch step, finds it empty, and stops.
+    const cursorClient = makeClient(async (sql) =>
+      sql.includes('COUNT') ? { rows: [{ count: '2' }] } : { rows: [] },
+    );
+    const batchClient = makeClient(async () => ({ rows: [] }));
+    const completeClient = makeClient(async () => ({ rows: [] }));
+
+    const svc = makeService(makePool(cursorClient, batchClient, completeClient), makeCursorRepo(2), 2);
+    await svc.replayEvents(REQUEST);
+
+    expect(await counterValue(indexerBatchesProcessedTotal, { contract_id: CONTRACT, outcome: 'success' })).toBe(1);
+    expect(await histogramCount({ contract_id: CONTRACT, outcome: 'success' })).toBe(1);
+  });
+
+  it('records a local error and still propagates the failure to the caller', async () => {
+    const cursorClient = makeClient(async (sql) =>
+      sql.includes('COUNT') ? { rows: [{ count: '2' }] } : { rows: [] },
+    );
+    const batchClient = makeClient(async (sql) => {
+      if (sql.includes('FROM historical_events')) {
+        throw Object.assign(new Error('relation "historical_events" does not exist'), { code: '42P01' });
+      }
+      return { rows: [] };
+    });
+
+    const svc = makeService(makePool(cursorClient, batchClient), makeCursorRepo(2), 2);
+
+    await expect(svc.replayEvents(REQUEST)).rejects.toThrow('historical_events');
+
+    expect(await counterValue(indexerBatchesProcessedTotal, { contract_id: CONTRACT, outcome: 'error' })).toBe(1);
+    expect(
+      await counterValue(indexerBatchErrorsTotal, {
+        contract_id: CONTRACT,
+        error_source: 'local',
+        error_type: 'db_error',
+      }),
+    ).toBe(1);
+    expect(await histogramCount({ contract_id: CONTRACT, outcome: 'error' })).toBe(1);
+  });
+
+  it('attributes a Stellar RPC failure inside a batch to error_source="stellar_rpc"', async () => {
+    const cursorClient = makeClient(async (sql) =>
+      sql.includes('COUNT') ? { rows: [{ count: '2' }] } : { rows: [] },
+    );
+    const batchClient = makeClient(async (sql) => {
+      if (sql.includes('FROM historical_events')) {
+        // Simulates an enrichment/verification call into
+        // src/services/stellar-rpc.ts failing partway through the batch.
+        throw new RpcProviderError('ledger fetch timed out', 'TIMEOUT');
+      }
+      return { rows: [] };
+    });
+
+    const svc = makeService(makePool(cursorClient, batchClient), makeCursorRepo(2), 2);
+
+    await expect(svc.replayEvents(REQUEST)).rejects.toBeInstanceOf(RpcProviderError);
+
+    expect(
+      await counterValue(indexerBatchErrorsTotal, {
+        contract_id: CONTRACT,
+        error_source: 'stellar_rpc',
+        error_type: 'timeout',
+      }),
+    ).toBe(1);
+    expect(await counterValue(indexerBatchErrorsTotal, { error_source: 'local' })).toBe(0);
+  });
+
+  it('logs replay_batch_failed with the classification labels', async () => {
+    const { logger } = await import('../../src/lib/logger.js');
+    const warnSpy = vi.spyOn(logger, 'warn').mockImplementation(() => {});
+
+    const cursorClient = makeClient(async (sql) =>
+      sql.includes('COUNT') ? { rows: [{ count: '2' }] } : { rows: [] },
+    );
+    const batchClient = makeClient(async (sql) => {
+      if (sql.includes('FROM historical_events')) throw new CircuitOpenError();
+      return { rows: [] };
+    });
+
+    const svc = makeService(makePool(cursorClient, batchClient), makeCursorRepo(2), 2);
+    await expect(svc.replayEvents(REQUEST)).rejects.toBeInstanceOf(CircuitOpenError);
+
+    expect(warnSpy).toHaveBeenCalledWith(
+      'replay_batch_failed',
+      undefined,
+      expect.objectContaining({
+        event: 'replay_batch_failed',
+        error_source: 'stellar_rpc',
+        error_type: 'circuit_open',
+      }),
+    );
+  });
+});


### PR DESCRIPTION
Closes #1219

## Summary

The indexer's core processing loop emitted `indexer_replay_*` counters (one observation per replay *job*) but no Rate/Errors/Duration triad for the per-ledger-batch step itself, so an indexer dashboard could not reuse the PromQL shapes already built for HTTP routes.

This adds a RED metric set scoped to indexer batch processing, deliberately named and labelled to mirror the existing HTTP RED metrics.

## Metrics

| Concern | HTTP (existing) | Indexer batch (new) |
| :--- | :--- | :--- |
| Rate | `http_requests_total` | `indexer_batches_processed_total` |
| Errors | 5xx slice of the above | `indexer_batch_errors_total` |
| Duration | `http_request_duration_seconds` | `indexer_batch_duration_seconds` |
| "which work" | `route` | `contract_id` |
| "what happened" | `status_code` | `outcome` (`success` \| `error`) |

- `indexer_batches_processed_total{contract_id,outcome}` — every batch step executed, successful or not.
- `indexer_batch_errors_total{contract_id,error_source,error_type}` — the ones that threw.
- `indexer_batch_duration_seconds{contract_id,outcome}` — buckets `[0.01 … 60]`, finer at the low end than the HTTP histogram (a batch is a multi-statement transaction) and extending to 60s so a pathological batch lands in a real bucket instead of `+Inf`.

Every `indexer_batch_errors_total` increment is paired with an `outcome="error"` increment on the rate counter, so the error ratio is well-defined against either denominator.

## Distinguishing RPC failures from local ones

Requirement: errors originating from `src/services/stellar-rpc.ts` must be separable from local processing errors.

| `error_source` | Meaning | `error_type` |
| :--- | :--- | :--- |
| `stellar_rpc` | Upstream — retrying the indexer won't help until the provider recovers | `timeout`, `network`, `provider`, `circuit_open`, `cancelled` |
| `local` | Ours — actionable by the indexer owner | `db_pool_exhausted`, `db_query_timeout`, `db_duplicate_entry`, `db_error`, `unknown` |

`error_type` for `stellar_rpc` mirrors the `RpcFailureKind` union exported by `src/services/stellar-rpc.ts`, bound at compile time via a **type-only** import — so the metrics module carries no runtime dependency on the RPC service's Redis/tracing import chain.

Classification is **structural** (matches on `name` / `kind`) rather than `instanceof`, so a `RpcProviderError` rethrown by an intermediate layer, or one crossing a dual ESM/CJS module-instance boundary, is still attributed correctly.

```promql
# Is it us, or is it the provider?
sum(rate(indexer_batch_errors_total[5m])) by (error_source, error_type)
```

## Changes

- **`src/metrics/indexerRed.ts`** (new) — the three collectors, the closed label unions, `classifyIndexerBatchError`, `normalizeContractIdLabel`, and the two recording helpers. Fully typed, no `any`.
- **`src/indexer/service.ts`** — `replayEvents` times **only** the `processBatch` call (loop guards for shutdown/leadership/budget are control flow, not work, and stay outside the timer), records the outcome, logs a `replay_batch_failed` structured event carrying the classification, and rethrows the original error unchanged.
- **`tests/indexer/redMetrics.test.ts`** (new) — 34 tests.
- **`docs/observability.md`** — new "Indexer Batch RED Metrics" section: parity table, dashboard queries, alert rules, cardinality/data-safety notes.

Timing uses `process.hrtime.bigint()` rather than `Date.now()`, so an NTP step mid-batch can't produce a negative or wildly inflated observation.

## Security notes

- **No raw error messages as label values.** `error_source`/`error_type` come from closed unions declared in the module. An error carrying user input, a token, or PII cannot leak into `/metrics` or inflate cardinality. Covered by a test that asserts a secret in an error message never reaches the scrape payload.
- **Bounded `contract_id`.** Trimmed, truncated to 64 chars (same convention as the existing `indexer_replay_*` metrics), blank/non-string collapses to `unknown`. A malformed replay request cannot mint an unbounded label value.
- **Not attacker-reachable anonymously.** Replay requires a JWT with `Permission.INDEXER_REPLAY`, so `contract_id` values never originate from unauthenticated traffic.
- **Instrumentation cannot mask a failure.** The classifier is total — a thrown string, `null`, or an unrecognised object yields `local`/`unknown` rather than throwing — and the batch error is always rethrown to the caller. Tested.
- **`/metrics` remains admin-gated** by the existing `ADMIN_API_KEY` bearer check; no route or auth change here.

## Test output

```
$ npx vitest run tests/indexer/redMetrics.test.ts

 ✓ tests/indexer/redMetrics.test.ts (34 tests) 137ms

 Test Files  1 passed (1)
      Tests  34 passed (34)
```

Covering:
- registration on the shared registry and presence in the scrape payload with the expected label names;
- `classifyIndexerBatchError` against the **real** error classes from `src/services/stellar-rpc.ts` (`RpcProviderError` for all five `RpcFailureKind` values, `CircuitOpenError`) and `src/db/pool.ts` (`PoolExhaustedError`, `QueryTimeoutError`, `DuplicateEntryError`), plus raw `pg` SQLSTATE errors;
- edge cases: unknown RPC `kind` → `provider`; re-wrapped error carrying only `kind`; non-SQLSTATE `code`; thrown string / `null` / `undefined` / number → `local`/`unknown`;
- `normalizeContractIdLabel` truncation and fallbacks;
- recording helpers keeping the three metrics mutually consistent, and RPC vs local staying on separate series;
- end-to-end through `IndexerService.replayEvents`: one increment per batch, zero-row batch counted as a processed step, a failing batch recorded **and** propagated to the caller, and `replay_batch_failed` logged with the classification labels.

Regression check on the surrounding suites — `tests/indexer*`, `tests/metrics*`, `src/indexer` — shows no new failures; the 14 failures in `tests/metrics/{businessMetrics,dbMetrics,pool}.test.ts` are present identically on `main` before this branch (they need a live Postgres).

## Reviewer notes

- A batch that fetches zero rows (source exhausted ahead of the counted total) counts as one `success` — a unit of work was performed. This is the one place `indexer_batches_processed_total` can exceed the pre-existing `indexer_replay_batches_committed_total`, which counts only batches reaching `COMMIT`. Documented.
- `resetIndexerRedMetrics()` uses `reset()` rather than `registry.removeSingleMetric()` on purpose: removal would leave the module-level singletons pointing at unregistered collectors, silently dropping later recordings from `/metrics`.
