### PR TITLE
Add Reflector-based fiat conversion display

### DIFF
--- a/src/components/AmountDisplay.tsx
+++ b/src/components/AmountDisplay.tsx
@@ -1,0 +1,51 @@
+import React from 'react';
+import { ReflectorOracle, type FiatCurrency } from '../lib/stellar/reflector.js';
+
+export interface AmountDisplayProps {
+  amount: number;
+  assetCode: string;
+  assetIssuer: string;
+  currency: FiatCurrency;
+  fiatCurrency?: FiatCurrency;
+  oracle?: ReflectorOracle;
+  showFiat?: boolean;
+}
+
+export function AmountDisplay({
+  amount,
+  assetCode,
+  assetIssuer,
+  currency,
+  fiatCurrency = 'USD',
+  oracle,
+  showFiat = true,
+}: AmountDisplayProps): JSX.Element {
+  const [fiatValue, setFiatValue] = React.useState<string | undefined>();
+
+  React.useEffect(() => {
+    let cancelled = false;
+    const run = async () => {
+      if (!showFiat) {
+        setFiatValue(undefined);
+        return;
+      }
+      const resolvedOracle = oracle ?? new ReflectorOracle();
+      const formatted = await resolvedOracle.formatAmount(amount, assetCode, assetIssuer, fiatCurrency);
+      if (!cancelled) {
+        setFiatValue(formatted);
+      }
+    };
+
+    void run();
+    return () => {
+      cancelled = true;
+    };
+  }, [amount, assetCode, assetIssuer, fiatCurrency, oracle, showFiat]);
+
+  return (
+    <span>
+      <span>{amount}</span>
+      {fiatValue ? <span>{` ${fiatValue}`}</span> : null}
+    </span>
+  );
+}

--- a/src/lib/stellar/reflector.ts
+++ b/src/lib/stellar/reflector.ts
@@ -1,0 +1,96 @@
+export type FiatCurrency = 'USD' | 'EUR' | 'GBP' | 'NGN';
+
+export interface ReflectorResponse {
+  price?: number;
+  [key: string]: unknown;
+}
+
+export interface ReflectorOracleOptions {
+  baseUrl?: string;
+  fetchImpl?: typeof fetch;
+  ttlMs?: number;
+}
+
+interface CacheEntry {
+  value: number;
+  expiresAt: number;
+}
+
+const DEFAULT_BASE_URL = 'https://api.reflector.network/v1/prices';
+const DEFAULT_TTL_MS = 60_000;
+const DEFAULT_CURRENCY_SYMBOLS: Record<FiatCurrency, string> = {
+  USD: '$',
+  EUR: '€',
+  GBP: '£',
+  NGN: '₦',
+};
+
+export class ReflectorOracle {
+  private readonly baseUrl: string;
+  private readonly fetchImpl: typeof fetch;
+  private readonly ttlMs: number;
+  private readonly cache = new Map<string, CacheEntry>();
+
+  constructor(options: ReflectorOracleOptions = {}) {
+    this.baseUrl = options.baseUrl ?? DEFAULT_BASE_URL;
+    this.fetchImpl = options.fetchImpl ?? fetch;
+    this.ttlMs = options.ttlMs ?? DEFAULT_TTL_MS;
+  }
+
+  async getPrice(assetCode: string, assetIssuer: string, currency: FiatCurrency): Promise<number | undefined> {
+    const cacheKey = `${assetCode}:${assetIssuer}:${currency}`;
+    const cached = this.cache.get(cacheKey);
+    if (cached && cached.expiresAt > Date.now()) {
+      return cached.value;
+    }
+
+    try {
+      const url = new URL(this.baseUrl);
+      url.searchParams.set('asset_code', assetCode);
+      url.searchParams.set('asset_issuer', assetIssuer);
+      url.searchParams.set('currency', currency);
+
+      const response = await this.fetchImpl(url.toString());
+      if (!response.ok) {
+        return undefined;
+      }
+
+      const payload = (await response.json()) as ReflectorResponse;
+      const price = payload.price;
+      if (typeof price !== 'number' || Number.isNaN(price)) {
+        return undefined;
+      }
+
+      this.cache.set(cacheKey, { value: price, expiresAt: Date.now() + this.ttlMs });
+      return price;
+    } catch {
+      return undefined;
+    }
+  }
+
+  async formatAmount(amount: number, assetCode: string, assetIssuer: string, currency: FiatCurrency): Promise<string | undefined> {
+    const price = await this.getPrice(assetCode, assetIssuer, currency);
+    if (price === undefined) {
+      return undefined;
+    }
+
+    const value = amount * price;
+    return `≈ ${formatFiatAmount(value, currency)}`;
+  }
+}
+
+export function formatFiatAmount(amount: number, currency: FiatCurrency): string {
+  const symbol = DEFAULT_CURRENCY_SYMBOLS[currency];
+  const normalized = new Intl.NumberFormat('en-US', {
+    style: 'currency',
+    currency,
+    maximumFractionDigits: 2,
+    minimumFractionDigits: 2,
+  }).format(amount);
+
+  if (currency === 'NGN') {
+    return `${symbol}${normalized.replace(/^\D+/, '')}`;
+  }
+
+  return normalized;
+}

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { type FiatCurrency } from '../lib/stellar/reflector.js';
+
+export interface SettingsProps {
+  fiatCurrency?: FiatCurrency;
+  onFiatCurrencyChange?: (currency: FiatCurrency) => void;
+}
+
+export function Settings({ fiatCurrency = 'USD', onFiatCurrencyChange }: SettingsProps): JSX.Element {
+  return (
+    <div>
+      <label htmlFor="fiat-currency">Fiat currency</label>
+      <select
+        id="fiat-currency"
+        value={fiatCurrency}
+        onChange={(event) => onFiatCurrencyChange?.(event.target.value as FiatCurrency)}
+      >
+        <option value="USD">USD</option>
+        <option value="EUR">EUR</option>
+        <option value="GBP">GBP</option>
+        <option value="NGN">NGN</option>
+      </select>
+    </div>
+  );
+}

--- a/tests/lib/stellar/reflector.test.ts
+++ b/tests/lib/stellar/reflector.test.ts
@@ -1,0 +1,51 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { ReflectorOracle, formatFiatAmount } from '../../../src/lib/stellar/reflector.js';
+
+describe('ReflectorOracle', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-01-01T00:00:00.000Z'));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it('returns undefined when the oracle is unreachable', async () => {
+    const fetchImpl = vi.fn(async () => {
+      throw new Error('offline');
+    });
+    const oracle = new ReflectorOracle({ fetchImpl, ttlMs: 60_000 });
+
+    await expect(oracle.getPrice('USDC', 'issuer', 'USD')).resolves.toBeUndefined();
+  });
+
+  it('caches prices for 60 seconds and refreshes afterward', async () => {
+    const fetchImpl = vi.fn(async () => ({
+      ok: true,
+      json: async () => ({ price: 1.23 }),
+    }));
+    const oracle = new ReflectorOracle({ fetchImpl, ttlMs: 60_000 });
+
+    await expect(oracle.getPrice('USDC', 'issuer', 'USD')).resolves.toBe(1.23);
+    await expect(oracle.getPrice('USDC', 'issuer', 'USD')).resolves.toBe(1.23);
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+
+    vi.advanceTimersByTime(60_001);
+
+    await expect(oracle.getPrice('USDC', 'issuer', 'USD')).resolves.toBe(1.23);
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+  });
+
+  it('formats amounts in the selected currency and hides the suffix when unavailable', async () => {
+    const fetchImpl = vi.fn(async () => ({
+      ok: true,
+      json: async () => ({ price: 2 }),
+    }));
+    const oracle = new ReflectorOracle({ fetchImpl, ttlMs: 60_000 });
+
+    await expect(oracle.formatAmount(12.5, 'USDC', 'issuer', 'EUR')).resolves.toBe('≈ €25.00');
+    await expect(formatFiatAmount(12.5, 'USD')).toBe('$12.50');
+  });
+});


### PR DESCRIPTION
Pull Request SummaryType: Bug fix / Feature updateComponent: Fiat conversion displayIntegration: Reflector-based rate fetchingKey ChangesDisplay Logic: Updated UI components to render converted fiat values using Reflector data.Data Fetching: Connected the conversion service to handle live rate updates correctly.Error Handling: Added fallback states for missing or failed rate requests.

closes #1064 