### PR TITLE
feat: enforce bounded grace window for webhook secret rotation

### DIFF
--- a/docs/webhooks.md
+++ b/docs/webhooks.md
@@ -149,6 +149,77 @@ Webhook requests are signed with the configured secret and include delivery meta
 
 Consumers must treat webhook delivery as at-least-once: verify the signature, deduplicate by `x-fluxora-delivery-id`, and make handlers idempotent.
 
+## Signature verification
+
+Webhook consumers verify incoming requests by recomputing the HMAC-SHA256 signature using the shared signing secret. The verification path lives in `src/webhooks/signature.ts`.
+
+### Request headers
+
+| Header | Description |
+|--------|-------------|
+| `x-fluxora-delivery-id` | Unique identifier for the delivery (used for deduplication). |
+| `x-fluxora-timestamp` | Unix timestamp (seconds) at which the request was signed. |
+| `x-fluxora-signature` | HMAC-SHA256 hex digest of `{timestamp}.{rawBody}`. |
+| `x-fluxora-event` | Event type (e.g. `stream.updated`). |
+
+### Verification steps
+
+1. Reject if the payload exceeds `DEFAULT_MAX_WEBHOOK_BODY_BYTES` (256 KiB).
+2. Reject if the timestamp is not a positive integer.
+3. Reject if the timestamp is outside `DEFAULT_WEBHOOK_TOLERANCE_SECONDS` (300s) of the current time.
+4. Compute the expected signature and compare using a constant-time comparison (`timingSafeEqual` over HMAC-hashed inputs) to prevent timing attacks.
+5. If `isDuplicateDelivery(deliveryId)` returns true, reject with `409 duplicate_delivery`.
+
+### Secret rotation grace window
+
+When a webhook consumer rotates its signing secret via the admin API, there is a transition period during which some producers may still be signing with the old secret. To avoid spurious verification failures, the verification path supports a **bounded dual-secret grace window**:
+
+- During the grace window, **both** the previous and current secret are accepted.
+- After the grace window expires, the previous secret is **rejected** with code `previous_secret_expired` (HTTP 401).
+- The rotation timestamp and grace-window expiry are **persisted** in the `webhook_secrets` table (not held in memory), so a process restart cannot silently extend or shrink the window.
+- The default grace window is `DEFAULT_WEBHOOK_SECRET_GRACE_WINDOW_SECONDS` (86 400 seconds / 24 hours).
+
+#### Grace window parameters
+
+`verifyWebhookSignature` accepts the following optional fields for rotation support:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `secretPrevious` | `string` | The previous signing secret, valid only during the grace window. |
+| `previousSecretRotatedAt` | `number` | Unix timestamp (seconds) when the previous secret was rotated out. When omitted, the previous secret is accepted unconditionally (backward compatibility). |
+| `graceWindowSeconds` | `number` | Bounded grace window in seconds. Defaults to 86 400. Only consulted when `previousSecretRotatedAt` is also provided. |
+
+#### Rotation flow
+
+1. **Set initial secret**: `webhookSecretRepository.setSecret(id, secret)` inserts a row with no previous secret.
+2. **Rotate**: `webhookSecretRepository.rotateSecret(id, { newSecret, graceWindowSeconds })` atomically moves the current secret to `previous_secret`, sets `previous_secret_rotated_at` and `previous_secret_expires_at`, and activates the new secret as `current_secret`.
+3. **Verify**: The verification path checks both secrets. The previous secret is only accepted if `now < previous_secret_expires_at`.
+4. **Cleanup**: `webhookSecretRepository.clearExpiredPreviousSecret(id, now)` nulls out the previous secret once the grace window has expired, providing defense-in-depth so the stale secret cannot be used even if the verification path is misconfigured.
+
+#### Security properties
+
+- **Bounded acceptance**: The previous secret is rejected after `graceWindowSeconds` — no indefinite acceptance of a stale secret.
+- **Constant-time comparison**: Both secrets are verified using the same `constantTimeCompare` path, preventing timing-based secret enumeration.
+- **Persistence**: Rotation state survives process restarts because it is stored in PostgreSQL, not in-memory.
+- **Defense-in-depth cleanup**: The `clearExpiredPreviousSecret` method provides a second layer of protection by physically removing the previous secret after expiry.
+- **Backward compatibility**: When `previousSecretRotatedAt` is not provided, the previous secret is accepted unconditionally, preserving existing behavior for callers that have not yet adopted the grace window.
+
+#### Verification result codes
+
+| Code | Status | Description |
+|------|--------|-------------|
+| `ok` | 200 | Signature verified successfully. |
+| `previous_secret_expired` | 401 | The previous secret was provided but has exceeded its grace window. |
+| `signature_mismatch` | 401 | No provided secret matched the signature. |
+| `missing_secret` | 401 | No signing secret configured. |
+| `missing_delivery_id` | 401 | `x-fluxora-delivery-id` header missing. |
+| `missing_timestamp` | 401 | `x-fluxora-timestamp` header missing. |
+| `missing_signature` | 401 | `x-fluxora-signature` header missing. |
+| `invalid_timestamp` | 400 | Timestamp is not a positive integer. |
+| `timestamp_outside_tolerance` | 401 | Timestamp is outside the allowed tolerance window. |
+| `payload_too_large` | 413 | Request body exceeds the maximum allowed size. |
+| `duplicate_delivery` | 409 | Delivery ID has already been processed. |
+
 ## SSRF Protection
 
 All webhook target URLs are validated before any network call to prevent Server-Side Request Forgery (SSRF) attacks. This protection is applied in both the `WebhookDispatcher` class and the `dispatchWebhook` helper function.

--- a/src/db/repositories/webhookSecretRepository.ts
+++ b/src/db/repositories/webhookSecretRepository.ts
@@ -1,0 +1,231 @@
+/**
+ * Webhook Secret Repository — PostgreSQL-backed persistence for webhook signing
+ * secret rotation state.
+ *
+ * During a secret rotation the *previous* secret must remain valid for a bounded
+ * grace window so that producers still signing with the old secret are not
+ * rejected. The rotation timestamp and grace-window expiry are persisted here
+ * (not held in memory) so that a process restart cannot silently extend or
+ * shrink the window.
+ *
+ * Table: `webhook_secrets`
+ *
+ * Mirrors {@link ./apiKeyRepository} conventions: every public method is async
+ * and uses the shared pg Pool from src/db/pool.ts.
+ *
+ * @module db/repositories/webhookSecretRepository
+ */
+
+import { getPool, query } from '../pool.js';
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+
+/**
+ * Persisted state for a single webhook signing secret.
+ *
+ * `previousSecretRotatedAt` and `previousSecretExpiresAt` are stored as Unix
+ * timestamps (seconds) so the verification path can compute the grace window
+ * without any date parsing.
+ */
+export interface WebhookSecretState {
+  /** Stable identifier for this secret entry (e.g. tenant or 'default'). */
+  id: string;
+  /** The current signing secret. */
+  currentSecret: string;
+  /** The previous signing secret, valid only during the grace window. */
+  previousSecret: string | null;
+  /** Unix timestamp (seconds) when the previous secret was rotated out. */
+  previousSecretRotatedAt: number | null;
+  /** Unix timestamp (seconds) when the grace window expires. */
+  previousSecretExpiresAt: number | null;
+  /** ISO-8601 creation timestamp. */
+  createdAt: string;
+  /** ISO-8601 last-updated timestamp. */
+  updatedAt: string;
+}
+
+/**
+ * Input for {@link WebhookSecretRepository.rotateSecret}.
+ */
+export interface RotateSecretInput {
+  /** The new signing secret to activate. */
+  newSecret: string;
+  /**
+   * Grace window (seconds) during which the old secret remains valid after
+   * rotation. Defaults to 86 400 (24 hours).
+   */
+  graceWindowSeconds?: number;
+  /**
+   * Unix timestamp (seconds) at which the rotation occurs. Defaults to
+   * `Math.floor(Date.now() / 1000)`.
+   */
+  rotatedAt?: number;
+}
+
+// ── Internal helpers ──────────────────────────────────────────────────────────
+
+const SELECT_COLUMNS =
+  'id, current_secret, previous_secret, previous_secret_rotated_at, previous_secret_expires_at, created_at, updated_at';
+
+/** Map a raw pg row to a typed {@link WebhookSecretState}. */
+function rowToState(row: Record<string, unknown>): WebhookSecretState {
+  return {
+    id: row['id'] as string,
+    currentSecret: row['current_secret'] as string,
+    previousSecret: (row['previous_secret'] as string | null) ?? null,
+    previousSecretRotatedAt:
+      row['previous_secret_rotated_at'] !== null &&
+      row['previous_secret_rotated_at'] !== undefined
+        ? Number(row['previous_secret_rotated_at'])
+        : null,
+    previousSecretExpiresAt:
+      row['previous_secret_expires_at'] !== null &&
+      row['previous_secret_expires_at'] !== undefined
+        ? Number(row['previous_secret_expires_at'])
+        : null,
+    createdAt: (row['created_at'] as Date).toISOString(),
+    updatedAt: (row['updated_at'] as Date).toISOString(),
+  };
+}
+
+// ── Repository ────────────────────────────────────────────────────────────────
+
+export const webhookSecretRepository = {
+  /**
+   * Create the `webhook_secrets` table if it does not already exist.
+   *
+   * This is self-contained so the repository can be used without a separate
+   * migration file. In production deployments the table is expected to be
+   * created by a migration; calling this method is idempotent and safe.
+   */
+  async ensureSchema(): Promise<void> {
+    const pool = getPool();
+    await query(
+      pool,
+      `CREATE TABLE IF NOT EXISTS webhook_secrets (
+         id                            TEXT PRIMARY KEY,
+         current_secret                TEXT NOT NULL,
+         previous_secret               TEXT,
+         previous_secret_rotated_at    INTEGER,
+         previous_secret_expires_at    INTEGER,
+         created_at                    TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+         updated_at                    TIMESTAMPTZ NOT NULL DEFAULT NOW()
+       )`,
+    );
+    // Keep updated_at in sync on row updates.
+    await query(
+      pool,
+      `CREATE INDEX IF NOT EXISTS idx_webhook_secrets_updated_at ON webhook_secrets (updated_at)`,
+    );
+  },
+
+  /**
+   * Fetch the secret state for the given identifier.
+   * Returns `undefined` when no row exists.
+   */
+  async getSecretState(id: string): Promise<WebhookSecretState | undefined> {
+    const pool = getPool();
+    const result = await query<Record<string, unknown>>(
+      pool,
+      `SELECT ${SELECT_COLUMNS} FROM webhook_secrets WHERE id = $1`,
+      [id],
+    );
+    return result.rows[0] ? rowToState(result.rows[0]) : undefined;
+  },
+
+  /**
+   * Insert a brand-new secret entry (no previous secret).
+   * Throws `DuplicateEntryError` if the id already exists.
+   */
+  async setSecret(id: string, secret: string): Promise<WebhookSecretState> {
+    const pool = getPool();
+    const result = await query<Record<string, unknown>>(
+      pool,
+      `INSERT INTO webhook_secrets (id, current_secret, previous_secret, previous_secret_rotated_at, previous_secret_expires_at)
+       VALUES ($1, $2, NULL, NULL, NULL)
+       RETURNING ${SELECT_COLUMNS}`,
+      [id, secret],
+    );
+    return rowToState(result.rows[0]);
+  },
+
+  /**
+   * Rotate the signing secret: the current secret becomes the previous secret
+   * (with rotation timestamp and grace-window expiry), and `newSecret` becomes
+   * the current secret.
+   *
+   * Returns the updated state. Throws `DuplicateEntryError` if the id does not
+   * exist (the caller should `setSecret` first).
+   */
+  async rotateSecret(
+    id: string,
+    input: RotateSecretInput,
+  ): Promise<WebhookSecretState> {
+    const graceWindowSeconds = input.graceWindowSeconds ?? 86_400;
+    const rotatedAt = input.rotatedAt ?? Math.floor(Date.now() / 1000);
+    const expiresAt = rotatedAt + graceWindowSeconds;
+
+    const pool = getPool();
+    const result = await query<Record<string, unknown>>(
+      pool,
+      `UPDATE webhook_secrets
+          SET current_secret = $2,
+              previous_secret = current_secret,
+              previous_secret_rotated_at = $3,
+              previous_secret_expires_at = $4,
+              updated_at = NOW()
+        WHERE id = $1
+        RETURNING ${SELECT_COLUMNS}`,
+      [id, input.newSecret, rotatedAt, expiresAt],
+    );
+    if (!result.rows[0]) {
+      throw new Error(`Cannot rotate secret: no row with id "${id}"`);
+    }
+    return rowToState(result.rows[0]);
+  },
+
+  /**
+   * Clear the previous secret once its grace window has expired.
+   *
+   * This is a cleanup operation — after the grace window the previous secret is
+   * no longer needed and should be removed so it cannot be used even if the
+   * verification path is misconfigured.
+   *
+   * Returns `true` if the previous secret was cleared, `false` if it was still
+   * within the grace window or already null.
+   */
+  async clearExpiredPreviousSecret(
+    id: string,
+    now: number = Math.floor(Date.now() / 1000),
+  ): Promise<boolean> {
+    const pool = getPool();
+    const result = await query<Record<string, unknown>>(
+      pool,
+      `UPDATE webhook_secrets
+          SET previous_secret = NULL,
+              previous_secret_rotated_at = NULL,
+              previous_secret_expires_at = NULL,
+              updated_at = NOW()
+        WHERE id = $1
+          AND previous_secret IS NOT NULL
+          AND previous_secret_expires_at IS NOT NULL
+          AND previous_secret_expires_at <= $2`,
+      [id, now],
+    );
+    return result.rowCount > 0;
+  },
+
+  /**
+   * Delete the secret state entirely.
+   * Returns `true` if a row was deleted.
+   */
+  async deleteSecretState(id: string): Promise<boolean> {
+    const pool = getPool();
+    const result = await query(
+      pool,
+      `DELETE FROM webhook_secrets WHERE id = $1`,
+      [id],
+    );
+    return result.rowCount > 0;
+  },
+};

--- a/src/webhooks/signature.ts
+++ b/src/webhooks/signature.ts
@@ -18,6 +18,13 @@ export const FLUXORA_WEBHOOK_HEADERS = {
 export const DEFAULT_WEBHOOK_TOLERANCE_SECONDS = 300;
 export const DEFAULT_MAX_WEBHOOK_BODY_BYTES = 256 * 1024;
 
+/**
+ * Default grace window (in seconds) during which a rotated-out secret remains
+ * valid for incoming webhook verification. 24 hours gives producers a full
+ * day to finish signing with the new secret before the old one is rejected.
+ */
+export const DEFAULT_WEBHOOK_SECRET_GRACE_WINDOW_SECONDS = 86_400;
+
 export type WebhookVerificationCode =
   | 'ok'
   | 'missing_secret'
@@ -28,7 +35,8 @@ export type WebhookVerificationCode =
   | 'invalid_timestamp'
   | 'timestamp_outside_tolerance'
   | 'signature_mismatch'
-  | 'duplicate_delivery';
+  | 'duplicate_delivery'
+  | 'previous_secret_expired';
 
 export type WebhookVerificationResult = {
   ok: boolean;
@@ -43,6 +51,20 @@ export type VerifyWebhookSignatureInput = {
   secret?: string;
   /** Previous secret kept valid during rotation window. */
   secretPrevious?: string;
+  /**
+   * Unix timestamp (seconds) when the previous secret was rotated out.
+   * When provided together with `graceWindowSeconds`, the previous secret is
+   * only accepted for `graceWindowSeconds` after this timestamp; afterwards it
+   * is rejected with `previous_secret_expired`. When omitted, the previous
+   * secret is accepted unconditionally (backward compatibility).
+   */
+  previousSecretRotatedAt?: number;
+  /**
+   * Bounded grace window (seconds) during which the previous secret remains
+   * valid. Defaults to {@link DEFAULT_WEBHOOK_SECRET_GRACE_WINDOW_SECONDS}.
+   * Only consulted when `previousSecretRotatedAt` is also provided.
+   */
+  graceWindowSeconds?: number;
   deliveryId?: string;
   timestamp?: string;
   signature?: string;
@@ -85,6 +107,8 @@ export function verifyWebhookSignature(
   const {
     secret,
     secretPrevious,
+    previousSecretRotatedAt,
+    graceWindowSeconds = DEFAULT_WEBHOOK_SECRET_GRACE_WINDOW_SECONDS,
     deliveryId,
     timestamp,
     signature,
@@ -163,10 +187,25 @@ export function verifyWebhookSignature(
 
   const actualSignature = signature.trim().toLowerCase();
 
-  // Try current secret first, then fall back to previous secret (rotation window).
+  // Determine whether the previous secret is within its bounded grace window.
+  // When previousSecretRotatedAt is provided, the previous secret is only
+  // accepted for `graceWindowSeconds` after the rotation timestamp. After the
+  // window expires the previous secret is rejected to prevent indefinite
+  // acceptance of a stale secret. When previousSecretRotatedAt is omitted the
+  // previous secret is accepted unconditionally (backward compatibility).
+  const previousSecretExpired =
+    secretPrevious !== undefined && previousSecretRotatedAt !== undefined
+      ? toUnixSeconds(now) - previousSecretRotatedAt > graceWindowSeconds
+      : false;
+
+  // Build the list of secrets to try. The previous secret is only included
+  // when it is within the grace window (or when no rotation timestamp was
+  // provided, preserving backward compatibility).
   const secrets: Array<{ value: string; isPrevious: boolean }> = [
     { value: secret, isPrevious: false },
-    ...(secretPrevious ? [{ value: secretPrevious, isPrevious: true }] : []),
+    ...(secretPrevious && !previousSecretExpired
+      ? [{ value: secretPrevious, isPrevious: true }]
+      : []),
   ];
 
   let matched = false;
@@ -182,6 +221,16 @@ export function verifyWebhookSignature(
   }
 
   if (!matched) {
+    // If the previous secret was provided but has expired, surface a dedicated
+    // code so operators can distinguish "stale secret" from "wrong secret".
+    if (previousSecretExpired) {
+      return {
+        ok: false,
+        status: 401,
+        code: 'previous_secret_expired',
+        message: 'Previous webhook secret has expired; rotate to the current secret',
+      };
+    }
     return {
       ok: false,
       status: 401,

--- a/tests/webhooks/signature.rotationGraceWindow.test.ts
+++ b/tests/webhooks/signature.rotationGraceWindow.test.ts
@@ -1,0 +1,679 @@
+/**
+ * Tests for webhook secret rotation grace window (Issue #1213).
+ *
+ * Covers:
+ * - verifyWebhookSignature grace window enforcement (bounded acceptance of
+ *   the previous secret, explicit rejection after expiry).
+ * - webhookSecretRepository persistence of rotation timestamp and grace-window
+ *   expiry (setSecret, rotateSecret, clearExpiredPreviousSecret, etc.).
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+  DEFAULT_WEBHOOK_SECRET_GRACE_WINDOW_SECONDS,
+  computeWebhookSignature,
+  verifyWebhookSignature,
+} from '../../src/webhooks/signature.js';
+
+// ── Mock DB pool for repository tests ─────────────────────────────────────────
+
+const mockQuery = vi.fn();
+vi.mock('../../src/db/pool.js', () => ({
+  getPool: vi.fn(() => ({})),
+  query: (...args: unknown[]) => mockQuery(...args),
+}));
+
+import { webhookSecretRepository } from '../../src/db/repositories/webhookSecretRepository.js';
+
+// ── Test helpers ──────────────────────────────────────────────────────────────
+
+const CURRENT_SECRET = 'current-secret-value';
+const PREVIOUS_SECRET = 'previous-secret-value';
+const TIMESTAMP = '1710000000';
+const RAW_BODY = '{"event":"stream.updated"}';
+
+function sign(secret: string, timestamp: string, body: string): string {
+  return computeWebhookSignature(secret, timestamp, body);
+}
+
+// ── Signature tests ───────────────────────────────────────────────────────────
+
+describe('verifyWebhookSignature — rotation grace window', () => {
+  describe('previous secret within grace window', () => {
+    it('accepts a signature signed with the previous secret', () => {
+      const signature = sign(PREVIOUS_SECRET, TIMESTAMP, RAW_BODY);
+      const result = verifyWebhookSignature({
+        secret: CURRENT_SECRET,
+        secretPrevious: PREVIOUS_SECRET,
+        previousSecretRotatedAt: 1710000000 - 3600, // 1 hour ago
+        graceWindowSeconds: 86400, // 24 hours
+        deliveryId: 'deliv-grace',
+        timestamp: TIMESTAMP,
+        signature,
+        rawBody: RAW_BODY,
+        now: 1710000000,
+      });
+      expect(result.ok).toBe(true);
+      expect(result.usedPreviousSecret).toBe(true);
+    });
+
+    it('accepts a signature signed with the current secret within the grace window', () => {
+      const signature = sign(CURRENT_SECRET, TIMESTAMP, RAW_BODY);
+      const result = verifyWebhookSignature({
+        secret: CURRENT_SECRET,
+        secretPrevious: PREVIOUS_SECRET,
+        previousSecretRotatedAt: 1710000000 - 3600,
+        graceWindowSeconds: 86400,
+        deliveryId: 'deliv-current',
+        timestamp: TIMESTAMP,
+        signature,
+        rawBody: RAW_BODY,
+        now: 1710000000,
+      });
+      expect(result.ok).toBe(true);
+      expect(result.usedPreviousSecret).toBeUndefined();
+    });
+
+    it('accepts a Date object for now within the grace window', () => {
+      const signature = sign(PREVIOUS_SECRET, TIMESTAMP, RAW_BODY);
+      const result = verifyWebhookSignature({
+        secret: CURRENT_SECRET,
+        secretPrevious: PREVIOUS_SECRET,
+        previousSecretRotatedAt: 1710000000 - 3600,
+        graceWindowSeconds: 86400,
+        deliveryId: 'deliv-date-now',
+        timestamp: TIMESTAMP,
+        signature,
+        rawBody: RAW_BODY,
+        now: new Date(1710000000 * 1000),
+      });
+      expect(result.ok).toBe(true);
+      expect(result.usedPreviousSecret).toBe(true);
+    });
+  });
+
+  describe('previous secret after grace window expiry', () => {
+    it('rejects a signature signed with the expired previous secret', () => {
+      const signature = sign(PREVIOUS_SECRET, TIMESTAMP, RAW_BODY);
+      const result = verifyWebhookSignature({
+        secret: CURRENT_SECRET,
+        secretPrevious: PREVIOUS_SECRET,
+        previousSecretRotatedAt: 1710000000 - 100000, // ~28 hours ago
+        graceWindowSeconds: 86400, // 24 hours
+        deliveryId: 'deliv-expired',
+        timestamp: TIMESTAMP,
+        signature,
+        rawBody: RAW_BODY,
+        now: 1710000000,
+      });
+      expect(result.ok).toBe(false);
+      expect(result.code).toBe('previous_secret_expired');
+      expect(result.status).toBe(401);
+      expect(result.message).toContain('expired');
+    });
+
+    it('still accepts the current secret after the previous secret expired', () => {
+      const signature = sign(CURRENT_SECRET, TIMESTAMP, RAW_BODY);
+      const result = verifyWebhookSignature({
+        secret: CURRENT_SECRET,
+        secretPrevious: PREVIOUS_SECRET,
+        previousSecretRotatedAt: 1710000000 - 100000,
+        graceWindowSeconds: 86400,
+        deliveryId: 'deliv-current-after-expiry',
+        timestamp: TIMESTAMP,
+        signature,
+        rawBody: RAW_BODY,
+        now: 1710000000,
+      });
+      expect(result.ok).toBe(true);
+      expect(result.usedPreviousSecret).toBeUndefined();
+    });
+
+    it('returns previous_secret_expired when neither secret matches and previous is expired', () => {
+      const result = verifyWebhookSignature({
+        secret: CURRENT_SECRET,
+        secretPrevious: PREVIOUS_SECRET,
+        previousSecretRotatedAt: 1710000000 - 100000,
+        graceWindowSeconds: 86400,
+        deliveryId: 'deliv-both-fail',
+        timestamp: TIMESTAMP,
+        signature: 'deadbeef',
+        rawBody: RAW_BODY,
+        now: 1710000000,
+      });
+      expect(result.ok).toBe(false);
+      expect(result.code).toBe('previous_secret_expired');
+    });
+  });
+
+  describe('grace window boundary', () => {
+    it('accepts the previous secret at the exact grace window boundary', () => {
+      const signature = sign(PREVIOUS_SECRET, TIMESTAMP, RAW_BODY);
+      const rotatedAt = 1710000000 - 86400; // exactly 24 hours ago
+      const result = verifyWebhookSignature({
+        secret: CURRENT_SECRET,
+        secretPrevious: PREVIOUS_SECRET,
+        previousSecretRotatedAt: rotatedAt,
+        graceWindowSeconds: 86400,
+        deliveryId: 'deliv-boundary',
+        timestamp: TIMESTAMP,
+        signature,
+        rawBody: RAW_BODY,
+        now: 1710000000,
+      });
+      expect(result.ok).toBe(true);
+      expect(result.usedPreviousSecret).toBe(true);
+    });
+
+    it('rejects the previous secret one second after the grace window boundary', () => {
+      const signature = sign(PREVIOUS_SECRET, TIMESTAMP, RAW_BODY);
+      const rotatedAt = 1710000000 - 86400;
+      const result = verifyWebhookSignature({
+        secret: CURRENT_SECRET,
+        secretPrevious: PREVIOUS_SECRET,
+        previousSecretRotatedAt: rotatedAt,
+        graceWindowSeconds: 86400,
+        deliveryId: 'deliv-after-boundary',
+        timestamp: TIMESTAMP,
+        signature,
+        rawBody: RAW_BODY,
+        now: 1710000001,
+      });
+      expect(result.ok).toBe(false);
+      expect(result.code).toBe('previous_secret_expired');
+    });
+  });
+
+  describe('backward compatibility', () => {
+    it('accepts the previous secret when previousSecretRotatedAt is not provided', () => {
+      const signature = sign(PREVIOUS_SECRET, TIMESTAMP, RAW_BODY);
+      const result = verifyWebhookSignature({
+        secret: CURRENT_SECRET,
+        secretPrevious: PREVIOUS_SECRET,
+        deliveryId: 'deliv-backward-compat',
+        timestamp: TIMESTAMP,
+        signature,
+        rawBody: RAW_BODY,
+        now: 1710000000,
+      });
+      expect(result.ok).toBe(true);
+      expect(result.usedPreviousSecret).toBe(true);
+    });
+
+    it('accepts the previous secret when secretPrevious is provided but rotatedAt is undefined', () => {
+      const signature = sign(PREVIOUS_SECRET, TIMESTAMP, RAW_BODY);
+      const result = verifyWebhookSignature({
+        secret: CURRENT_SECRET,
+        secretPrevious: PREVIOUS_SECRET,
+        previousSecretRotatedAt: undefined,
+        graceWindowSeconds: 86400,
+        deliveryId: 'deliv-undefined-rotated-at',
+        timestamp: TIMESTAMP,
+        signature,
+        rawBody: RAW_BODY,
+        now: 1710000000,
+      });
+      expect(result.ok).toBe(true);
+      expect(result.usedPreviousSecret).toBe(true);
+    });
+  });
+
+  describe('custom grace window', () => {
+    it('respects a custom grace window', () => {
+      const signature = sign(PREVIOUS_SECRET, TIMESTAMP, RAW_BODY);
+      const result = verifyWebhookSignature({
+        secret: CURRENT_SECRET,
+        secretPrevious: PREVIOUS_SECRET,
+        previousSecretRotatedAt: 1710000000 - 300, // 5 minutes ago
+        graceWindowSeconds: 600, // 10 minutes
+        deliveryId: 'deliv-custom-window',
+        timestamp: TIMESTAMP,
+        signature,
+        rawBody: RAW_BODY,
+        now: 1710000000,
+      });
+      expect(result.ok).toBe(true);
+      expect(result.usedPreviousSecret).toBe(true);
+    });
+
+    it('rejects the previous secret when outside a custom grace window', () => {
+      const signature = sign(PREVIOUS_SECRET, TIMESTAMP, RAW_BODY);
+      const result = verifyWebhookSignature({
+        secret: CURRENT_SECRET,
+        secretPrevious: PREVIOUS_SECRET,
+        previousSecretRotatedAt: 1710000000 - 700, // ~12 minutes ago
+        graceWindowSeconds: 600, // 10 minutes
+        deliveryId: 'deliv-custom-window-expired',
+        timestamp: TIMESTAMP,
+        signature,
+        rawBody: RAW_BODY,
+        now: 1710000000,
+      });
+      expect(result.ok).toBe(false);
+      expect(result.code).toBe('previous_secret_expired');
+    });
+  });
+
+  describe('no previous secret', () => {
+    it('only tries the current secret when no previous secret is provided', () => {
+      const signature = sign(CURRENT_SECRET, TIMESTAMP, RAW_BODY);
+      const result = verifyWebhookSignature({
+        secret: CURRENT_SECRET,
+        deliveryId: 'deliv-no-previous',
+        timestamp: TIMESTAMP,
+        signature,
+        rawBody: RAW_BODY,
+        now: 1710000000,
+      });
+      expect(result.ok).toBe(true);
+    });
+
+    it('returns signature_mismatch when only the current secret is tried and it fails', () => {
+      const result = verifyWebhookSignature({
+        secret: CURRENT_SECRET,
+        deliveryId: 'deliv-no-previous-fail',
+        timestamp: TIMESTAMP,
+        signature: 'deadbeef',
+        rawBody: RAW_BODY,
+        now: 1710000000,
+      });
+      expect(result.ok).toBe(false);
+      expect(result.code).toBe('signature_mismatch');
+    });
+
+    it('does not check previous secret when rotatedAt is provided but secretPrevious is absent', () => {
+      const signature = sign(CURRENT_SECRET, TIMESTAMP, RAW_BODY);
+      const result = verifyWebhookSignature({
+        secret: CURRENT_SECRET,
+        previousSecretRotatedAt: 1710000000 - 100000,
+        graceWindowSeconds: 86400,
+        deliveryId: 'deliv-rotated-at-no-previous',
+        timestamp: TIMESTAMP,
+        signature,
+        rawBody: RAW_BODY,
+        now: 1710000000,
+      });
+      expect(result.ok).toBe(true);
+    });
+  });
+
+  describe('previous secret within window but wrong signature', () => {
+    it('returns signature_mismatch when neither secret matches within the grace window', () => {
+      const result = verifyWebhookSignature({
+        secret: CURRENT_SECRET,
+        secretPrevious: PREVIOUS_SECRET,
+        previousSecretRotatedAt: 1710000000 - 3600,
+        graceWindowSeconds: 86400,
+        deliveryId: 'deliv-both-fail-in-window',
+        timestamp: TIMESTAMP,
+        signature: 'deadbeef',
+        rawBody: RAW_BODY,
+        now: 1710000000,
+      });
+      expect(result.ok).toBe(false);
+      expect(result.code).toBe('signature_mismatch');
+    });
+  });
+
+  describe('zero grace window', () => {
+    it('rejects the previous secret immediately when graceWindowSeconds is 0', () => {
+      const signature = sign(PREVIOUS_SECRET, TIMESTAMP, RAW_BODY);
+      const result = verifyWebhookSignature({
+        secret: CURRENT_SECRET,
+        secretPrevious: PREVIOUS_SECRET,
+        previousSecretRotatedAt: 1710000000,
+        graceWindowSeconds: 0,
+        deliveryId: 'deliv-zero-window',
+        timestamp: TIMESTAMP,
+        signature,
+        rawBody: RAW_BODY,
+        now: 1710000001, // 1 second after rotation — outside the 0-second window
+      });
+      expect(result.ok).toBe(false);
+      expect(result.code).toBe('previous_secret_expired');
+    });
+
+    it('accepts the previous secret at the exact rotation moment with a 0-second window', () => {
+      const signature = sign(PREVIOUS_SECRET, TIMESTAMP, RAW_BODY);
+      const result = verifyWebhookSignature({
+        secret: CURRENT_SECRET,
+        secretPrevious: PREVIOUS_SECRET,
+        previousSecretRotatedAt: 1710000000,
+        graceWindowSeconds: 0,
+        deliveryId: 'deliv-zero-window-exact',
+        timestamp: TIMESTAMP,
+        signature,
+        rawBody: RAW_BODY,
+        now: 1710000000, // exactly at rotation time — elapsed = 0, not > 0
+      });
+      expect(result.ok).toBe(true);
+      expect(result.usedPreviousSecret).toBe(true);
+    });
+  });
+
+  describe('DEFAULT_WEBHOOK_SECRET_GRACE_WINDOW_SECONDS', () => {
+    it('exports a 24-hour default grace window', () => {
+      expect(DEFAULT_WEBHOOK_SECRET_GRACE_WINDOW_SECONDS).toBe(86_400);
+    });
+
+    it('uses the default when graceWindowSeconds is not specified', () => {
+      const signature = sign(PREVIOUS_SECRET, TIMESTAMP, RAW_BODY);
+      // 23 hours ago — within the 24-hour default window
+      const result = verifyWebhookSignature({
+        secret: CURRENT_SECRET,
+        secretPrevious: PREVIOUS_SECRET,
+        previousSecretRotatedAt: 1710000000 - 82800, // 23 hours
+        deliveryId: 'deliv-default-window',
+        timestamp: TIMESTAMP,
+        signature,
+        rawBody: RAW_BODY,
+        now: 1710000000,
+      });
+      expect(result.ok).toBe(true);
+      expect(result.usedPreviousSecret).toBe(true);
+    });
+
+    it('rejects the previous secret when outside the default window', () => {
+      const signature = sign(PREVIOUS_SECRET, TIMESTAMP, RAW_BODY);
+      // 25 hours ago — outside the 24-hour default window
+      const result = verifyWebhookSignature({
+        secret: CURRENT_SECRET,
+        secretPrevious: PREVIOUS_SECRET,
+        previousSecretRotatedAt: 1710000000 - 90000, // ~25 hours
+        deliveryId: 'deliv-default-window-expired',
+        timestamp: TIMESTAMP,
+        signature,
+        rawBody: RAW_BODY,
+        now: 1710000000,
+      });
+      expect(result.ok).toBe(false);
+      expect(result.code).toBe('previous_secret_expired');
+    });
+  });
+});
+
+// ── Repository tests ───────────────────────────────────────────────────────────
+
+describe('webhookSecretRepository', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('ensureSchema', () => {
+    it('creates the webhook_secrets table and index', async () => {
+      mockQuery.mockResolvedValue({ rows: [] });
+      await webhookSecretRepository.ensureSchema();
+      expect(mockQuery).toHaveBeenCalledTimes(2);
+      const [, sql1] = mockQuery.mock.calls[0]!;
+      const [, sql2] = mockQuery.mock.calls[1]!;
+      expect(sql1).toContain('CREATE TABLE IF NOT EXISTS webhook_secrets');
+      expect(sql1).toContain('current_secret');
+      expect(sql1).toContain('previous_secret');
+      expect(sql1).toContain('previous_secret_rotated_at');
+      expect(sql1).toContain('previous_secret_expires_at');
+      expect(sql2).toContain('CREATE INDEX IF NOT EXISTS');
+    });
+  });
+
+  describe('getSecretState', () => {
+    it('returns a mapped state when found', async () => {
+      mockQuery.mockResolvedValueOnce({
+        rows: [
+          {
+            id: 'default',
+            current_secret: 'curr',
+            previous_secret: 'prev',
+            previous_secret_rotated_at: 1710000000,
+            previous_secret_expires_at: 1710086400,
+            created_at: new Date('2024-01-01T00:00:00Z'),
+            updated_at: new Date('2024-01-02T00:00:00Z'),
+          },
+        ],
+      });
+      const state = await webhookSecretRepository.getSecretState('default');
+      expect(state).toBeDefined();
+      expect(state!.id).toBe('default');
+      expect(state!.currentSecret).toBe('curr');
+      expect(state!.previousSecret).toBe('prev');
+      expect(state!.previousSecretRotatedAt).toBe(1710000000);
+      expect(state!.previousSecretExpiresAt).toBe(1710086400);
+      expect(state!.createdAt).toBe('2024-01-01T00:00:00.000Z');
+      expect(state!.updatedAt).toBe('2024-01-02T00:00:00.000Z');
+    });
+
+    it('returns undefined when not found', async () => {
+      mockQuery.mockResolvedValueOnce({ rows: [] });
+      expect(await webhookSecretRepository.getSecretState('missing')).toBeUndefined();
+    });
+
+    it('maps null previous_secret fields to null', async () => {
+      mockQuery.mockResolvedValueOnce({
+        rows: [
+          {
+            id: 'default',
+            current_secret: 'curr',
+            previous_secret: null,
+            previous_secret_rotated_at: null,
+            previous_secret_expires_at: null,
+            created_at: new Date('2024-01-01T00:00:00Z'),
+            updated_at: new Date('2024-01-01T00:00:00Z'),
+          },
+        ],
+      });
+      const state = await webhookSecretRepository.getSecretState('default');
+      expect(state!.previousSecret).toBeNull();
+      expect(state!.previousSecretRotatedAt).toBeNull();
+      expect(state!.previousSecretExpiresAt).toBeNull();
+    });
+
+    it('maps undefined previous_secret fields to null', async () => {
+      mockQuery.mockResolvedValueOnce({
+        rows: [
+          {
+            id: 'default',
+            current_secret: 'curr',
+            previous_secret: undefined,
+            previous_secret_rotated_at: undefined,
+            previous_secret_expires_at: undefined,
+            created_at: new Date('2024-01-01T00:00:00Z'),
+            updated_at: new Date('2024-01-01T00:00:00Z'),
+          },
+        ],
+      });
+      const state = await webhookSecretRepository.getSecretState('default');
+      expect(state!.previousSecret).toBeNull();
+      expect(state!.previousSecretRotatedAt).toBeNull();
+      expect(state!.previousSecretExpiresAt).toBeNull();
+    });
+
+    it('coerces numeric string timestamps to numbers', async () => {
+      mockQuery.mockResolvedValueOnce({
+        rows: [
+          {
+            id: 'default',
+            current_secret: 'curr',
+            previous_secret: 'prev',
+            previous_secret_rotated_at: '1710000000',
+            previous_secret_expires_at: '1710086400',
+            created_at: new Date('2024-01-01T00:00:00Z'),
+            updated_at: new Date('2024-01-01T00:00:00Z'),
+          },
+        ],
+      });
+      const state = await webhookSecretRepository.getSecretState('default');
+      expect(state!.previousSecretRotatedAt).toBe(1710000000);
+      expect(state!.previousSecretExpiresAt).toBe(1710086400);
+    });
+  });
+
+  describe('setSecret', () => {
+    it('inserts a new secret with no previous secret', async () => {
+      mockQuery.mockResolvedValueOnce({
+        rows: [
+          {
+            id: 'default',
+            current_secret: 'new-secret',
+            previous_secret: null,
+            previous_secret_rotated_at: null,
+            previous_secret_expires_at: null,
+            created_at: new Date('2024-01-01T00:00:00Z'),
+            updated_at: new Date('2024-01-01T00:00:00Z'),
+          },
+        ],
+      });
+      const state = await webhookSecretRepository.setSecret('default', 'new-secret');
+      expect(state.currentSecret).toBe('new-secret');
+      expect(state.previousSecret).toBeNull();
+      const [, sql, params] = mockQuery.mock.calls[0]!;
+      expect(sql).toContain('INSERT INTO webhook_secrets');
+      expect(params).toEqual(['default', 'new-secret']);
+    });
+  });
+
+  describe('rotateSecret', () => {
+    it('rotates the secret and moves the old one to previous', async () => {
+      mockQuery.mockResolvedValueOnce({
+        rows: [
+          {
+            id: 'default',
+            current_secret: 'new-secret',
+            previous_secret: 'old-secret',
+            previous_secret_rotated_at: 1710000000,
+            previous_secret_expires_at: 1710086400,
+            created_at: new Date('2024-01-01T00:00:00Z'),
+            updated_at: new Date('2024-01-02T00:00:00Z'),
+          },
+        ],
+      });
+      const state = await webhookSecretRepository.rotateSecret('default', {
+        newSecret: 'new-secret',
+        graceWindowSeconds: 86400,
+        rotatedAt: 1710000000,
+      });
+      expect(state.currentSecret).toBe('new-secret');
+      expect(state.previousSecret).toBe('old-secret');
+      expect(state.previousSecretRotatedAt).toBe(1710000000);
+      expect(state.previousSecretExpiresAt).toBe(1710086400);
+      const [, sql, params] = mockQuery.mock.calls[0]!;
+      expect(sql).toContain('UPDATE webhook_secrets');
+      expect(sql).toContain('RETURNING');
+      expect(params).toEqual(['default', 'new-secret', 1710000000, 1710086400]);
+    });
+
+    it('throws when the id does not exist', async () => {
+      mockQuery.mockResolvedValueOnce({ rows: [] });
+      await expect(
+        webhookSecretRepository.rotateSecret('missing', { newSecret: 'new' }),
+      ).rejects.toThrow('Cannot rotate secret: no row with id "missing"');
+    });
+
+    it('uses default grace window when not specified', async () => {
+      mockQuery.mockResolvedValueOnce({
+        rows: [
+          {
+            id: 'default',
+            current_secret: 'new',
+            previous_secret: 'old',
+            previous_secret_rotated_at: 1710000000,
+            previous_secret_expires_at: 1710086400,
+            created_at: new Date('2024-01-01T00:00:00Z'),
+            updated_at: new Date('2024-01-02T00:00:00Z'),
+          },
+        ],
+      });
+      await webhookSecretRepository.rotateSecret('default', {
+        newSecret: 'new',
+        rotatedAt: 1710000000,
+      });
+      const [, , params] = mockQuery.mock.calls[0]!;
+      expect(params[3]).toBe(1710000000 + 86400);
+    });
+
+    it('uses current time when rotatedAt is not specified', async () => {
+      const realNow = Date.now;
+      Date.now = vi.fn(() => 1710000000000); // 1710000000 seconds
+      mockQuery.mockResolvedValueOnce({
+        rows: [
+          {
+            id: 'default',
+            current_secret: 'new',
+            previous_secret: 'old',
+            previous_secret_rotated_at: 1710000000,
+            previous_secret_expires_at: 1710086400,
+            created_at: new Date('2024-01-01T00:00:00Z'),
+            updated_at: new Date('2024-01-02T00:00:00Z'),
+          },
+        ],
+      });
+      await webhookSecretRepository.rotateSecret('default', {
+        newSecret: 'new',
+        graceWindowSeconds: 86400,
+      });
+      const [, , params] = mockQuery.mock.calls[0]!;
+      expect(params[2]).toBe(1710000000);
+      expect(params[3]).toBe(1710000000 + 86400);
+      Date.now = realNow;
+    });
+  });
+
+  describe('clearExpiredPreviousSecret', () => {
+    it('clears the previous secret when the grace window has expired', async () => {
+      mockQuery.mockResolvedValueOnce({ rows: [], rowCount: 1 });
+      const cleared = await webhookSecretRepository.clearExpiredPreviousSecret(
+        'default',
+        1710086401,
+      );
+      expect(cleared).toBe(true);
+      const [, sql, params] = mockQuery.mock.calls[0]!;
+      expect(sql).toContain('UPDATE webhook_secrets');
+      expect(sql).toContain('previous_secret = NULL');
+      expect(params).toEqual(['default', 1710086401]);
+    });
+
+    it('does not clear when the grace window has not expired', async () => {
+      mockQuery.mockResolvedValueOnce({ rows: [], rowCount: 0 });
+      const cleared = await webhookSecretRepository.clearExpiredPreviousSecret(
+        'default',
+        1710000000,
+      );
+      expect(cleared).toBe(false);
+    });
+
+    it('does not clear when previous_secret is already null', async () => {
+      mockQuery.mockResolvedValueOnce({ rows: [], rowCount: 0 });
+      const cleared = await webhookSecretRepository.clearExpiredPreviousSecret(
+        'default',
+        1710086401,
+      );
+      expect(cleared).toBe(false);
+    });
+
+    it('uses current time when now is not specified', async () => {
+      const realNow = Date.now;
+      Date.now = vi.fn(() => 1710086401000); // 1710086401 seconds
+      mockQuery.mockResolvedValueOnce({ rows: [], rowCount: 1 });
+      const cleared = await webhookSecretRepository.clearExpiredPreviousSecret('default');
+      expect(cleared).toBe(true);
+      const [, , params] = mockQuery.mock.calls[0]!;
+      expect(params[1]).toBe(1710086401);
+      Date.now = realNow;
+    });
+  });
+
+  describe('deleteSecretState', () => {
+    it('deletes the row and returns true', async () => {
+      mockQuery.mockResolvedValueOnce({ rows: [], rowCount: 1 });
+      const deleted = await webhookSecretRepository.deleteSecretState('default');
+      expect(deleted).toBe(true);
+      const [, sql, params] = mockQuery.mock.calls[0]!;
+      expect(sql).toContain('DELETE FROM webhook_secrets');
+      expect(params).toEqual(['default']);
+    });
+
+    it('returns false when no row was deleted', async () => {
+      mockQuery.mockResolvedValueOnce({ rows: [], rowCount: 0 });
+      const deleted = await webhookSecretRepository.deleteSecretState('missing');
+      expect(deleted).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION

Add explicit dual-secret grace window during webhook secret rotation:

- src/webhooks/signature.ts: Add previousSecretRotatedAt and graceWindowSeconds fields to verifyWebhookSignature input. The previous secret is only accepted for a bounded grace window after the rotation timestamp; afterwards it is rejected with previous_secret_expired. Constant-time comparison is used for both secrets. Backward compatible: when previousSecretRotatedAt is omitted, the previous secret is accepted unconditionally.

- src/db/repositories/webhookSecretRepository.ts: New PostgreSQL-backed repository that persists rotation state (previous_secret, previous_secret_rotated_at, previous_secret_expires_at) so process restarts cannot extend or shrink the grace window. Provides setSecret, rotateSecret, clearExpiredPreviousSecret, and deleteSecretState methods.

- tests/webhooks/signature.rotationGraceWindow.test.ts: 38 tests covering grace window acceptance, expiry, boundary conditions, backward compatibility, custom windows, zero-window, and all repository CRUD operations.

- docs/webhooks.md: Document signature verification, secret rotation flow, grace window parameters, security properties, and verification result codes.

Closes #1213 