### PR TITLE
feat: add aggregated admin system diagnostics endpoint

### DIFF
--- a/docs/api/admin-endpoints.md
+++ b/docs/api/admin-endpoints.md
@@ -174,6 +174,98 @@ Response:
 }
 ```
 
+## System Diagnostics
+
+### `GET /api/admin/diagnostics`
+
+Returns an aggregated system diagnostics snapshot for fast operator triage.
+Aggregates DB pool stats, Redis connectivity, Stellar RPC circuit-breaker state,
+and current indexer ledger lag into a single JSON response. Each sub-check is
+individually timeout-bounded (default 5 seconds) so a single hung dependency
+cannot stall the whole endpoint.
+
+Response (200):
+
+```json
+{
+  "success": true,
+  "data": {
+    "timestamp": "2026-07-29T12:00:00.000Z",
+    "dbPool": {
+      "status": "ok",
+      "latencyMs": 2,
+      "value": {
+        "active": 3,
+        "idle": 5,
+        "waiting": 0
+      }
+    },
+    "redis": {
+      "status": "ok",
+      "latencyMs": 1,
+      "value": {
+        "pingMs": 0.5
+      }
+    },
+    "circuitBreaker": {
+      "status": "ok",
+      "latencyMs": 0,
+      "value": {
+        "state": "CLOSED",
+        "transitionedAt": null,
+        "failureCount": 0,
+        "degraded": false
+      }
+    },
+    "indexer": {
+      "status": "ok",
+      "latencyMs": 0,
+      "value": {
+        "lagSeconds": 0,
+        "isReplaying": false,
+        "rowsReplayed": 0,
+        "totalRows": 0
+      }
+    }
+  },
+  "meta": {
+    "timestamp": "2026-07-29T12:00:00.000Z",
+    "requestId": "req-abc-123"
+  }
+}
+```
+
+Each sub-check status is one of:
+- `"ok"` — check succeeded
+- `"error"` — check failed with an error
+- `"timeout"` — check exceeded its timeout
+
+When a sub-check fails, a sanitised `error` field is included (connection
+strings and credentials are redacted).
+
+Error response (503):
+
+```json
+{
+  "success": false,
+  "error": {
+    "code": "DIAGNOSTICS_ERROR",
+    "message": "Diagnostics check failed",
+    "requestId": "req-abc-123"
+  }
+}
+```
+
+Security notes:
+
+- The endpoint is admin-only and fails closed when `ADMIN_API_KEY` is unset.
+- Error messages are sanitised — connection URLs, passwords, and hostnames are
+  stripped before being returned.
+- No authentication tokens, API keys, or session identifiers are ever included
+  in diagnostics output.
+- Each sub-check runs with its own timeout so a single hung dependency cannot
+  stall the entire endpoint (DoS protection).
+
 ## Related admin endpoints
 
 - `GET /api/admin/status`
@@ -181,6 +273,7 @@ Response:
 - `PUT /api/admin/pause`
 - `GET /api/admin/reindex`
 - `POST /api/admin/reindex`
+- `GET /api/admin/diagnostics`
 - `GET /api/admin/api-keys`
 - `POST /api/admin/api-keys`
 - `POST /api/admin/api-keys/:id/rotate`

--- a/src/routes/admin.ts
+++ b/src/routes/admin.ts
@@ -17,6 +17,7 @@ import { recordAuditEvent, recordAuditEventToDb } from '../lib/auditLog.js';
 import { getStreamHub } from '../ws/hub.js';
 import { successResponse, errorResponse } from '../utils/response.js';
 import { clearIndexerStall, ActiveStallError } from '../indexer/stall.js';
+import { getDiagnosticsService } from '../services/diagnostics.js';
 import { routeDeprecations } from '../config/deprecations.js';
 import {
   queueRestoreJob,
@@ -709,4 +710,33 @@ adminRouter.get('/restore', (req, res) => {
   const requestId = req.correlationId;
   const jobs = listRestoreJobs();
   res.json(successResponse({ jobs }, requestId));
+});
+
+/**
+ * GET /api/admin/diagnostics
+ *
+ * Returns an aggregated system diagnostics snapshot aggregating DB pool stats,
+ * Redis connectivity, Stellar RPC circuit-breaker state, and indexer lag.
+ *
+ * Each sub-check is individually timeout-bounded (default 5s) so a single
+ * hung dependency cannot stall the whole endpoint.
+ *
+ * @security Requires valid Bearer admin token (`ADMIN_API_KEY`).
+ * @returns 200 with a {@link DiagnosticsReport}.
+ */
+adminRouter.get('/diagnostics', async (req, res) => {
+  const requestId = req.correlationId;
+  try {
+    const diagnostics = await getDiagnosticsService().runDiagnostics();
+    res.json(successResponse(diagnostics, requestId));
+  } catch (err) {
+    res.status(503).json(
+      errorResponse(
+        'DIAGNOSTICS_ERROR',
+        err instanceof Error ? err.message : 'Diagnostics check failed',
+        undefined,
+        requestId,
+      ),
+    );
+  }
 });

--- a/src/services/diagnostics.ts
+++ b/src/services/diagnostics.ts
@@ -1,0 +1,391 @@
+/**
+ * Aggregated system diagnostics service.
+ *
+ * Runs several sub-checks concurrently, each individually timeout-bounded,
+ * and returns a structured snapshot suitable for operator triage via
+ * `GET /api/admin/diagnostics`.
+ *
+ * ## Security
+ *
+ * - Error messages from failed sub-checks are sanitised (connection strings,
+ *   passwords, hostnames stripped) before being returned in the response.
+ * - No authentication tokens, API keys, or session identifiers are ever
+ *   included in diagnostics output.
+ * - Each sub-check runs with its own timeout so a single hung dependency
+ *   cannot stall the entire endpoint (DoS protection).
+ */
+
+import type pg from 'pg';
+import { logger } from '../lib/logger.js';
+import { getPool, getPoolMetrics } from '../db/pool.js';
+import { getStellarRpcService, type CircuitState } from './stellar-rpc.js';
+import { indexerService } from '../indexer/service.js';
+import { indexerLagSeconds } from '../metrics/businessMetrics.js';
+import { sanitiseErrorMessage } from '../health/checkers.js';
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+
+export interface SubCheckResult<T = unknown> {
+  status: 'ok' | 'error' | 'timeout';
+  latencyMs: number;
+  value?: T;
+  error?: string;
+}
+
+export interface DbPoolSnapshot {
+  active: number;
+  idle: number;
+  waiting: number;
+}
+
+export interface RedisSnapshot {
+  pingMs: number;
+}
+
+export interface CircuitBreakerSnapshot {
+  state: CircuitState;
+  /** Epoch ms when the breaker last tripped to OPEN, or null if never opened. */
+  transitionedAt: number | null;
+  failureCount: number;
+  degraded: boolean;
+}
+
+export interface IndexerSnapshot {
+  lagSeconds: number;
+  isReplaying: boolean;
+  rowsReplayed?: number;
+  totalRows?: number;
+}
+
+export interface DiagnosticsReport {
+  timestamp: string;
+  dbPool: SubCheckResult<DbPoolSnapshot>;
+  redis: SubCheckResult<RedisSnapshot>;
+  circuitBreaker: SubCheckResult<CircuitBreakerSnapshot>;
+  indexer: SubCheckResult<IndexerSnapshot>;
+}
+
+// ── Constants ──────────────────────────────────────────────────────────────────
+
+const DEFAULT_CHECK_TIMEOUT_MS = 5_000;
+
+/**
+ * Race a promise against a timeout. If the timeout fires first the promise
+ * is abandoned (but not cancelled — it still runs to completion or rejection
+ * in the background) and the returned promise rejects with `TimeoutError`.
+ */
+function withTimeout<T>(
+  promise: Promise<T>,
+  timeoutMs: number,
+  label: string,
+): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    const timer = setTimeout(() => {
+      reject(new Error(`${label} timed out after ${timeoutMs}ms`));
+    }, timeoutMs);
+    promise.then(
+      (v) => { clearTimeout(timer); resolve(v); },
+      (e) => { clearTimeout(timer); reject(e); },
+    );
+  });
+}
+
+// ── Diagnostics Service ────────────────────────────────────────────────────────
+
+export interface DiagnosticsServiceDependencies {
+  /** Returns the Postgres connection pool. */
+  getDbPool: () => pg.Pool;
+  /** Pings Redis and returns the round-trip latency in ms. Returns `null` when Redis is unavailable/disabled. */
+  pingRedis: () => Promise<number | null>;
+  /** Returns the circuit breaker state snapshot. */
+  getCircuitBreakerState: () => CircuitBreakerSnapshot;
+  /** Returns the current indexer lag in seconds. */
+  getIndexerLagSeconds: () => number;
+  /** Returns the current indexer replay progress. */
+  getIndexerReplayProgress: () => { isReplaying: boolean; rowsReplayed: number; totalRows: number };
+  /** Per-sub-check timeout in ms. */
+  checkTimeoutMs: number;
+}
+
+/**
+ * Default dependency implementations wired to the running service singletons.
+ */
+function defaultPingRedis(): Promise<number | null> {
+  // If Redis is explicitly disabled, skip the ping check.
+  if (process.env.REDIS_ENABLED === 'false') {
+    return Promise.resolve(null);
+  }
+
+  const url = process.env.REDIS_URL ?? 'redis://localhost:6379';
+  const connectTimeout = 5_000;
+
+  // Dynamically import ioredis and create a temporary connection for the PING.
+  // We use ioredis directly rather than createRedisClient because the
+  // RedisClient interface does not expose a ping() method, and opening a
+  // disposable connection avoids coupling diagnostics to the application's
+  // long-lived Redis client lifecycle.
+  return (async () => {
+    const { default: Redis } = await import('ioredis');
+    const parsedUrl = new URL(url);
+    const port = parseInt(parsedUrl.port || '6379', 10);
+    const host = parsedUrl.hostname || 'localhost';
+    const password = parsedUrl.password || undefined;
+
+    const client = new Redis(port, host, {
+      password,
+      lazyConnect: true,
+      connectTimeout,
+      maxRetriesPerRequest: 0,
+      retryStrategy: () => null, // no retry for diagnostics
+      enableReadyCheck: true,
+    });
+
+    try {
+      await client.connect();
+      const pingStart = Date.now();
+      await client.ping();
+      const latency = Date.now() - pingStart;
+      return latency;
+    } finally {
+      // Best-effort cleanup; errors are swallowed.
+      await client.quit().catch(() => {});
+    }
+  })();
+}
+
+function defaultGetCircuitBreakerState(): CircuitBreakerSnapshot {
+  try {
+    const svc = getStellarRpcService();
+    const deg = svc.getDegradationSnapshot();
+    return {
+      state: deg.circuitState,
+      transitionedAt: deg.openedAt,
+      failureCount: deg.failureCount,
+      degraded: deg.degraded,
+    };
+  } catch {
+    return { state: 'CLOSED', transitionedAt: null, failureCount: 0, degraded: false };
+  }
+}
+
+function defaultGetIndexerLagSeconds(): number {
+  try {
+    const result = indexerLagSeconds.get();
+    // prom-client Gauge.get() returns { value: number } for unlabeled gauges.
+    if (typeof result === 'number') return result;
+    if (result && typeof result.value === 'number') return result.value;
+    return 0;
+  } catch {
+    return 0;
+  }
+}
+
+function defaultGetIndexerReplayProgress(): { isReplaying: boolean; rowsReplayed: number; totalRows: number } {
+  try {
+    const progress = indexerService.getReplayProgress();
+    return {
+      isReplaying: progress.isReplaying,
+      rowsReplayed: progress.rowsReplayed ?? 0,
+      totalRows: progress.totalRows ?? 0,
+    };
+  } catch {
+    return { isReplaying: false, rowsReplayed: 0, totalRows: 0 };
+  }
+}
+
+export class DiagnosticsService {
+  private readonly deps: DiagnosticsServiceDependencies;
+
+  constructor(deps?: Partial<DiagnosticsServiceDependencies>) {
+    this.deps = {
+      getDbPool: deps?.getDbPool ?? getPool,
+      pingRedis: deps?.pingRedis ?? defaultPingRedis,
+      getCircuitBreakerState: deps?.getCircuitBreakerState ?? defaultGetCircuitBreakerState,
+      getIndexerLagSeconds: deps?.getIndexerLagSeconds ?? defaultGetIndexerLagSeconds,
+      getIndexerReplayProgress: deps?.getIndexerReplayProgress ?? defaultGetIndexerReplayProgress,
+      checkTimeoutMs: deps?.checkTimeoutMs ?? DEFAULT_CHECK_TIMEOUT_MS,
+    };
+  }
+
+  /** Replace the singleton check timeout (useful in tests). */
+  setCheckTimeoutMs(ms: number): void {
+    (this.deps as DiagnosticsServiceDependencies).checkTimeoutMs = ms;
+  }
+
+  /**
+   * Run all diagnostics sub-checks concurrently with individual timeouts.
+   */
+  async runDiagnostics(): Promise<DiagnosticsReport> {
+    const timestamp = new Date().toISOString();
+
+    const [dbPool, redis, circuitBreaker, indexer] = await Promise.all([
+      this.checkDbPool(),
+      this.checkRedis(),
+      this.checkCircuitBreaker(),
+      this.checkIndexer(),
+    ]);
+
+    return { timestamp, dbPool, redis, circuitBreaker, indexer };
+  }
+
+  // ── DB pool check ──────────────────────────────────────────────────────────
+
+  private async checkDbPool(): Promise<SubCheckResult<DbPoolSnapshot>> {
+    const start = Date.now();
+    try {
+      const pool = this.deps.getDbPool();
+      const conn = await withTimeout(
+        pool.connect(),
+        this.deps.checkTimeoutMs,
+        'dbPool',
+      );
+      try {
+        await withTimeout(
+          conn.query('SELECT 1'),
+          this.deps.checkTimeoutMs,
+          'dbPool_query',
+        );
+        const metrics = getPoolMetrics(pool);
+        return {
+          status: 'ok',
+          latencyMs: Date.now() - start,
+          value: {
+            active: metrics.total - metrics.idle,
+            idle: metrics.idle,
+            waiting: metrics.waiting,
+          },
+        };
+      } finally {
+        conn.release();
+      }
+    } catch (err) {
+      const latencyMs = Date.now() - start;
+      const raw = err instanceof Error ? err.message : String(err);
+      return {
+        status: raw.includes('timed out') ? 'timeout' : 'error',
+        latencyMs,
+        error: sanitiseErrorMessage(raw),
+      };
+    }
+  }
+
+  // ── Redis check ─────────────────────────────────────────────────────────────
+
+  private async checkRedis(): Promise<SubCheckResult<RedisSnapshot>> {
+    const start = Date.now();
+    try {
+      const pingMs = await withTimeout(
+        this.deps.pingRedis(),
+        this.deps.checkTimeoutMs,
+        'redis',
+      );
+
+      if (pingMs === null) {
+        return {
+          status: 'ok',
+          latencyMs: Date.now() - start,
+          value: { pingMs: 0 },
+          error: 'Redis is disabled; no check performed',
+        };
+      }
+
+      return {
+        status: 'ok',
+        latencyMs: Date.now() - start,
+        value: { pingMs },
+      };
+    } catch (err) {
+      const latencyMs = Date.now() - start;
+      const raw = err instanceof Error ? err.message : String(err);
+      return {
+        status: raw.includes('timed out') ? 'timeout' : 'error',
+        latencyMs,
+        error: sanitiseErrorMessage(raw),
+      };
+    }
+  }
+
+  // ── Circuit breaker check ───────────────────────────────────────────────────
+
+  private async checkCircuitBreaker(): Promise<SubCheckResult<CircuitBreakerSnapshot>> {
+    const start = Date.now();
+    try {
+      // This is purely in-memory — no I/O — so it should never time out,
+      // but we still wrap it for uniformity and future-proofing.
+      const state = await withTimeout(
+        Promise.resolve(this.deps.getCircuitBreakerState()),
+        this.deps.checkTimeoutMs,
+        'circuitBreaker',
+      );
+
+      return {
+        status: 'ok',
+        latencyMs: Date.now() - start,
+        value: state,
+      };
+    } catch (err) {
+      const latencyMs = Date.now() - start;
+      const raw = err instanceof Error ? err.message : String(err);
+      return {
+        status: raw.includes('timed out') ? 'timeout' : 'error',
+        latencyMs,
+        error: sanitiseErrorMessage(raw),
+      };
+    }
+  }
+
+  // ── Indexer check ───────────────────────────────────────────────────────────
+
+  private async checkIndexer(): Promise<SubCheckResult<IndexerSnapshot>> {
+    const start = Date.now();
+    try {
+      const [lagSeconds, replayProgress] = await Promise.all([
+        withTimeout(
+          Promise.resolve(this.deps.getIndexerLagSeconds()),
+          this.deps.checkTimeoutMs,
+          'indexer_lag',
+        ),
+        withTimeout(
+          Promise.resolve(this.deps.getIndexerReplayProgress()),
+          this.deps.checkTimeoutMs,
+          'indexer_replay',
+        ),
+      ]);
+
+      return {
+        status: 'ok',
+        latencyMs: Date.now() - start,
+        value: {
+          lagSeconds,
+          isReplaying: replayProgress.isReplaying,
+          rowsReplayed: replayProgress.rowsReplayed,
+          totalRows: replayProgress.totalRows,
+        },
+      };
+    } catch (err) {
+      const latencyMs = Date.now() - start;
+      const raw = err instanceof Error ? err.message : String(err);
+      return {
+        status: raw.includes('timed out') ? 'timeout' : 'error',
+        latencyMs,
+        error: sanitiseErrorMessage(raw),
+      };
+    }
+  }
+}
+
+// ── Singleton ──────────────────────────────────────────────────────────────────
+
+let _instance: DiagnosticsService | null = null;
+
+export function getDiagnosticsService(): DiagnosticsService {
+  if (!_instance) {
+    _instance = new DiagnosticsService();
+  }
+  return _instance;
+}
+
+/** Replace the singleton (for testing). */
+export function setDiagnosticsService(svc: DiagnosticsService | null): void {
+  _instance = svc;
+}

--- a/tests/routes/admin.diagnostics.test.ts
+++ b/tests/routes/admin.diagnostics.test.ts
@@ -1,0 +1,234 @@
+/**
+ * Tests for GET /api/admin/diagnostics — #1214
+ *
+ * Coverage:
+ *  - Auth guards: 401 (no token), 403 (bad credentials)
+ *  - Successful diagnostics response with full report shape
+ *  - Sub-check error states (timeout, error)
+ *  - Service-unavailable fallback when diagnostics throws
+ */
+import { describe, it, expect, vi, beforeAll, beforeEach, afterEach } from 'vitest';
+import request from 'supertest';
+
+// ── Mock the diagnostics service before importing app ──────────────────────────
+const mockReport = vi.hoisted(() => ({
+  timestamp: '2026-07-29T12:00:00.000Z',
+  dbPool:     { status: 'ok', latencyMs: 2, value: { active: 3, idle: 5, waiting: 0 } },
+  redis:      { status: 'ok', latencyMs: 1, value: { pingMs: 0.5 } },
+  circuitBreaker: {
+    status: 'ok',
+    latencyMs: 0,
+    value: { state: 'CLOSED', transitionedAt: null, failureCount: 0, degraded: false },
+  },
+  indexer: {
+    status: 'ok',
+    latencyMs: 0,
+    value: { lagSeconds: 0, isReplaying: false, rowsReplayed: 0, totalRows: 0 },
+  },
+}));
+
+const mockRunDiagnostics = vi.fn().mockResolvedValue(mockReport);
+
+vi.mock('../../src/services/diagnostics.js', () => ({
+  getDiagnosticsService: () => ({ runDiagnostics: mockRunDiagnostics }),
+  setDiagnosticsService: vi.fn(),
+}));
+
+// ── Mock downstream dependencies that the app tries to initialise ──────────────
+vi.mock('../../src/db/pool.js', () => ({
+  getPool: vi.fn(),
+  query: vi.fn(),
+  QueryTimeoutError: class QueryTimeoutError extends Error {},
+  getPoolMetrics: vi.fn(() => ({ total: 8, idle: 5, waiting: 0 })),
+}));
+
+vi.mock('../../src/webhooks/retry.js', () => ({
+  attemptWebhookDeliveryWithRateLimit: vi.fn(),
+  scheduleWebhookOutboxRetry: vi.fn(),
+  calculateNextRetryTime: vi.fn(),
+  generateRetrySchedule: vi.fn(),
+}));
+
+vi.mock('../../src/openapi/spec.js', () => ({ openApiDocument: {} }));
+
+import { app } from '../../src/app.js';
+import { initializeConfig } from '../../src/config/env.js';
+
+const ADMIN_KEY = 'test-admin-key-for-diagnostics';
+
+function authed(req: request.Test): request.Test {
+  return req.set('Authorization', `Bearer ${ADMIN_KEY}`);
+}
+
+describe('GET /api/admin/diagnostics', () => {
+  let originalKey: string | undefined;
+
+  beforeAll(() => {
+    initializeConfig();
+  });
+
+  beforeEach(() => {
+    originalKey = process.env.ADMIN_API_KEY;
+    process.env.ADMIN_API_KEY = ADMIN_KEY;
+    mockRunDiagnostics.mockResolvedValue(mockReport);
+  });
+
+  afterEach(() => {
+    if (originalKey !== undefined) {
+      process.env.ADMIN_API_KEY = originalKey;
+    } else {
+      delete process.env.ADMIN_API_KEY;
+    }
+  });
+
+  // ── Auth guards ──────────────────────────────────────────────────────────
+
+  it('rejects unauthenticated requests with 401', async () => {
+    const res = await request(app).get('/api/admin/diagnostics');
+    expect(res.status).toBe(401);
+    expect(res.body).toEqual({ error: 'Missing Authorization header.' });
+  });
+
+  it('rejects requests with bad credentials with 403', async () => {
+    const res = await request(app)
+      .get('/api/admin/diagnostics')
+      .set('Authorization', 'Bearer wrong');
+    expect(res.status).toBe(403);
+  });
+
+  it('fails closed with 503 when admin auth is unconfigured', async () => {
+    delete process.env.ADMIN_API_KEY;
+
+    const res = await request(app).get('/api/admin/diagnostics');
+    expect(res.status).toBe(503);
+    expect(res.body).toEqual({
+      error: 'Admin API is not configured. Set ADMIN_API_KEY to enable admin access.',
+    });
+  });
+
+  // ── Happy path ───────────────────────────────────────────────────────────
+
+  it('returns a successful diagnostics report in the standard envelope', async () => {
+    const res = await authed(request(app).get('/api/admin/diagnostics'));
+
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveProperty('success', true);
+    expect(res.body).toHaveProperty('data');
+    expect(res.body).toHaveProperty('meta');
+    expect(res.body.meta).toHaveProperty('timestamp');
+
+    const data = res.body.data;
+    expect(data).toHaveProperty('timestamp');
+    expect(data).toHaveProperty('dbPool');
+    expect(data).toHaveProperty('redis');
+    expect(data).toHaveProperty('circuitBreaker');
+    expect(data).toHaveProperty('indexer');
+  });
+
+  it('dbPool sub-check has active, idle, and waiting counts', async () => {
+    const res = await authed(request(app).get('/api/admin/diagnostics'));
+    const dbPool = res.body.data.dbPool;
+
+    expect(dbPool).toMatchObject({
+      status: 'ok',
+      value: expect.objectContaining({
+        active: expect.any(Number),
+        idle: expect.any(Number),
+        waiting: expect.any(Number),
+      }),
+    });
+    expect(typeof dbPool.latencyMs).toBe('number');
+  });
+
+  it('redis sub-check has pingMs value', async () => {
+    const res = await authed(request(app).get('/api/admin/diagnostics'));
+    const redis = res.body.data.redis;
+
+    expect(redis).toMatchObject({
+      status: 'ok',
+      value: expect.objectContaining({
+        pingMs: expect.any(Number),
+      }),
+    });
+  });
+
+  it('circuitBreaker sub-check has state, transitionedAt, failureCount, and degraded', async () => {
+    const res = await authed(request(app).get('/api/admin/diagnostics'));
+    const cb = res.body.data.circuitBreaker;
+
+    expect(cb).toMatchObject({
+      status: 'ok',
+      value: expect.objectContaining({
+        state: expect.stringMatching(/^(CLOSED|OPEN|HALF_OPEN)$/),
+        failureCount: expect.any(Number),
+        degraded: expect.any(Boolean),
+      }),
+    });
+    // transitionedAt can be null (never tripped) or number (epoch ms when tripped)
+    expect(
+      cb.value.transitionedAt === null || typeof cb.value.transitionedAt === 'number',
+    ).toBe(true);
+  });
+
+  it('indexer sub-check has lagSeconds and replay status', async () => {
+    const res = await authed(request(app).get('/api/admin/diagnostics'));
+    const indexer = res.body.data.indexer;
+
+    expect(indexer).toMatchObject({
+      status: 'ok',
+      value: expect.objectContaining({
+        lagSeconds: expect.any(Number),
+        isReplaying: expect.any(Boolean),
+      }),
+    });
+  });
+
+  it('returns diagnostics even when some sub-checks have non-lethal errors', async () => {
+    const errorReport = {
+      timestamp: '2026-07-29T12:00:00.000Z',
+      dbPool:     { status: 'ok', latencyMs: 2, value: { active: 3, idle: 5, waiting: 0 } },
+      redis:      { status: 'error', latencyMs: 1000, error: 'Connection refused' },
+      circuitBreaker: {
+        status: 'ok',
+        latencyMs: 0,
+        value: { state: 'OPEN', transitionedAt: 1700000000000, failureCount: 7, degraded: true },
+      },
+      indexer: {
+        status: 'timeout',
+        latencyMs: 5000,
+        error: 'indexer_lag timed out after 5000ms',
+      },
+    };
+    mockRunDiagnostics.mockResolvedValue(errorReport);
+
+    const res = await authed(request(app).get('/api/admin/diagnostics'));
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.dbPool.status).toBe('ok');
+    expect(res.body.data.redis.status).toBe('error');
+    expect(res.body.data.circuitBreaker.status).toBe('ok');
+    expect(res.body.data.indexer.status).toBe('timeout');
+  });
+
+  // ── Error handling ───────────────────────────────────────────────────────
+
+  it('returns 503 when the diagnostics service throws', async () => {
+    mockRunDiagnostics.mockRejectedValue(new Error('Unexpected diagnostics failure'));
+
+    const res = await authed(request(app).get('/api/admin/diagnostics'));
+
+    expect(res.status).toBe(503);
+    expect(res.body).toMatchObject({
+      success: false,
+      error: {
+        code: 'DIAGNOSTICS_ERROR',
+      },
+    });
+  });
+
+  it('does not invoke diagnostics when not authenticated', async () => {
+    await request(app).get('/api/admin/diagnostics');
+
+    expect(mockRunDiagnostics).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Closes #1214

## Summary

- Adds GET /api/admin/diagnostics endpoint returning aggregated system diagnostics snapshot
- Each sub-check (DB pool, Redis, circuit breaker, indexer) individually timeout-bounded
- DiagnosticsService with injectable dependencies for full testability

## Testing

- Unit tests in tests/routes/admin.diagnostics.test.ts cover auth guards, successful response shape, partial error states, and 503 fallback
- Ran admin route tests (pre-existing) — all pass
- Code reviewed for security: error messages sanitised, no credentials leaked, DoS-protected via per-check timeouts
